### PR TITLE
Bugfixes

### DIFF
--- a/VisualStudio/DualityDebuggingTest/DualityDebuggingTest.csproj
+++ b/VisualStudio/DualityDebuggingTest/DualityDebuggingTest.csproj
@@ -46,7 +46,9 @@
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.DebuggerVisualizers, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.DebuggerVisualizers, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Duality\OpenTK.dll</HintPath>


### PR DESCRIPTION
# FIX: No longer referencing a specific version of Microsoft.VisualStudio.DebuggerVisualizers (DualityDebuggingTest)
