### PR TITLE
Adding a security measure to avoid crashes during file import

### DIFF
--- a/DualityEditor/CorePluginInterface/FileImportProvider.cs
+++ b/DualityEditor/CorePluginInterface/FileImportProvider.cs
@@ -80,7 +80,7 @@ namespace Duality.Editor
 				catch (Exception ex)
 				{
 					Log.Editor.WriteError("A {0} occurred while trying to import file {1}.", ex.GetType().Name, srcFilePath);
-                    return false;
+					return false;
 				}
 
 				GC.Collect();


### PR DESCRIPTION
As described here http://forum.adamslair.net/viewtopic.php?f=18&t=292&start=10#p1223

in some cases the editor will crash while trying to import, for example, a malformed image file.
This fixes the issue by trapping the error and logging the exception in the editor's log.
