### PR TITLE
Added Windows 10 friendly name

### DIFF
--- a/Duality/DualityApp.cs
+++ b/Duality/DualityApp.cs
@@ -335,7 +335,9 @@ namespace Duality
 				string osFriendlyName = null;
 				if (Environment.OSVersion.Platform == PlatformID.Win32NT)
 				{
-					if (Environment.OSVersion.Version >= new Version(6, 3, 0))
+					if (Environment.OSVersion.Version >= new Version(10, 0, 0))
+						osFriendlyName = "Windows 10";
+					else if (Environment.OSVersion.Version >= new Version(6, 3, 0))
 						osFriendlyName = "Windows 8.1";
 					else if (Environment.OSVersion.Version >= new Version(6, 2, 0))
 						osFriendlyName = "Windows 8";


### PR DESCRIPTION
Just a tip: Duality should be targeted for Windows 10 too, otherwise running Duality on Windows 10 makes it think it is running on a Windows 8 environment.

See https://msdn.microsoft.com/en-us/library/windows/desktop/dn481241(v=vs.85).aspx