### PR TITLE
Target Windows 8.1 and 10 on app.manifest

### DIFF
--- a/DualityEditor/app.manifest
+++ b/DualityEditor/app.manifest
@@ -4,4 +4,12 @@
       <dpiAware>false</dpiAware>
     </asmv3:windowsSettings>
   </asmv3:application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+    </application>
+  </compatibility>
 </assembly>


### PR DESCRIPTION
This is required so Duality displays the correct Windows version instead of displaying the version as Windows 8.

Source: https://msdn.microsoft.com/en-us/library/windows/desktop/dn481241%28v=vs.85%29.aspx