### PR TITLE
Added the ability to add components to multiple selected GameObjects

### DIFF
--- a/DualityEditorPlugins/SceneView/Modules/SceneView.cs
+++ b/DualityEditorPlugins/SceneView/Modules/SceneView.cs
@@ -747,7 +747,7 @@ namespace Duality.Editor.Plugins.SceneView
 			bool multiSelect = selNodeData.Count > 1;
 			bool gameObjSelect = selNodeData.Any(n => n is GameObjectNode);
 
-            this.nodeContextItemNew.Visible = gameObjSelect || noSelect;
+			this.nodeContextItemNew.Visible = gameObjSelect || noSelect;
 
 			this.nodeContextItemClone.Visible = !noSelect && gameObjSelect;
 			this.nodeContextItemDelete.Visible = !noSelect;
@@ -1485,35 +1485,35 @@ namespace Duality.Editor.Plugins.SceneView
 			Type clickedType = ReflectionHelper.ResolveType(clickedEntry.TypeId);
 			if (clickedType == null) return;
             
-            //Track the nodes that we add so that we can select them later
-		    List<NodeBase> addedNodes = new List<NodeBase>(this.objectView.SelectedNodes.Count);
-		    foreach (var selectedNode in this.objectView.SelectedNodes)
-		    {
-                //Create the Component
-                Component cmp = this.CreateComponent(selectedNode, clickedType);
-		        if (cmp == null) continue;
+			//Track the nodes that we add so that we can select them later
+			List<NodeBase> addedNodes = new List<NodeBase>(this.objectView.SelectedNodes.Count);
+			foreach (var selectedNode in this.objectView.SelectedNodes)
+			{
+				//Create the Component
+				Component cmp = this.CreateComponent(selectedNode, clickedType);
+				if (cmp == null) continue;
 
-                NodeBase cmpNode = (NodeBase)this.FindNode(cmp) ?? this.FindNode(cmp.GameObj);
-                if (cmpNode != null)
-                {
-                    addedNodes.Add(cmpNode);
-                }
-            }
+				NodeBase cmpNode = (NodeBase)this.FindNode(cmp) ?? this.FindNode(cmp.GameObj);
+				if (cmpNode != null)
+				{
+					addedNodes.Add(cmpNode);
+				}
+			}
 
-            // Deselect previous
-            this.objectView.ClearSelection();
+			// Deselect previous
+			this.objectView.ClearSelection();
 
-            // Select all new nodes
-            foreach (var cmpNode in addedNodes)
-		    {
-                TreeNodeAdv dragObjViewNode = this.objectView.FindNode(this.objectModel.GetPath(cmpNode));
-                if (dragObjViewNode != null)
-                {
-                    dragObjViewNode.IsSelected = true;
-                    this.objectView.EnsureVisible(dragObjViewNode);
-                }
-            }
-        }
+			// Select all new nodes
+			foreach (var cmpNode in addedNodes)
+			{
+				TreeNodeAdv dragObjViewNode = this.objectView.FindNode(this.objectModel.GetPath(cmpNode));
+				if (dragObjViewNode != null)
+				{
+					dragObjViewNode.IsSelected = true;
+					this.objectView.EnsureVisible(dragObjViewNode);
+				}
+			}
+		}
 		private void customObjectActionItem_Click(object sender, EventArgs e)
 		{
 			List<NodeBase> selNodeData = new List<NodeBase>(

--- a/DualityEditorPlugins/SceneView/Modules/SceneView.cs
+++ b/DualityEditorPlugins/SceneView/Modules/SceneView.cs
@@ -747,7 +747,7 @@ namespace Duality.Editor.Plugins.SceneView
 			bool multiSelect = selNodeData.Count > 1;
 			bool gameObjSelect = selNodeData.Any(n => n is GameObjectNode);
 
-			this.nodeContextItemNew.Visible = (singleSelect && gameObjSelect) || noSelect;
+            this.nodeContextItemNew.Visible = gameObjSelect || noSelect;
 
 			this.nodeContextItemClone.Visible = !noSelect && gameObjSelect;
 			this.nodeContextItemDelete.Visible = !noSelect;
@@ -1484,27 +1484,36 @@ namespace Duality.Editor.Plugins.SceneView
 			CreateContextEntryTag clickedEntry = clickedItem.Tag as CreateContextEntryTag;
 			Type clickedType = ReflectionHelper.ResolveType(clickedEntry.TypeId);
 			if (clickedType == null) return;
+            
+            //Track the nodes that we add so that we can select them later
+		    List<NodeBase> addedNodes = new List<NodeBase>(this.objectView.SelectedNodes.Count);
+		    foreach (var selectedNode in this.objectView.SelectedNodes)
+		    {
+                //Create the Component
+                Component cmp = this.CreateComponent(selectedNode, clickedType);
+		        if (cmp == null) continue;
 
-			// Create the Component
-			Component cmp = this.CreateComponent(this.objectView.SelectedNode, clickedType);
-			if (cmp == null) return;
+                NodeBase cmpNode = (NodeBase)this.FindNode(cmp) ?? this.FindNode(cmp.GameObj);
+                if (cmpNode != null)
+                {
+                    addedNodes.Add(cmpNode);
+                }
+            }
 
-			NodeBase cmpNode = (NodeBase)this.FindNode(cmp) ?? this.FindNode(cmp.GameObj);
-			if (cmpNode != null)
-			{
-				// Deselect previous
-				this.objectView.ClearSelection();
+            // Deselect previous
+            this.objectView.ClearSelection();
 
-				// Select new node
-				TreeNodeAdv dragObjViewNode = this.objectView.FindNode(this.objectModel.GetPath(cmpNode));
-				if (dragObjViewNode != null)
-				{
-					dragObjViewNode.IsSelected = true;
-					this.objectView.EnsureVisible(dragObjViewNode);
-				}
-				return;
-			}
-		}
+            // Select all new nodes
+            foreach (var cmpNode in addedNodes)
+		    {
+                TreeNodeAdv dragObjViewNode = this.objectView.FindNode(this.objectModel.GetPath(cmpNode));
+                if (dragObjViewNode != null)
+                {
+                    dragObjViewNode.IsSelected = true;
+                    this.objectView.EnsureVisible(dragObjViewNode);
+                }
+            }
+        }
 		private void customObjectActionItem_Click(object sender, EventArgs e)
 		{
 			List<NodeBase> selNodeData = new List<NodeBase>(


### PR DESCRIPTION
What I had to do:

1) Removed the check for a single selection when deciding if the "new" context menu item should be shown
2) Looped over the SelectedNodes property rather than just SelectedNode. This forced me to track the added nodes so that we could select them later. Selecting them inside the foreach loop would have modified the enumerable.

I checked and verified that this does not overwrite Component's if they already exist on a GameObject.