### PR TITLE
RenderTarget checks Texture size

### DIFF
--- a/Duality/Resources/RenderTarget.cs
+++ b/Duality/Resources/RenderTarget.cs
@@ -211,6 +211,14 @@ namespace Duality.Resources
 		/// </summary>
 		protected void SetupNativeRes()
 		{
+			foreach (var target in this.targets.Where(t => t != null).Res()) {
+				if (target.PixelWidth == 0 || target.PixelHeight == 0) {
+					Log.Core.WriteError("Error initializing RenderTarget {0}: Texture {1} has a dimension of 0 {2}",
+						this.FullName, target.FullName, Environment.NewLine);
+					return;
+				}
+			}
+
 			if (this.native == null) this.native = DualityApp.GraphicsBackend.CreateRenderTarget();
 
 			INativeTexture[] targets = this.targets

--- a/Duality/Resources/RenderTarget.cs
+++ b/Duality/Resources/RenderTarget.cs
@@ -215,8 +215,7 @@ namespace Duality.Resources
 			{
 				if (target.PixelWidth == 0 || target.PixelHeight == 0)
 				{
-					Log.Core.WriteError("Error initializing RenderTarget {0}: Texture {1} has a dimension of 0 {2}",
-						this.FullName, target.FullName, Environment.NewLine);
+					Log.Core.WriteError("Error initializing '{0}' because of '{1}' has a dimension of 0", this, target);
 					return;
 				}
 			}

--- a/Duality/Resources/RenderTarget.cs
+++ b/Duality/Resources/RenderTarget.cs
@@ -211,8 +211,10 @@ namespace Duality.Resources
 		/// </summary>
 		protected void SetupNativeRes()
 		{
-			foreach (var target in this.targets.Where(t => t != null).Res()) {
-				if (target.PixelWidth == 0 || target.PixelHeight == 0) {
+			foreach (var target in this.targets.Where(t => t != null).Res())
+			{
+				if (target.PixelWidth == 0 || target.PixelHeight == 0)
+				{
 					Log.Core.WriteError("Error initializing RenderTarget {0}: Texture {1} has a dimension of 0 {2}",
 						this.FullName, target.FullName, Environment.NewLine);
 					return;


### PR DESCRIPTION
_A small usability addition_

When assigning textures to the render target, first it checks if the texture's size is set correctly (e.g. not 0). If not, it sends an error message to the user, and returns early.

This helps mostly beginner users, as it is not trivial that texture size has to be set before assigning.