### PR TITLE
Fixed two warnings about XML documentation comments.

### DIFF
--- a/Duality/PluginManager.cs
+++ b/Duality/PluginManager.cs
@@ -308,7 +308,7 @@ namespace Duality
 		}
 		/// <summary>
 		/// Initializes the specified plugin. This concludes a manual plugin load or reload operation
-		/// using API like <see cref="LoadPlugin"/> and <see cref="ReloadPlugin"/>.
+		/// using API like <see cref="LoadPlugin(Assembly, string)"/> and <see cref="ReloadPlugin"/>.
 		/// </summary>
 		/// <param name="plugin"></param>
 		public void InitPlugin(T plugin)

--- a/DualityEditorPlugins/Tilemaps/CamViewStates/TilemapTools/ITilemapToolEnvironment.cs
+++ b/DualityEditorPlugins/Tilemaps/CamViewStates/TilemapTools/ITilemapToolEnvironment.cs
@@ -13,7 +13,7 @@ using Duality.Editor.Plugins.Tilemaps.UndoRedoActions;
 namespace Duality.Editor.Plugins.Tilemaps.CamViewStates
 {
 	/// <summary>
-	/// Provides an interface for <see cref="TilemapTool"/> instances to access <see="TilemapEditorCamViewState"/> internals and perform editing operations.
+	/// Provides an interface for <see cref="TilemapTool"/> instances to access <see cref="TilemapEditorCamViewState"/> internals and perform editing operations.
 	/// </summary>
 	public interface ITilemapToolEnvironment
 	{


### PR DESCRIPTION
This is a tiny pull request with no impact on the actual code itself, just fixes two warnings for two XML documentation comments thrown by Visual Studio.

(First pull request was based off of the wrong branch, this one is correct, hopefully)