### PR TITLE
Can't delete a Component if RequiredComponent missing

### DIFF
--- a/DualityEditorPlugins/EditorBase/PropertyEditors/ComponentPropertyEditor.cs
+++ b/DualityEditorPlugins/EditorBase/PropertyEditors/ComponentPropertyEditor.cs
@@ -158,6 +158,8 @@ namespace Duality.Editor.Plugins.Base.PropertyEditors
 			{
 				foreach (Component r in c.GameObj.GetComponents<Component>())
 				{
+					if (r == c)
+						continue;
 					if (!r.IsComponentRequirementMet(c))
 					{
 						canRemove = false;


### PR DESCRIPTION
Fix of issue #382 
There are multiple ways to solve this. The one 'below' seemed the best, because:

* it's simple
* it's nonsene to check wheter the component we're going to remove has itself as a dependency

enjoy 🍕 