### PR TITLE
Fixes crash after creating a texture from an empty pixmap

### DIFF
--- a/DualityEditorPlugins/EditorBase/PreviewGenerators/PixmapPreviewGenerator.cs
+++ b/DualityEditorPlugins/EditorBase/PreviewGenerators/PixmapPreviewGenerator.cs
@@ -19,7 +19,7 @@ namespace Duality.Editor.Plugins.Base.PreviewGenerators
 			Point2 cropToSize = new Point2(4096, 4096);
 
 			PixelData layer = pixmap.MainLayer;
-			if (layer == null)
+			if (layer == null || layer.Data.Length == 0)
 			{
 				query.Result = new Bitmap(1, 1);
 				return;

--- a/DualityEditorPlugins/EditorBase/PreviewGenerators/PixmapPreviewGenerator.cs
+++ b/DualityEditorPlugins/EditorBase/PreviewGenerators/PixmapPreviewGenerator.cs
@@ -19,7 +19,7 @@ namespace Duality.Editor.Plugins.Base.PreviewGenerators
 			Point2 cropToSize = new Point2(4096, 4096);
 
 			PixelData layer = pixmap.MainLayer;
-			if (layer == null || layer.Data.Length == 0)
+			if (layer == null || layer.Width * layer.Height == 0)
 			{
 				query.Result = new Bitmap(1, 1);
 				return;


### PR DESCRIPTION
Fixes [#405
](https://github.com/AdamsLair/duality/issues/405)