### PR TITLE
MoveTo(Vector2) and MoveToAbs(Vector2) not changing Z coordinate

### DIFF
--- a/Source/Core/Duality/Components/Transform.cs
+++ b/Source/Core/Duality/Components/Transform.cs
@@ -501,12 +501,13 @@ namespace Duality.Components
 			this.MoveBy(value - this.pos);
 		}
 		/// <summary>
-		/// Moves the object to the given relative position. This will affect the Transforms <see cref="Vel">velocity</see> value.
+		/// Moves the object to the given relative position, leaving the Z coordinate unchanged.
+		/// This will affect the Transforms <see cref="Vel">velocity</see> value.
 		/// </summary>
 		/// <param name="value"></param>
 		public void MoveTo(Vector2 value)
 		{
-			this.MoveTo(new Vector3(value));
+			this.MoveTo(new Vector3(value, pos.Z));
 		}
 		/// <summary>
 		/// Moves the object to the given absolute position. This will affect the Transforms <see cref="Vel">velocity</see> value.
@@ -517,12 +518,13 @@ namespace Duality.Components
 			this.MoveByAbs(value - this.posAbs);
 		}
 		/// <summary>
-		/// Moves the object to the given absolute position. This will affect the Transforms <see cref="Vel">velocity</see> value.
+		/// Moves the object to the given absolute position, leaving the Z coordinate unchanged.
+		/// This will affect the Transforms <see cref="Vel">velocity</see> value.
 		/// </summary>
 		/// <param name="value"></param>
 		public void MoveToAbs(Vector2 value)
 		{
-			this.MoveToAbs(new Vector3(value));
+			this.MoveToAbs(new Vector3(value, posAbs.Z));
 		}
 		/// <summary>
 		/// Turns the object by the given radian angle. This will affect the Transforms <see cref="AngleVel">angular velocity</see> value.


### PR DESCRIPTION
As discussed on Discord, the `MoveTo(Vector2)` and `MoveToAbs(Vector2)` methods of `Transform` are slightly changed, not resetting the Z coordinate of the position by simply casting to `Vector3`. I did not find any similar methods or usages in the solution.