### PR TITLE
NativeWindow

### DIFF
--- a/Source/Platform/DefaultOpenTK/Backend/Graphics/NativeWindow.cs
+++ b/Source/Platform/DefaultOpenTK/Backend/Graphics/NativeWindow.cs
@@ -200,6 +200,7 @@ namespace Duality.Backend.DefaultOpenTK
 				case ScreenMode.Window:
 					targetWindowState = WindowState.Normal;
 					targetWindowBorder = WindowBorder.Resizable;
+					targetSize = new Size(DualityApp.UserData.GfxWidth, DualityApp.UserData.GfxHeight);
 					break;
 
 				case ScreenMode.FixedWindow:


### PR DESCRIPTION
Allows to programmatically resize a resizeable window.
Although it looks a non-sense, I feel it's more counter-intuitive the fact that specifically setting a desired GfxHeight and Width in UserData gets ignored if the window is already resizeable by the user.

This normalizes the behavior of setting UserData and could be used, for example, to enforce a minimum/maximum window size, while leaving the user free to resize it between said limits.

*also, I think I didn't mess up the alignment this time* :)
