### PR TITLE
master_488: When creating a new empty texture it is now initialized t…

### DIFF
--- a/Source/Core/Duality/Resources/Texture.cs
+++ b/Source/Core/Duality/Resources/Texture.cs
@@ -164,7 +164,7 @@ namespace Duality.Resources
 		/// [GET / SET] The Textures size. Readonly, when created from a <see cref="BasePixmap"/>.
 		/// </summary>
 		[EditorHintFlags(MemberFlags.AffectsOthers)]
-		[EditorHintRange(0, int.MaxValue)]
+		[EditorHintRange(1, int.MaxValue)]
 		[EditorHintIncrement(1)]
 		[EditorHintDecimalPlaces(0)]
 		public Vector2 Size

--- a/Source/Plugins/EditorBase/EditorActions/SetupTextureForEditing.cs
+++ b/Source/Plugins/EditorBase/EditorActions/SetupTextureForEditing.cs
@@ -1,0 +1,22 @@
+﻿using Duality.Resources;
+
+namespace Duality.Editor.Plugins.Base.EditorActions
+{
+	public class SetupTextureForEditing : EditorSingleAction<Texture>
+	{
+		public override bool CanPerformOn(Texture texture)
+		{
+			return base.CanPerformOn(texture) && texture.PixelWidth == 0 && texture.PixelHeight == 0;
+		}
+
+		public override void Perform(Texture texture)
+		{
+			texture.Size = new Vector2(128, 128);
+		}
+		
+		public override bool MatchesContext(string context)
+		{
+			return context == DualityEditorApp.ActionContextSetupObjectForEditing;
+		}
+	}
+}

--- a/Source/Plugins/EditorBase/EditorActions/SetupTextureForEditing.cs
+++ b/Source/Plugins/EditorBase/EditorActions/SetupTextureForEditing.cs
@@ -12,6 +12,7 @@ namespace Duality.Editor.Plugins.Base.EditorActions
 		public override void Perform(Texture texture)
 		{
 			texture.Size = new Vector2(128, 128);
+			texture.ReloadData();
 		}
 		
 		public override bool MatchesContext(string context)

--- a/Source/Plugins/EditorBase/EditorBase.Editor.csproj
+++ b/Source/Plugins/EditorBase/EditorBase.Editor.csproj
@@ -73,6 +73,7 @@
     <Compile Include="EditorActions\OpenScene.cs" />
     <Compile Include="EditorActions\InstantiatePrefab.cs" />
     <Compile Include="EditorActions\OpenResource.cs" />
+    <Compile Include="EditorActions\SetupTextureForEditing.cs" />
     <Compile Include="EditorActions\ShaderToProgram.cs" />
     <Compile Include="EditorActions\TextureToMaterial.cs" />
     <Compile Include="EditorActions\PixmapToTexture.cs" />


### PR DESCRIPTION
Textures are not initialized to 128x128 pixels instead of 0x0 pixels. Also changed the editor hint for the size to be between 1 and int.max.

