### PR TITLE
Potential LogView crash fix.

### DIFF
--- a/Source/Plugins/EditorModules/LogView/Modules/LogView.cs
+++ b/Source/Plugins/EditorModules/LogView/Modules/LogView.cs
@@ -82,6 +82,9 @@ namespace Duality.Editor.Plugins.LogView
 		}
 		private void DockPanel_ActiveContentChanged(object sender, EventArgs e)
 		{
+			if (this.DockPanel == null)
+				return;
+
 			if (this.DockPanel.ActiveAutoHideContent == this)
 			{
 				this.MarkAsRead();


### PR DESCRIPTION
Fixed a crash that would occur when closing the editor while the `LogView` is undocked.

Closes issue #500.