### PR TITLE
Fixed NullReferenceException in MeasureText

### DIFF
--- a/Source/Core/Duality/Resources/Font.cs
+++ b/Source/Core/Duality/Resources/Font.cs
@@ -769,7 +769,7 @@ namespace Duality.Resources
 		/// <returns>The size of the measured text.</returns>
 		public Vector2 MeasureText(string text)
 		{
-			if (this.texture == null) return Vector2.Zero;
+			if (this.texture == null || text == null) return Vector2.Zero;
 
 			Vector2 textSize = Vector2.Zero;
 			float curOffset = 0.0f;


### PR DESCRIPTION
Fixed a NullReferenceException when the parameter of MeasureText (Font.cs) is null