### PR TITLE
Fix GetLocalPosAtTile

### DIFF
--- a/Source/Plugins/Tilemaps/Core/Tilemaps/Components/TilemapRenderer.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilemaps/Components/TilemapRenderer.cs
@@ -220,8 +220,13 @@ namespace Duality.Plugins.Tilemaps
 		/// <returns></returns>
 		public Vector2 GetLocalPosAtTile(Point2 tilePos)
 		{
-			Vector2 tileSize = this.LocalTileSize;
-			return new Vector2(tilePos.X * tileSize.X, tilePos.Y * tileSize.Y);
+			Rect localRect = this.LocalTilemapRect;
+			Tilemap tilemap = this.ActiveTilemap;
+			Point2 tileCount = tilemap != null ? tilemap.Size : new Point2(1, 1);
+
+			return new Vector2(
+				MathF.Lerp(localRect.LeftX, localRect.RightX, (float)tilePos.X / tileCount.X),
+				MathF.Lerp(localRect.TopY, localRect.BottomY, (float)tilePos.Y / tileCount.Y));
 		}
 		/// <summary>
 		/// Determines the generated depth offset for the tile at the specified tile coordinates.


### PR DESCRIPTION
The current solution works correctly only with the `TilemapRenderer.Origin` set to `TopLeft`. This code works for every alignment case. (I assume that the function should return the tile position in the `TilemapRenderer.GameObj`'s local coordinate system.)
