### PR TITLE
Fixed a bug in the rigidbody editor

### DIFF
--- a/Source/Plugins/EditorModules/CamView/CamViewStates/RigidBodyEditor/RigidBodyEditorCamViewState.cs
+++ b/Source/Plugins/EditorModules/CamView/CamViewStates/RigidBodyEditor/RigidBodyEditorCamViewState.cs
@@ -459,7 +459,7 @@ namespace Duality.Editor.Plugins.CamView.CamViewStates
 		private bool BeginToolAction(RigidBodyEditorTool action, MouseButtons mouseButton)
 		{
 			if (this.actionTool == action) return true;
-			if (!action.CanBeginAction(mouseButton)) return false;
+			if (!action.CanBeginAction(mouseButton) || this.selectedBody == null) return false;
 
 			if (this.actionTool != this.toolNone)
 				this.EndToolAction();


### PR DESCRIPTION
When you select a rigidbody tool in the rigidbody editor view and deselect the current gameobject, the tool keeps selected. As soon as you click somewhere in the view, the editor throws an exception.

![](https://thumbs.gfycat.com/LameHighGrayling-size_restricted.gif)
[Click for full size
](https://gfycat.com/LameHighGrayling)

So this bug is now fixed with this tiny pull request.
