### PR TITLE
Object ref dialog icons

### DIFF
--- a/Source/Editor/DualityEditor/Forms/ObjectRefSelectionDialog.Designer.cs
+++ b/Source/Editor/DualityEditor/Forms/ObjectRefSelectionDialog.Designer.cs
@@ -32,151 +32,172 @@ namespace Duality.Editor.Forms
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.buttonCancel = new System.Windows.Forms.Button();
-			this.buttonOk = new System.Windows.Forms.Button();
-			this.labelInfo = new System.Windows.Forms.Label();
-			this.objectReferenceListing = new Aga.Controls.Tree.TreeViewAdv();
-			this.columnName = new Aga.Controls.Tree.TreeColumn();
-			this.columnPath = new Aga.Controls.Tree.TreeColumn();
-			this.nodeName = new Aga.Controls.Tree.NodeControls.NodeTextBox();
-			this.nodePath = new Aga.Controls.Tree.NodeControls.NodeTextBox();
-			this.txtFilterInput = new Duality.Editor.Controls.CueTextBox();
-			this.SuspendLayout();
-			// 
-			// buttonCancel
-			// 
-			this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.buttonCancel.Location = new System.Drawing.Point(454, 361);
-			this.buttonCancel.Name = "buttonCancel";
-			this.buttonCancel.Size = new System.Drawing.Size(75, 23);
-			this.buttonCancel.TabIndex = 3;
-			this.buttonCancel.Text = "Cancel";
-			this.buttonCancel.UseVisualStyleBackColor = true;
-			// 
-			// buttonOk
-			// 
-			this.buttonOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.buttonOk.DialogResult = System.Windows.Forms.DialogResult.OK;
-			this.buttonOk.Location = new System.Drawing.Point(373, 361);
-			this.buttonOk.Name = "buttonOk";
-			this.buttonOk.Size = new System.Drawing.Size(75, 23);
-			this.buttonOk.TabIndex = 2;
-			this.buttonOk.Text = "Ok";
-			this.buttonOk.UseVisualStyleBackColor = true;
-			// 
-			// labelInfo
-			// 
-			this.labelInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.buttonCancel = new System.Windows.Forms.Button();
+            this.buttonOk = new System.Windows.Forms.Button();
+            this.labelInfo = new System.Windows.Forms.Label();
+            this.objectReferenceListing = new Aga.Controls.Tree.TreeViewAdv();
+            this.columnImage = new Aga.Controls.Tree.TreeColumn();
+            this.columnName = new Aga.Controls.Tree.TreeColumn();
+            this.columnPath = new Aga.Controls.Tree.TreeColumn();
+            this.nodeImage = new Aga.Controls.Tree.NodeControls.NodeStateIcon();
+            this.nodeName = new Aga.Controls.Tree.NodeControls.NodeTextBox();
+            this.nodePath = new Aga.Controls.Tree.NodeControls.NodeTextBox();
+            this.txtFilterInput = new Duality.Editor.Controls.CueTextBox();
+            this.SuspendLayout();
+            // 
+            // buttonCancel
+            // 
+            this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.buttonCancel.Location = new System.Drawing.Point(454, 361);
+            this.buttonCancel.Name = "buttonCancel";
+            this.buttonCancel.Size = new System.Drawing.Size(75, 23);
+            this.buttonCancel.TabIndex = 3;
+            this.buttonCancel.Text = "Cancel";
+            this.buttonCancel.UseVisualStyleBackColor = true;
+            // 
+            // buttonOk
+            // 
+            this.buttonOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonOk.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.buttonOk.Location = new System.Drawing.Point(373, 361);
+            this.buttonOk.Name = "buttonOk";
+            this.buttonOk.Size = new System.Drawing.Size(75, 23);
+            this.buttonOk.TabIndex = 2;
+            this.buttonOk.Text = "Ok";
+            this.buttonOk.UseVisualStyleBackColor = true;
+            // 
+            // labelInfo
+            // 
+            this.labelInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.labelInfo.Location = new System.Drawing.Point(12, 9);
-			this.labelInfo.Name = "labelInfo";
-			this.labelInfo.Size = new System.Drawing.Size(516, 21);
-			this.labelInfo.TabIndex = 6;
-			this.labelInfo.Text = "Please select the reference you would like to use.";
-			// 
-			// objectReferenceListing
-			// 
-			this.objectReferenceListing.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.labelInfo.Location = new System.Drawing.Point(12, 9);
+            this.labelInfo.Name = "labelInfo";
+            this.labelInfo.Size = new System.Drawing.Size(516, 21);
+            this.labelInfo.TabIndex = 6;
+            this.labelInfo.Text = "Please select the reference you would like to use.";
+            // 
+            // objectReferenceListing
+            // 
+            this.objectReferenceListing.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.objectReferenceListing.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(196)))), ((int)(((byte)(196)))), ((int)(((byte)(196)))));
-			this.objectReferenceListing.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.objectReferenceListing.Columns.Add(this.columnName);
-			this.objectReferenceListing.Columns.Add(this.columnPath);
-			this.objectReferenceListing.DefaultToolTipProvider = null;
-			this.objectReferenceListing.DragDropMarkColor = System.Drawing.Color.Black;
-			this.objectReferenceListing.FullRowSelect = true;
-			this.objectReferenceListing.FullRowSelectActiveColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-			this.objectReferenceListing.FullRowSelectInactiveColor = System.Drawing.Color.FromArgb(((int)(((byte)(212)))), ((int)(((byte)(212)))), ((int)(((byte)(212)))));
-			this.objectReferenceListing.Indent = 5;
-			this.objectReferenceListing.LineColor = System.Drawing.Color.FromArgb(((int)(((byte)(92)))), ((int)(((byte)(92)))), ((int)(((byte)(92)))));
-			this.objectReferenceListing.LoadOnDemand = true;
-			this.objectReferenceListing.Location = new System.Drawing.Point(11, 57);
-			this.objectReferenceListing.Model = null;
-			this.objectReferenceListing.Name = "objectReferenceListing";
-			this.objectReferenceListing.NodeControls.Add(this.nodeName);
-			this.objectReferenceListing.NodeControls.Add(this.nodePath);
-			this.objectReferenceListing.NodeFilter = null;
-			this.objectReferenceListing.SelectedNode = null;
-			this.objectReferenceListing.ShowLines = false;
-			this.objectReferenceListing.ShowPlusMinus = false;
-			this.objectReferenceListing.Size = new System.Drawing.Size(517, 298);
-			this.objectReferenceListing.TabIndex = 1;
-			this.objectReferenceListing.UseColumns = true;
-			// 
-			// columnName
-			// 
-			this.columnName.Header = "Name";
-			this.columnName.MaxColumnWidth = 300;
-			this.columnName.MinColumnWidth = 80;
-			this.columnName.Sortable = true;
-			this.columnName.SortOrder = System.Windows.Forms.SortOrder.Ascending;
-			this.columnName.TooltipText = null;
-			this.columnName.Width = 150;
-			// 
-			// columnPath
-			// 
-			this.columnPath.Header = "Path";
-			this.columnPath.MaxColumnWidth = 800;
-			this.columnPath.MinColumnWidth = 200;
-			this.columnPath.Sortable = true;
-			this.columnPath.SortOrder = System.Windows.Forms.SortOrder.None;
-			this.columnPath.TooltipText = null;
-			this.columnPath.Width = 300;
-			// 
-			// nodeName
-			// 
-			this.nodeName.DataPropertyName = "Name";
-			this.nodeName.IncrementalSearchEnabled = true;
-			this.nodeName.LeftMargin = 3;
-			this.nodeName.ParentColumn = this.columnName;
-			// 
-			// nodePath
-			// 
-			this.nodePath.DataPropertyName = "Path";
-			this.nodePath.IncrementalSearchEnabled = true;
-			this.nodePath.LeftMargin = 3;
-			this.nodePath.ParentColumn = this.columnPath;
-			// 
-			// txtFilterInput
-			// 
-			this.txtFilterInput.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.objectReferenceListing.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(196)))), ((int)(((byte)(196)))), ((int)(((byte)(196)))));
+            this.objectReferenceListing.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.objectReferenceListing.Columns.Add(this.columnImage);
+            this.objectReferenceListing.Columns.Add(this.columnName);
+            this.objectReferenceListing.Columns.Add(this.columnPath);
+            this.objectReferenceListing.DefaultToolTipProvider = null;
+            this.objectReferenceListing.DragDropMarkColor = System.Drawing.Color.Black;
+            this.objectReferenceListing.FullRowSelect = true;
+            this.objectReferenceListing.FullRowSelectActiveColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
+            this.objectReferenceListing.FullRowSelectInactiveColor = System.Drawing.Color.FromArgb(((int)(((byte)(212)))), ((int)(((byte)(212)))), ((int)(((byte)(212)))));
+            this.objectReferenceListing.Indent = 5;
+            this.objectReferenceListing.LineColor = System.Drawing.Color.FromArgb(((int)(((byte)(92)))), ((int)(((byte)(92)))), ((int)(((byte)(92)))));
+            this.objectReferenceListing.LoadOnDemand = true;
+            this.objectReferenceListing.Location = new System.Drawing.Point(11, 57);
+            this.objectReferenceListing.Model = null;
+            this.objectReferenceListing.Name = "objectReferenceListing";
+            this.objectReferenceListing.NodeControls.Add(this.nodeImage);
+            this.objectReferenceListing.NodeControls.Add(this.nodeName);
+            this.objectReferenceListing.NodeControls.Add(this.nodePath);
+            this.objectReferenceListing.NodeFilter = null;
+            this.objectReferenceListing.SelectedNode = null;
+            this.objectReferenceListing.ShowLines = false;
+            this.objectReferenceListing.ShowPlusMinus = false;
+            this.objectReferenceListing.Size = new System.Drawing.Size(517, 298);
+            this.objectReferenceListing.TabIndex = 1;
+            this.objectReferenceListing.UseColumns = true;
+            // 
+            // columnImage
+            // 
+            this.columnImage.Header = "Icon";
+            this.columnImage.MaxColumnWidth = 45;
+            this.columnImage.MinColumnWidth = 20;
+            this.columnImage.SortOrder = System.Windows.Forms.SortOrder.None;
+            this.columnImage.TooltipText = null;
+            this.columnImage.Width = 32;
+            // 
+            // columnName
+            // 
+            this.columnName.Header = "Name";
+            this.columnName.MaxColumnWidth = 300;
+            this.columnName.MinColumnWidth = 80;
+            this.columnName.Sortable = true;
+            this.columnName.SortOrder = System.Windows.Forms.SortOrder.None;
+            this.columnName.TooltipText = null;
+            this.columnName.Width = 150;
+            // 
+            // columnPath
+            // 
+            this.columnPath.Header = "Path";
+            this.columnPath.MaxColumnWidth = 800;
+            this.columnPath.MinColumnWidth = 200;
+            this.columnPath.Sortable = true;
+            this.columnPath.SortOrder = System.Windows.Forms.SortOrder.None;
+            this.columnPath.TooltipText = null;
+            this.columnPath.Width = 300;
+            // 
+            // nodeImage
+            // 
+            this.nodeImage.DataPropertyName = "Image";
+            this.nodeImage.IncrementalSearchEnabled = true;
+            this.nodeImage.LeftMargin = 3;
+            this.nodeImage.ParentColumn = this.columnImage;
+            this.nodeImage.ScaleMode = Aga.Controls.Tree.ImageScaleMode.Clip;
+            // 
+            // nodeName
+            // 
+            this.nodeName.DataPropertyName = "Name";
+            this.nodeName.IncrementalSearchEnabled = true;
+            this.nodeName.LeftMargin = 3;
+            this.nodeName.ParentColumn = this.columnName;
+            // 
+            // nodePath
+            // 
+            this.nodePath.DataPropertyName = "Path";
+            this.nodePath.IncrementalSearchEnabled = true;
+            this.nodePath.LeftMargin = 3;
+            this.nodePath.ParentColumn = this.columnPath;
+            // 
+            // txtFilterInput
+            // 
+            this.txtFilterInput.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txtFilterInput.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(196)))), ((int)(((byte)(196)))), ((int)(((byte)(196)))));
-			this.txtFilterInput.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtFilterInput.CueText = "Reference Filter";
-			this.txtFilterInput.Location = new System.Drawing.Point(11, 32);
-			this.txtFilterInput.Margin = new System.Windows.Forms.Padding(2);
-			this.txtFilterInput.Name = "txtFilterInput";
-			this.txtFilterInput.Size = new System.Drawing.Size(517, 20);
-			this.txtFilterInput.TabIndex = 0;
-			this.txtFilterInput.TextChanged += new System.EventHandler(this.txtFilterInput_TextChanged);
-			// 
-			// ObjectRefSelectionDialog
-			// 
-			this.AcceptButton = this.buttonOk;
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.AutoValidate = System.Windows.Forms.AutoValidate.Disable;
-			this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(212)))), ((int)(((byte)(212)))), ((int)(((byte)(212)))));
-			this.CancelButton = this.buttonCancel;
-			this.ClientSize = new System.Drawing.Size(540, 396);
-			this.Controls.Add(this.txtFilterInput);
-			this.Controls.Add(this.objectReferenceListing);
-			this.Controls.Add(this.buttonCancel);
-			this.Controls.Add(this.labelInfo);
-			this.Controls.Add(this.buttonOk);
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.MinimumSize = new System.Drawing.Size(380, 399);
-			this.Name = "ObjectRefSelectionDialog";
-			this.ShowIcon = false;
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Select a Reference...";
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.txtFilterInput.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(196)))), ((int)(((byte)(196)))), ((int)(((byte)(196)))));
+            this.txtFilterInput.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtFilterInput.CueText = "Reference Filter";
+            this.txtFilterInput.Location = new System.Drawing.Point(11, 32);
+            this.txtFilterInput.Margin = new System.Windows.Forms.Padding(2);
+            this.txtFilterInput.Name = "txtFilterInput";
+            this.txtFilterInput.Size = new System.Drawing.Size(517, 20);
+            this.txtFilterInput.TabIndex = 0;
+            this.txtFilterInput.TextChanged += new System.EventHandler(this.txtFilterInput_TextChanged);
+            // 
+            // ObjectRefSelectionDialog
+            // 
+            this.AcceptButton = this.buttonOk;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoValidate = System.Windows.Forms.AutoValidate.Disable;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(212)))), ((int)(((byte)(212)))), ((int)(((byte)(212)))));
+            this.CancelButton = this.buttonCancel;
+            this.ClientSize = new System.Drawing.Size(540, 396);
+            this.Controls.Add(this.txtFilterInput);
+            this.Controls.Add(this.objectReferenceListing);
+            this.Controls.Add(this.buttonCancel);
+            this.Controls.Add(this.labelInfo);
+            this.Controls.Add(this.buttonOk);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(380, 399);
+            this.Name = "ObjectRefSelectionDialog";
+            this.ShowIcon = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Select a Reference...";
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -186,10 +207,12 @@ namespace Duality.Editor.Forms
 		private System.Windows.Forms.Button buttonOk;
 		private System.Windows.Forms.Label labelInfo;
 		private TreeViewAdv objectReferenceListing;
+		private Aga.Controls.Tree.NodeControls.NodeStateIcon nodeImage;
 		private Aga.Controls.Tree.NodeControls.NodeTextBox nodeName;
 		private Aga.Controls.Tree.NodeControls.NodeTextBox nodePath;
 		private TreeColumn columnName;
 		private TreeColumn columnPath;
 		private CueTextBox txtFilterInput;
+		private TreeColumn columnImage;
 	}
 }

--- a/Source/Editor/DualityEditor/Forms/ObjectRefSelectionDialog.Designer.cs
+++ b/Source/Editor/DualityEditor/Forms/ObjectRefSelectionDialog.Designer.cs
@@ -124,7 +124,7 @@ namespace Duality.Editor.Forms
 			this.columnName.MaxColumnWidth = 300;
 			this.columnName.MinColumnWidth = 80;
 			this.columnName.Sortable = true;
-			this.columnName.SortOrder = System.Windows.Forms.SortOrder.None;
+			this.columnName.SortOrder = System.Windows.Forms.SortOrder.Ascending;
 			this.columnName.TooltipText = null;
 			this.columnName.Width = 150;
 			// 
@@ -198,6 +198,7 @@ namespace Duality.Editor.Forms
 			this.Text = "Select a Reference...";
 			this.ResumeLayout(false);
 			this.PerformLayout();
+
 		}
 
 		#endregion

--- a/Source/Editor/DualityEditor/Forms/ObjectRefSelectionDialog.Designer.cs
+++ b/Source/Editor/DualityEditor/Forms/ObjectRefSelectionDialog.Designer.cs
@@ -209,9 +209,9 @@ namespace Duality.Editor.Forms
 		private Aga.Controls.Tree.NodeControls.NodeStateIcon nodeImage;
 		private Aga.Controls.Tree.NodeControls.NodeTextBox nodeName;
 		private Aga.Controls.Tree.NodeControls.NodeTextBox nodePath;
+		private TreeColumn columnImage;
 		private TreeColumn columnName;
 		private TreeColumn columnPath;
 		private CueTextBox txtFilterInput;
-		private TreeColumn columnImage;
 	}
 }

--- a/Source/Editor/DualityEditor/Forms/ObjectRefSelectionDialog.Designer.cs
+++ b/Source/Editor/DualityEditor/Forms/ObjectRefSelectionDialog.Designer.cs
@@ -70,7 +70,7 @@ namespace Duality.Editor.Forms
 			// labelInfo
 			// 
 			this.labelInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-			| System.Windows.Forms.AnchorStyles.Right)));
+            | System.Windows.Forms.AnchorStyles.Right)));
 			this.labelInfo.Location = new System.Drawing.Point(12, 9);
 			this.labelInfo.Name = "labelInfo";
 			this.labelInfo.Size = new System.Drawing.Size(516, 21);
@@ -80,8 +80,8 @@ namespace Duality.Editor.Forms
 			// objectReferenceListing
 			// 
 			this.objectReferenceListing.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-			| System.Windows.Forms.AnchorStyles.Left) 
-			| System.Windows.Forms.AnchorStyles.Right)));
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
 			this.objectReferenceListing.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(196)))), ((int)(((byte)(196)))), ((int)(((byte)(196)))));
 			this.objectReferenceListing.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
 			this.objectReferenceListing.Columns.Add(this.columnImage);
@@ -163,8 +163,8 @@ namespace Duality.Editor.Forms
 			// txtFilterInput
 			// 
 			this.txtFilterInput.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-			| System.Windows.Forms.AnchorStyles.Left) 
-			| System.Windows.Forms.AnchorStyles.Right)));
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
 			this.txtFilterInput.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(196)))), ((int)(((byte)(196)))), ((int)(((byte)(196)))));
 			this.txtFilterInput.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
 			this.txtFilterInput.CueText = "Reference Filter";

--- a/Source/Editor/DualityEditor/Forms/ObjectRefSelectionDialog.Designer.cs
+++ b/Source/Editor/DualityEditor/Forms/ObjectRefSelectionDialog.Designer.cs
@@ -32,173 +32,172 @@ namespace Duality.Editor.Forms
 		/// </summary>
 		private void InitializeComponent()
 		{
-            this.buttonCancel = new System.Windows.Forms.Button();
-            this.buttonOk = new System.Windows.Forms.Button();
-            this.labelInfo = new System.Windows.Forms.Label();
-            this.objectReferenceListing = new Aga.Controls.Tree.TreeViewAdv();
-            this.columnImage = new Aga.Controls.Tree.TreeColumn();
-            this.columnName = new Aga.Controls.Tree.TreeColumn();
-            this.columnPath = new Aga.Controls.Tree.TreeColumn();
-            this.nodeImage = new Aga.Controls.Tree.NodeControls.NodeStateIcon();
-            this.nodeName = new Aga.Controls.Tree.NodeControls.NodeTextBox();
-            this.nodePath = new Aga.Controls.Tree.NodeControls.NodeTextBox();
-            this.txtFilterInput = new Duality.Editor.Controls.CueTextBox();
-            this.SuspendLayout();
-            // 
-            // buttonCancel
-            // 
-            this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(454, 361);
-            this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.Size = new System.Drawing.Size(75, 23);
-            this.buttonCancel.TabIndex = 3;
-            this.buttonCancel.Text = "Cancel";
-            this.buttonCancel.UseVisualStyleBackColor = true;
-            // 
-            // buttonOk
-            // 
-            this.buttonOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOk.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.buttonOk.Location = new System.Drawing.Point(373, 361);
-            this.buttonOk.Name = "buttonOk";
-            this.buttonOk.Size = new System.Drawing.Size(75, 23);
-            this.buttonOk.TabIndex = 2;
-            this.buttonOk.Text = "Ok";
-            this.buttonOk.UseVisualStyleBackColor = true;
-            // 
-            // labelInfo
-            // 
-            this.labelInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.labelInfo.Location = new System.Drawing.Point(12, 9);
-            this.labelInfo.Name = "labelInfo";
-            this.labelInfo.Size = new System.Drawing.Size(516, 21);
-            this.labelInfo.TabIndex = 6;
-            this.labelInfo.Text = "Please select the reference you would like to use.";
-            // 
-            // objectReferenceListing
-            // 
-            this.objectReferenceListing.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.objectReferenceListing.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(196)))), ((int)(((byte)(196)))), ((int)(((byte)(196)))));
-            this.objectReferenceListing.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.objectReferenceListing.Columns.Add(this.columnImage);
-            this.objectReferenceListing.Columns.Add(this.columnName);
-            this.objectReferenceListing.Columns.Add(this.columnPath);
-            this.objectReferenceListing.DefaultToolTipProvider = null;
-            this.objectReferenceListing.DragDropMarkColor = System.Drawing.Color.Black;
-            this.objectReferenceListing.FullRowSelect = true;
-            this.objectReferenceListing.FullRowSelectActiveColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.objectReferenceListing.FullRowSelectInactiveColor = System.Drawing.Color.FromArgb(((int)(((byte)(212)))), ((int)(((byte)(212)))), ((int)(((byte)(212)))));
-            this.objectReferenceListing.Indent = 5;
-            this.objectReferenceListing.LineColor = System.Drawing.Color.FromArgb(((int)(((byte)(92)))), ((int)(((byte)(92)))), ((int)(((byte)(92)))));
-            this.objectReferenceListing.LoadOnDemand = true;
-            this.objectReferenceListing.Location = new System.Drawing.Point(11, 57);
-            this.objectReferenceListing.Model = null;
-            this.objectReferenceListing.Name = "objectReferenceListing";
-            this.objectReferenceListing.NodeControls.Add(this.nodeImage);
-            this.objectReferenceListing.NodeControls.Add(this.nodeName);
-            this.objectReferenceListing.NodeControls.Add(this.nodePath);
-            this.objectReferenceListing.NodeFilter = null;
-            this.objectReferenceListing.SelectedNode = null;
-            this.objectReferenceListing.ShowLines = false;
-            this.objectReferenceListing.ShowPlusMinus = false;
-            this.objectReferenceListing.Size = new System.Drawing.Size(517, 298);
-            this.objectReferenceListing.TabIndex = 1;
-            this.objectReferenceListing.UseColumns = true;
-            // 
-            // columnImage
-            // 
-            this.columnImage.Header = "Icon";
-            this.columnImage.MaxColumnWidth = 45;
-            this.columnImage.MinColumnWidth = 20;
-            this.columnImage.SortOrder = System.Windows.Forms.SortOrder.None;
-            this.columnImage.TooltipText = null;
-            this.columnImage.Width = 32;
-            // 
-            // columnName
-            // 
-            this.columnName.Header = "Name";
-            this.columnName.MaxColumnWidth = 300;
-            this.columnName.MinColumnWidth = 80;
-            this.columnName.Sortable = true;
-            this.columnName.SortOrder = System.Windows.Forms.SortOrder.None;
-            this.columnName.TooltipText = null;
-            this.columnName.Width = 150;
-            // 
-            // columnPath
-            // 
-            this.columnPath.Header = "Path";
-            this.columnPath.MaxColumnWidth = 800;
-            this.columnPath.MinColumnWidth = 200;
-            this.columnPath.Sortable = true;
-            this.columnPath.SortOrder = System.Windows.Forms.SortOrder.None;
-            this.columnPath.TooltipText = null;
-            this.columnPath.Width = 300;
-            // 
-            // nodeImage
-            // 
-            this.nodeImage.DataPropertyName = "Image";
-            this.nodeImage.IncrementalSearchEnabled = true;
-            this.nodeImage.LeftMargin = 3;
-            this.nodeImage.ParentColumn = this.columnImage;
-            this.nodeImage.ScaleMode = Aga.Controls.Tree.ImageScaleMode.Clip;
-            // 
-            // nodeName
-            // 
-            this.nodeName.DataPropertyName = "Name";
-            this.nodeName.IncrementalSearchEnabled = true;
-            this.nodeName.LeftMargin = 3;
-            this.nodeName.ParentColumn = this.columnName;
-            // 
-            // nodePath
-            // 
-            this.nodePath.DataPropertyName = "Path";
-            this.nodePath.IncrementalSearchEnabled = true;
-            this.nodePath.LeftMargin = 3;
-            this.nodePath.ParentColumn = this.columnPath;
-            // 
-            // txtFilterInput
-            // 
-            this.txtFilterInput.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtFilterInput.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(196)))), ((int)(((byte)(196)))), ((int)(((byte)(196)))));
-            this.txtFilterInput.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.txtFilterInput.CueText = "Reference Filter";
-            this.txtFilterInput.Location = new System.Drawing.Point(11, 32);
-            this.txtFilterInput.Margin = new System.Windows.Forms.Padding(2);
-            this.txtFilterInput.Name = "txtFilterInput";
-            this.txtFilterInput.Size = new System.Drawing.Size(517, 20);
-            this.txtFilterInput.TabIndex = 0;
-            this.txtFilterInput.TextChanged += new System.EventHandler(this.txtFilterInput_TextChanged);
-            // 
-            // ObjectRefSelectionDialog
-            // 
-            this.AcceptButton = this.buttonOk;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.AutoValidate = System.Windows.Forms.AutoValidate.Disable;
-            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(212)))), ((int)(((byte)(212)))), ((int)(((byte)(212)))));
-            this.CancelButton = this.buttonCancel;
-            this.ClientSize = new System.Drawing.Size(540, 396);
-            this.Controls.Add(this.txtFilterInput);
-            this.Controls.Add(this.objectReferenceListing);
-            this.Controls.Add(this.buttonCancel);
-            this.Controls.Add(this.labelInfo);
-            this.Controls.Add(this.buttonOk);
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(380, 399);
-            this.Name = "ObjectRefSelectionDialog";
-            this.ShowIcon = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Select a Reference...";
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+			this.buttonCancel = new System.Windows.Forms.Button();
+			this.buttonOk = new System.Windows.Forms.Button();
+			this.labelInfo = new System.Windows.Forms.Label();
+			this.objectReferenceListing = new Aga.Controls.Tree.TreeViewAdv();
+			this.columnImage = new Aga.Controls.Tree.TreeColumn();
+			this.columnName = new Aga.Controls.Tree.TreeColumn();
+			this.columnPath = new Aga.Controls.Tree.TreeColumn();
+			this.nodeImage = new Aga.Controls.Tree.NodeControls.NodeStateIcon();
+			this.nodeName = new Aga.Controls.Tree.NodeControls.NodeTextBox();
+			this.nodePath = new Aga.Controls.Tree.NodeControls.NodeTextBox();
+			this.txtFilterInput = new Duality.Editor.Controls.CueTextBox();
+			this.SuspendLayout();
+			// 
+			// buttonCancel
+			// 
+			this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+			this.buttonCancel.Location = new System.Drawing.Point(454, 361);
+			this.buttonCancel.Name = "buttonCancel";
+			this.buttonCancel.Size = new System.Drawing.Size(75, 23);
+			this.buttonCancel.TabIndex = 3;
+			this.buttonCancel.Text = "Cancel";
+			this.buttonCancel.UseVisualStyleBackColor = true;
+			// 
+			// buttonOk
+			// 
+			this.buttonOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.buttonOk.DialogResult = System.Windows.Forms.DialogResult.OK;
+			this.buttonOk.Location = new System.Drawing.Point(373, 361);
+			this.buttonOk.Name = "buttonOk";
+			this.buttonOk.Size = new System.Drawing.Size(75, 23);
+			this.buttonOk.TabIndex = 2;
+			this.buttonOk.Text = "Ok";
+			this.buttonOk.UseVisualStyleBackColor = true;
+			// 
+			// labelInfo
+			// 
+			this.labelInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			| System.Windows.Forms.AnchorStyles.Right)));
+			this.labelInfo.Location = new System.Drawing.Point(12, 9);
+			this.labelInfo.Name = "labelInfo";
+			this.labelInfo.Size = new System.Drawing.Size(516, 21);
+			this.labelInfo.TabIndex = 6;
+			this.labelInfo.Text = "Please select the reference you would like to use.";
+			// 
+			// objectReferenceListing
+			// 
+			this.objectReferenceListing.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+			| System.Windows.Forms.AnchorStyles.Left) 
+			| System.Windows.Forms.AnchorStyles.Right)));
+			this.objectReferenceListing.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(196)))), ((int)(((byte)(196)))), ((int)(((byte)(196)))));
+			this.objectReferenceListing.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.objectReferenceListing.Columns.Add(this.columnImage);
+			this.objectReferenceListing.Columns.Add(this.columnName);
+			this.objectReferenceListing.Columns.Add(this.columnPath);
+			this.objectReferenceListing.DefaultToolTipProvider = null;
+			this.objectReferenceListing.DragDropMarkColor = System.Drawing.Color.Black;
+			this.objectReferenceListing.FullRowSelect = true;
+			this.objectReferenceListing.FullRowSelectActiveColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
+			this.objectReferenceListing.FullRowSelectInactiveColor = System.Drawing.Color.FromArgb(((int)(((byte)(212)))), ((int)(((byte)(212)))), ((int)(((byte)(212)))));
+			this.objectReferenceListing.Indent = 5;
+			this.objectReferenceListing.LineColor = System.Drawing.Color.FromArgb(((int)(((byte)(92)))), ((int)(((byte)(92)))), ((int)(((byte)(92)))));
+			this.objectReferenceListing.LoadOnDemand = true;
+			this.objectReferenceListing.Location = new System.Drawing.Point(11, 57);
+			this.objectReferenceListing.Model = null;
+			this.objectReferenceListing.Name = "objectReferenceListing";
+			this.objectReferenceListing.NodeControls.Add(this.nodeImage);
+			this.objectReferenceListing.NodeControls.Add(this.nodeName);
+			this.objectReferenceListing.NodeControls.Add(this.nodePath);
+			this.objectReferenceListing.NodeFilter = null;
+			this.objectReferenceListing.SelectedNode = null;
+			this.objectReferenceListing.ShowLines = false;
+			this.objectReferenceListing.ShowPlusMinus = false;
+			this.objectReferenceListing.Size = new System.Drawing.Size(517, 298);
+			this.objectReferenceListing.TabIndex = 1;
+			this.objectReferenceListing.UseColumns = true;
+			// 
+			// columnImage
+			// 
+			this.columnImage.Header = "Icon";
+			this.columnImage.MaxColumnWidth = 45;
+			this.columnImage.MinColumnWidth = 20;
+			this.columnImage.SortOrder = System.Windows.Forms.SortOrder.None;
+			this.columnImage.TooltipText = null;
+			this.columnImage.Width = 32;
+			// 
+			// columnName
+			// 
+			this.columnName.Header = "Name";
+			this.columnName.MaxColumnWidth = 300;
+			this.columnName.MinColumnWidth = 80;
+			this.columnName.Sortable = true;
+			this.columnName.SortOrder = System.Windows.Forms.SortOrder.None;
+			this.columnName.TooltipText = null;
+			this.columnName.Width = 150;
+			// 
+			// columnPath
+			// 
+			this.columnPath.Header = "Path";
+			this.columnPath.MaxColumnWidth = 800;
+			this.columnPath.MinColumnWidth = 200;
+			this.columnPath.Sortable = true;
+			this.columnPath.SortOrder = System.Windows.Forms.SortOrder.None;
+			this.columnPath.TooltipText = null;
+			this.columnPath.Width = 300;
+			// 
+			// nodeImage
+			// 
+			this.nodeImage.DataPropertyName = "Image";
+			this.nodeImage.IncrementalSearchEnabled = true;
+			this.nodeImage.LeftMargin = 3;
+			this.nodeImage.ParentColumn = this.columnImage;
+			this.nodeImage.ScaleMode = Aga.Controls.Tree.ImageScaleMode.Clip;
+			// 
+			// nodeName
+			// 
+			this.nodeName.DataPropertyName = "Name";
+			this.nodeName.IncrementalSearchEnabled = true;
+			this.nodeName.LeftMargin = 3;
+			this.nodeName.ParentColumn = this.columnName;
+			// 
+			// nodePath
+			// 
+			this.nodePath.DataPropertyName = "Path";
+			this.nodePath.IncrementalSearchEnabled = true;
+			this.nodePath.LeftMargin = 3;
+			this.nodePath.ParentColumn = this.columnPath;
+			// 
+			// txtFilterInput
+			// 
+			this.txtFilterInput.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+			| System.Windows.Forms.AnchorStyles.Left) 
+			| System.Windows.Forms.AnchorStyles.Right)));
+			this.txtFilterInput.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(196)))), ((int)(((byte)(196)))), ((int)(((byte)(196)))));
+			this.txtFilterInput.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.txtFilterInput.CueText = "Reference Filter";
+			this.txtFilterInput.Location = new System.Drawing.Point(11, 32);
+			this.txtFilterInput.Margin = new System.Windows.Forms.Padding(2);
+			this.txtFilterInput.Name = "txtFilterInput";
+			this.txtFilterInput.Size = new System.Drawing.Size(517, 20);
+			this.txtFilterInput.TabIndex = 0;
+			this.txtFilterInput.TextChanged += new System.EventHandler(this.txtFilterInput_TextChanged);
+			// 
+			// ObjectRefSelectionDialog
+			// 
+			this.AcceptButton = this.buttonOk;
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.AutoValidate = System.Windows.Forms.AutoValidate.Disable;
+			this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(212)))), ((int)(((byte)(212)))), ((int)(((byte)(212)))));
+			this.CancelButton = this.buttonCancel;
+			this.ClientSize = new System.Drawing.Size(540, 396);
+			this.Controls.Add(this.txtFilterInput);
+			this.Controls.Add(this.objectReferenceListing);
+			this.Controls.Add(this.buttonCancel);
+			this.Controls.Add(this.labelInfo);
+			this.Controls.Add(this.buttonOk);
+			this.MaximizeBox = false;
+			this.MinimizeBox = false;
+			this.MinimumSize = new System.Drawing.Size(380, 399);
+			this.Name = "ObjectRefSelectionDialog";
+			this.ShowIcon = false;
+			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+			this.Text = "Select a Reference...";
+			this.ResumeLayout(false);
+			this.PerformLayout();
 		}
 
 		#endregion

--- a/Source/Editor/DualityEditor/Forms/ObjectRefSelectionDialog.cs
+++ b/Source/Editor/DualityEditor/Forms/ObjectRefSelectionDialog.cs
@@ -25,6 +25,7 @@ namespace Duality.Editor.Forms
 				this.Text = this.Name;
 
 				this.ResourceReference = resource;
+				this.Image = resource.GetType().GetEditorImage();
 			}
 			public ReferenceNode(GameObject gameObject)
 			{
@@ -33,6 +34,7 @@ namespace Duality.Editor.Forms
 				this.Text = this.Name;
 
 				this.GameObjectReference = gameObject;
+				this.Image = gameObject.GetType().GetEditorImage();
 			}
 			public ReferenceNode(Component component)
 			{
@@ -43,6 +45,7 @@ namespace Duality.Editor.Forms
 				this.Text = this.Name;
 
 				this.ComponentReference = component;
+				this.Image = component.GetType().GetEditorImage();
 			}
 		}
 
@@ -75,6 +78,7 @@ namespace Duality.Editor.Forms
 			this.nodeName.DrawText += this.NodeName_OnDrawText;
 			this.nodePath.DrawText += this.NodePath_OnDrawText;
 
+			this.columnImage.DrawColHeaderBg += this.treeColumn_DrawColHeaderBg;
 			this.columnName.DrawColHeaderBg += this.treeColumn_DrawColHeaderBg;
 			this.columnPath.DrawColHeaderBg += this.treeColumn_DrawColHeaderBg;
 		}

--- a/Source/Editor/DualityEditor/Forms/ObjectRefSelectionDialog.cs
+++ b/Source/Editor/DualityEditor/Forms/ObjectRefSelectionDialog.cs
@@ -14,9 +14,9 @@ namespace Duality.Editor.Forms
 		{
 			public string Name { get; set; }
 			public string Path { get; set; }
-			public IContentRef ResourceReference { get; set; }
-			public GameObject GameObjectReference { get; set; }
-			public Component ComponentReference { get; set; }
+			public IContentRef ResourceReference { get; private set; }
+			public GameObject GameObjectReference { get; private set; }
+			public Component ComponentReference { get; private set; }
 
 			public ReferenceNode(IContentRef resource)
 			{


### PR DESCRIPTION
### Summary
Implemented #606. The implementation follows almost exactly as described in the issue text. There is one decision I made that is debatable, however.

The ReferenceNode class has three Reference properties that had public get/setters. With the edits I made, the Image property is assigned within the inspector based on the value of the Reference property passed into the constructor. If these properties were left with public setters, some later code could set these Reference properties to a new object that could need a different image than the one originally set in the constructor. The simplest solution was to make the setters private. Now, future uses of this class avoid a possible bug.

The alternative is to change the getter/setters to use private backing fields and to update the Image whenever the a Reference property changes. This would certainly work, but just seemed like more work than is necessary right now. If requested, I can implement that.