### PR TITLE
Default graphics backend now follows init rules

### DIFF
--- a/Source/Platform/DefaultOpenTK/Backend/Graphics/GraphicsBackend.cs
+++ b/Source/Platform/DefaultOpenTK/Backend/Graphics/GraphicsBackend.cs
@@ -92,7 +92,8 @@ namespace Duality.Backend.DefaultOpenTK
 		{
 			// Initialize OpenTK, if not done yet
 			DefaultOpenTKBackendPlugin.InitOpenTK();
-			
+			DefaultOpenTKBackendPlugin.DetectInputDevices();
+
 			// Log information about the available display devices
 			GraphicsBackend.LogDisplayDevices();
 

--- a/Source/Platform/DefaultOpenTK/CorePlugin.cs
+++ b/Source/Platform/DefaultOpenTK/CorePlugin.cs
@@ -17,28 +17,21 @@ namespace Duality.Backend.DefaultOpenTK
 	{
 		private static bool openTKInitialized;
 		private static Thread mainThread;
-		private double lastInputDeviceUpdate;
+		private static double lastInputDeviceUpdate;
 
 		protected override void InitPlugin()
 		{
 			base.InitPlugin();
-
 			mainThread = Thread.CurrentThread;
-
-			// Initialize OpenTK, if not done yet
-			InitOpenTK();
-
-			// Initially check for available input devices
-			this.DetectInputDevices();
 		}
 		protected override void OnAfterUpdate()
 		{
 			base.OnAfterUpdate();
 
 			// Periodically check for global / non-windowbound input devices
-			if (Time.MainTimer.TotalSeconds - this.lastInputDeviceUpdate > 1.0f)
+			if (Time.MainTimer.TotalSeconds - lastInputDeviceUpdate > 1.0f)
 			{
-				this.DetectInputDevices();
+				DetectInputDevices();
 			}
 		}
 		protected override void OnDisposePlugin()
@@ -57,9 +50,9 @@ namespace Duality.Backend.DefaultOpenTK
 			}
 		}
 
-		private void DetectInputDevices()
+		internal static void DetectInputDevices()
 		{
-			this.lastInputDeviceUpdate = Time.MainTimer.TotalSeconds;
+			lastInputDeviceUpdate = Time.MainTimer.TotalSeconds;
 			GlobalGamepadInputSource.UpdateAvailableDecives(DualityApp.Gamepads);
 			GlobalJoystickInputSource.UpdateAvailableDecives(DualityApp.Joysticks);
 		}


### PR DESCRIPTION
Fixed a bug where DefaultOpenTKBackendPlugin would initialize OpenTK even if Duality did not select it as the graphics backend