### PR TITLE
Made flat perspective scroll more uniform

### DIFF
--- a/Source/Plugins/EditorModules/CamView/CamViewStates/CamViewState.cs
+++ b/Source/Plugins/EditorModules/CamView/CamViewStates/CamViewState.cs
@@ -812,7 +812,7 @@ namespace Duality.Editor.Plugins.CamView.CamViewStates
 				}
 				else
 				{
-					this.View.FocusDist = this.View.FocusDist + this.View.FocusDistIncrement * e.Delta / 40;
+					this.View.FocusDist += ((float)e.Delta / 1000f) * this.View.FocusDist;
 				}
 			}
 


### PR DESCRIPTION
Zooming in flat mode is buggy and inconsistent due to FocusDistIncrement, multiplying Delta by current FocusDist is much smoother and provides a more natural zoom experience.