### PR TITLE
647 sceneview multi object create

### DIFF
--- a/Source/Plugins/EditorModules/SceneView/Modules/SceneView.cs
+++ b/Source/Plugins/EditorModules/SceneView/Modules/SceneView.cs
@@ -1477,16 +1477,22 @@ namespace Duality.Editor.Plugins.SceneView
 
 		private void gameObjectToolStripMenuItem_Click(object sender, EventArgs e)
 		{
-			// Create the GameObject
-			GameObject obj = this.CreateGameObject(this.objectView.SelectedNode);
-			GameObjectNode objNode = this.FindNode(obj);
+			// Create new objects
+			List<GameObjectNode> newObjects = new List<GameObjectNode>();
+			foreach (TreeNodeAdv node in this.objectView.SelectedNodes)
+			{
+				GameObject obj = this.CreateGameObject(node);
+				GameObjectNode objNode = this.FindNode(obj);
+				newObjects.Add(objNode);
+			}
 
-			// Deselect previous
 			this.objectView.ClearSelection();
 
-			// Select new node
-			if (objNode != null)
+			// Select newly created objects
+			foreach (GameObjectNode objNode in newObjects)
 			{
+				if (objNode == null) continue;
+
 				TreeNodeAdv dragObjViewNode;
 				dragObjViewNode = this.objectView.FindNode(this.objectModel.GetPath(objNode));
 				if (dragObjViewNode != null)

--- a/Source/Plugins/EditorModules/SceneView/Modules/SceneView.cs
+++ b/Source/Plugins/EditorModules/SceneView/Modules/SceneView.cs
@@ -1479,11 +1479,20 @@ namespace Duality.Editor.Plugins.SceneView
 		{
 			// Create new objects
 			List<GameObjectNode> newObjects = new List<GameObjectNode>();
-			foreach (TreeNodeAdv node in this.objectView.SelectedNodes)
+			if (this.objectView.SelectedNodes.Count <= 1)
 			{
-				GameObject obj = this.CreateGameObject(node);
+				GameObject obj = this.CreateGameObject(this.objectView.SelectedNode);
 				GameObjectNode objNode = this.FindNode(obj);
 				newObjects.Add(objNode);
+			}
+			else
+			{
+				foreach (TreeNodeAdv node in this.objectView.SelectedNodes)
+				{
+					GameObject obj = this.CreateGameObject(node);
+					GameObjectNode objNode = this.FindNode(obj);
+					newObjects.Add(objNode);
+				}
 			}
 
 			this.objectView.ClearSelection();


### PR DESCRIPTION
### Summary
Addressed #647 so that ""New/GameObject" now creates new child objects for every object selected.

There exists a minor issue: when multiple objects are created, only the last one created will have its name selected and in the process of being edited. I don't think any functionality exists to have multiple object names edited at the same time. What might make more sense is to not select a name for editing when multiple objects are selected. The other option would be some kind of popup dialog that asks for the name of the new objects.
