### PR TITLE
#653 Serializable References

### DIFF
--- a/Source/Editor/DualityEditor/DualityEditor.csproj
+++ b/Source/Editor/DualityEditor/DualityEditor.csproj
@@ -304,6 +304,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utility\PathHelper.cs" />
     <Compile Include="Utility\RecycleBin.cs" />
+    <Compile Include="Utility\SerializableReferenceWrapper.cs" />
     <Compile Include="Utility\SerializableWrapper.cs" />
     <Compile Include="Utility\XmlCodeDoc.cs" />
     <Compile Include="UndoRedoActions\DeleteGameObjectAction.cs" />

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -20,10 +20,13 @@ namespace Duality.Editor
 		/// </summary>
 		/// <param name="data"></param>
 		/// <param name="value"></param>
+		/// <param name="reference">Whether or not to store the value as a reference or to perform a clone of the value</param>
 		public static void SetWrappedData(this IDataObject data, object value, bool reference = true)
 		{
 			data.SetData(WrapperPrefix + value.GetType().FullName, 
-				reference ? new SerializableReferenceWrapper(value) : new SerializableWrapper(value));
+				reference 
+					? new SerializableReferenceWrapper(value) 
+					: new SerializableWrapper(value));
 		}
 		/// <summary>
 		/// Determines whether the specified type of wrapped non-<see cref="SerializableAttribute"/> data is available in the data object.

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -6,6 +6,7 @@ using System.IO;
 
 using Duality;
 using Duality.Drawing;
+using Duality.Editor.Utility;
 using Duality.Resources;
 
 namespace Duality.Editor
@@ -19,9 +20,10 @@ namespace Duality.Editor
 		/// </summary>
 		/// <param name="data"></param>
 		/// <param name="value"></param>
-		public static void SetWrappedData(this IDataObject data, object value)
+		public static void SetWrappedData(this IDataObject data, object value, bool reference = true)
 		{
-			data.SetData(WrapperPrefix + value.GetType().FullName, new SerializableWrapper(value));
+			data.SetData(WrapperPrefix + value.GetType().FullName, 
+				reference ? new SerializableReferenceWrapper(value) : new SerializableWrapper(value));
 		}
 		/// <summary>
 		/// Determines whether the specified type of wrapped non-<see cref="SerializableAttribute"/> data is available in the data object.

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -21,7 +21,7 @@ namespace Duality.Editor
 		/// <param name="data"></param>
 		/// <param name="value"></param>
 		/// <param name="reference">Whether or not to store the value as a reference or to perform a clone of the value</param>
-		public static void SetWrappedData(this IDataObject data, object value, bool reference = true)
+		public static void SetWrappedData(this IDataObject data, object value, bool reference = false)
 		{
 			data.SetData(WrapperPrefix + value.GetType().FullName, 
 				reference 
@@ -88,7 +88,7 @@ namespace Duality.Editor
 		public static void SetComponentRefs(this IDataObject data, IEnumerable<Component> cmp)
 		{
 			Component[] cmpArray = cmp.ToArray();
-			if (cmpArray.Length > 0) data.SetWrappedData(cmpArray);
+			if (cmpArray.Length > 0) data.SetWrappedData(cmpArray, true);
 		}
 		public static bool ContainsComponentRefs<T>(this IDataObject data) where T : Component
 		{
@@ -128,7 +128,7 @@ namespace Duality.Editor
 		public static void SetGameObjectRefs(this IDataObject data, IEnumerable<GameObject> obj)
 		{
 			GameObject[] objArray = obj.ToArray();
-			if (objArray.Length > 0) data.SetWrappedData(objArray);
+			if (objArray.Length > 0) data.SetWrappedData(objArray, true);
 		}
 		public static bool ContainsGameObjectRefs(this IDataObject data)
 		{
@@ -142,7 +142,7 @@ namespace Duality.Editor
 		public static void SetContentRefs(this IDataObject data, IEnumerable<IContentRef> content)
 		{
 			if (!content.Any()) return;
-			data.SetWrappedData(content.ToArray());
+			data.SetWrappedData(content.ToArray(), true);
 		}
 		public static bool ContainsContentRefs<T>(this IDataObject data) where T : Resource
 		{

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -6,7 +6,6 @@ using System.IO;
 
 using Duality;
 using Duality.Drawing;
-using Duality.Editor.Utility;
 using Duality.Resources;
 
 namespace Duality.Editor

--- a/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Duality.Editor.Utility
+{
+	[Serializable]
+	public class SerializableReferenceWrapper : SerializableWrapper
+	{
+		private static long NextID = 0;
+		private static readonly Dictionary<long, object> ReferenceMap 
+			= new Dictionary<long, object>();
+
+		private long ID = -1;
+
+		public sealed override object Data
+		{
+			get
+			{
+				return this.ID < 0 
+					? null 
+					: ReferenceMap[this.ID];
+			}
+			set
+			{
+				if (this.ID < 0)
+					this.ID = NextID++;
+
+				ReferenceMap[this.ID] = value;
+				base.Data = this.ID;
+			}
+		}
+
+		public SerializableReferenceWrapper(object data)
+		{
+			this.Data = data;
+		}
+	}
+}

--- a/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
@@ -41,13 +41,13 @@ namespace Duality.Editor
 			object serializedObject = info.GetValue("data", typeof(long));
 			if (serializedObject is long)
 			{
-				this.ID = (long) serializedObject;
-				base.Data = referenceMap[this.ID];
+				long id = (long) serializedObject;
+				this.Data = referenceMap[id];
+				this.ID = id;
 			}
 			else
 			{
-				this.ID = -1;
-				base.Data = null;
+				this.Data = null;
 			}
 		}
 
@@ -58,7 +58,7 @@ namespace Duality.Editor
 			if (this.ID < 0)
 			{
 				this.ID = nextID++;
-				referenceMap[this.ID] = base.Data;
+				referenceMap[this.ID] = this.Data;
 			}
 			info.AddValue("data", this.ID);
 		}

--- a/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
@@ -49,6 +49,8 @@ namespace Duality.Editor
 
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
+			// First time this object is being serialized. Give it an ID in the reference map
+			// so we can look it up when deserializing the object and get the same reference
 			if (this.ID < 0)
 			{
 				this.ID = nextID++;

--- a/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Runtime.Serialization;
 using Duality.Serialization;
 
-namespace Duality.Editor.Utility
+namespace Duality.Editor
 {
 	/// <summary>
 	/// A wrapper object that stores a reference to a non-<see cref="SerializableAttribute"/> object.

--- a/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
@@ -20,9 +20,7 @@ namespace Duality.Editor
 		{
 			get
 			{
-				return this.ID < 0 
-					? base.Data 
-					: referenceMap[this.ID];
+				return base.Data;
 			}
 			set
 			{
@@ -42,9 +40,15 @@ namespace Duality.Editor
 		{
 			object serializedObject = info.GetValue("data", typeof(long));
 			if (serializedObject is long)
+			{
 				this.ID = (long) serializedObject;
+				base.Data = referenceMap[this.ID];
+			}
 			else
+			{
 				this.ID = -1;
+				base.Data = null;
+			}
 		}
 
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)

--- a/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
@@ -12,8 +12,8 @@ namespace Duality.Editor.Utility
 	[Serializable]
 	public class SerializableReferenceWrapper : SerializableWrapper
 	{
-		private static long NextID = 0;
-		private static readonly Dictionary<long, object> ReferenceMap 
+		private static long nextID = 0;
+		private static readonly Dictionary<long, object> referenceMap 
 			= new Dictionary<long, object>();
 
 		private long ID = -1;
@@ -24,14 +24,14 @@ namespace Duality.Editor.Utility
 			{
 				return this.ID < 0 
 					? null 
-					: ReferenceMap[this.ID];
+					: referenceMap[this.ID];
 			}
 			set
 			{
 				if (this.ID < 0)
-					this.ID = NextID++;
+					this.ID = nextID++;
 
-				ReferenceMap[this.ID] = value;
+				referenceMap[this.ID] = value;
 			}
 		}
 

--- a/Source/Editor/DualityEditor/Utility/SerializableWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableWrapper.cs
@@ -19,7 +19,7 @@ namespace Duality.Editor
 	{
 		private object data;
 
-		public object Data
+		public virtual object Data
 		{
 			get { return this.data; }
 			set { this.data = value; }

--- a/Source/Editor/DualityEditor/Utility/SerializableWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableWrapper.cs
@@ -39,7 +39,7 @@ namespace Duality.Editor
 			}
 		}
 
-		void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			using (MemoryStream stream = new MemoryStream())
 			{


### PR DESCRIPTION
### Summary

Created a SerializableReferenceWrapper class to store references to objects through serialization. All that gets serialized is a long value which is used to lookup the object in a Dictionary<long, object>. Addresses #653.

### Details

All existing uses of the SetWrappedData DataObject extension method now use this wrapper except for the VectorPropertyEditor and SetIColorData. Both will end up using SerializableWrapper and a copy will be created but this maintains the current functionality as those are both value types.