### PR TITLE
DataObject Extension Improvements

### DIFF
--- a/Source/Editor/DualityEditor/Controls/PropertyEditors/IColorDataPropertyEditor.cs
+++ b/Source/Editor/DualityEditor/Controls/PropertyEditors/IColorDataPropertyEditor.cs
@@ -178,9 +178,10 @@ namespace Duality.Editor.Controls.PropertyEditors
 			else if (e.KeyCode == Keys.V && e.Control)
 			{
 				DataObject data = Clipboard.GetDataObject() as DataObject;
-				if (data.ContainsIColorData())
+				IColorData[] colorData;
+				if (data.TryGetIColorData(out colorData))
 				{
-					this.value = data.GetIColorData<IColorData>().FirstOrDefault();
+					this.value = colorData.FirstOrDefault();
 					this.PerformSetValue();
 					this.PerformGetValue();
 					this.OnEditingFinished(FinishReason.LeapValue);

--- a/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
+++ b/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
@@ -156,10 +155,11 @@ namespace Duality.Editor.Controls.PropertyEditors
 				{
 					DataObject data = Clipboard.GetDataObject() as DataObject;
 					bool success = false;
-					if (data.GetWrappedDataPresent(VectorDataFormat, DataObjectStorage.Value))
+					IEnumerable<object> storedVectors;
+					if (data.TryGetWrappedData(VectorDataFormat, DataObjectStorage.Value, out storedVectors))
 					{
-						object stored = data.GetWrappedData(VectorDataFormat, DataObjectStorage.Value).First();
-						this.SetValue(stored);
+						object vectorObj = storedVectors.First();
+						this.SetValue(vectorObj);
 						this.PerformGetValue();
 						this.OnEditingFinished(FinishReason.LeapValue);
 						this.SetFocusEditorIndex(-1, true);

--- a/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
+++ b/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
@@ -132,7 +132,7 @@ namespace Duality.Editor.Controls.PropertyEditors
 					string valString = this.editor.Select(ve => ve.Value).ToString(", ");
 					DataObject data = new DataObject();
 					data.SetText(valString);
-					data.SetWrappedData(new [] { this.DisplayedValue }, DataFormat.Value);
+					data.SetWrappedData(new [] { this.DisplayedValue }, this.DisplayedValue.GetType(), DataFormat.Value);
 
 					Clipboard.SetDataObject(data);
 					this.SetFocusEditorIndex(-1, true);
@@ -156,7 +156,7 @@ namespace Duality.Editor.Controls.PropertyEditors
 					bool success = false;
 					if (data.GetWrappedDataPresent(this.DisplayedValue.GetType(), DataFormat.Value))
 					{
-						object stored = data.GetWrappedData(this.DisplayedValue.GetType(), DataFormat.Value)[0];
+						object stored = data.GetWrappedData(this.DisplayedValue.GetType(), DataFormat.Value).First();
 						this.SetValue(stored);
 						this.PerformGetValue();
 						this.OnEditingFinished(FinishReason.LeapValue);

--- a/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
+++ b/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
@@ -132,7 +132,7 @@ namespace Duality.Editor.Controls.PropertyEditors
 					string valString = this.editor.Select(ve => ve.Value).ToString(", ");
 					DataObject data = new DataObject();
 					data.SetText(valString);
-					data.SetWrappedData(new [] { this.DisplayedValue }, this.DisplayedValue.GetType(), DataFormat.Value);
+					data.SetWrappedData(new [] { this.DisplayedValue }, DataFormat.Value);
 
 					Clipboard.SetDataObject(data);
 					this.SetFocusEditorIndex(-1, true);

--- a/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
+++ b/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
@@ -131,7 +132,9 @@ namespace Duality.Editor.Controls.PropertyEditors
 					string valString = this.editor.Select(ve => ve.Value).ToString(", ");
 					DataObject data = new DataObject();
 					data.SetText(valString);
-					data.SetWrappedData(this.DisplayedValue, DataFormat.Value);
+
+					data.SetWrappedData(new [] { this.DisplayedValue }, this.DisplayedValue.GetType(), DataFormat.Value);
+
 					Clipboard.SetDataObject(data);
 					this.SetFocusEditorIndex(-1, true);
 					if (e.KeyCode == Keys.X)
@@ -154,7 +157,7 @@ namespace Duality.Editor.Controls.PropertyEditors
 					bool success = false;
 					if (data.GetWrappedDataPresent(this.DisplayedValue.GetType(), DataFormat.Value))
 					{
-						object stored = data.GetWrappedData(this.DisplayedValue.GetType(), DataFormat.Value);
+						object stored = data.GetWrappedData(this.DisplayedValue.GetType(), DataFormat.Value)[0];
 						this.SetValue(stored);
 						this.PerformGetValue();
 						this.OnEditingFinished(FinishReason.LeapValue);

--- a/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
+++ b/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
@@ -15,6 +15,8 @@ namespace Duality.Editor.Controls.PropertyEditors
 {
 	public abstract class VectorPropertyEditor : PropertyEditor
 	{
+		private const string VectorDataFormat = "Vectors";
+
 		protected	NumericEditorTemplate[]	editor		= null;
 		protected	bool[]					multiple	= null;
 		protected	int						focusEditor	= -2;
@@ -132,7 +134,7 @@ namespace Duality.Editor.Controls.PropertyEditors
 					string valString = this.editor.Select(ve => ve.Value).ToString(", ");
 					DataObject data = new DataObject();
 					data.SetText(valString);
-					data.SetWrappedData(new [] { this.DisplayedValue }, this.DisplayedValue.GetType(), DataFormat.Value);
+					data.SetWrappedData(new [] { this.DisplayedValue }, VectorDataFormat, DataType.Value);
 
 					Clipboard.SetDataObject(data);
 					this.SetFocusEditorIndex(-1, true);
@@ -154,9 +156,9 @@ namespace Duality.Editor.Controls.PropertyEditors
 				{
 					DataObject data = Clipboard.GetDataObject() as DataObject;
 					bool success = false;
-					if (data.GetWrappedDataPresent(this.DisplayedValue.GetType(), DataFormat.Value))
+					if (data.GetWrappedDataPresent(VectorDataFormat, DataType.Value))
 					{
-						object stored = data.GetWrappedData(this.DisplayedValue.GetType(), DataFormat.Value).First();
+						object stored = data.GetWrappedData(VectorDataFormat, DataType.Value).First();
 						this.SetValue(stored);
 						this.PerformGetValue();
 						this.OnEditingFinished(FinishReason.LeapValue);

--- a/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
+++ b/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
@@ -131,7 +131,7 @@ namespace Duality.Editor.Controls.PropertyEditors
 					string valString = this.editor.Select(ve => ve.Value).ToString(", ");
 					DataObject data = new DataObject();
 					data.SetText(valString);
-					data.SetWrappedData(this.DisplayedValue);
+					data.SetWrappedData(this.DisplayedValue, DataFormat.Value);
 					Clipboard.SetDataObject(data);
 					this.SetFocusEditorIndex(-1, true);
 					if (e.KeyCode == Keys.X)
@@ -152,9 +152,9 @@ namespace Duality.Editor.Controls.PropertyEditors
 				{
 					DataObject data = Clipboard.GetDataObject() as DataObject;
 					bool success = false;
-					if (data.GetWrappedDataPresent(this.DisplayedValue.GetType()))
+					if (data.GetWrappedDataPresent(this.DisplayedValue.GetType(), DataFormat.Value))
 					{
-						object stored = data.GetWrappedData(this.DisplayedValue.GetType());
+						object stored = data.GetWrappedData(this.DisplayedValue.GetType(), DataFormat.Value);
 						this.SetValue(stored);
 						this.PerformGetValue();
 						this.OnEditingFinished(FinishReason.LeapValue);

--- a/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
+++ b/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
@@ -132,7 +132,6 @@ namespace Duality.Editor.Controls.PropertyEditors
 					string valString = this.editor.Select(ve => ve.Value).ToString(", ");
 					DataObject data = new DataObject();
 					data.SetText(valString);
-
 					data.SetWrappedData(new [] { this.DisplayedValue }, this.DisplayedValue.GetType(), DataFormat.Value);
 
 					Clipboard.SetDataObject(data);

--- a/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
+++ b/Source/Editor/DualityEditor/Controls/PropertyEditors/VectorPropertyEditor.cs
@@ -134,7 +134,7 @@ namespace Duality.Editor.Controls.PropertyEditors
 					string valString = this.editor.Select(ve => ve.Value).ToString(", ");
 					DataObject data = new DataObject();
 					data.SetText(valString);
-					data.SetWrappedData(new [] { this.DisplayedValue }, VectorDataFormat, DataType.Value);
+					data.SetWrappedData(new [] { this.DisplayedValue }, VectorDataFormat, DataObjectStorage.Value);
 
 					Clipboard.SetDataObject(data);
 					this.SetFocusEditorIndex(-1, true);
@@ -156,9 +156,9 @@ namespace Duality.Editor.Controls.PropertyEditors
 				{
 					DataObject data = Clipboard.GetDataObject() as DataObject;
 					bool success = false;
-					if (data.GetWrappedDataPresent(VectorDataFormat, DataType.Value))
+					if (data.GetWrappedDataPresent(VectorDataFormat, DataObjectStorage.Value))
 					{
-						object stored = data.GetWrappedData(VectorDataFormat, DataType.Value).First();
+						object stored = data.GetWrappedData(VectorDataFormat, DataObjectStorage.Value).First();
 						this.SetValue(stored);
 						this.PerformGetValue();
 						this.OnEditingFinished(FinishReason.LeapValue);

--- a/Source/Editor/DualityEditor/DualityEditor.csproj
+++ b/Source/Editor/DualityEditor/DualityEditor.csproj
@@ -211,6 +211,7 @@
     <Compile Include="Utility\EventArgs\HighlightObjectEventArgs.cs" />
     <Compile Include="Utility\EventArgs\SelectionChangedEventArgs.cs" />
     <Compile Include="Utility\EventArgs\HelpStackChangedEventArgs.cs" />
+    <Compile Include="Utility\Extensions\DataObjectStorage.cs" />
     <Compile Include="Utility\GlobalColorPickOperation.cs" />
     <Compile Include="Utility\SelectionChangeReason.cs" />
     <Compile Include="Utility\HighlightMode.cs" />

--- a/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
+++ b/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
@@ -35,15 +35,15 @@ namespace Duality.Editor
 		{
 			bool isCached = 
 				this.dataCache.GetDataPresent(format, autoConvert) || 
-				this.dataCache.GetWrappedDataPresent(format);
+				this.dataCache.GetWrappedDataPresent(format, DataFormat.Reference);
 
 			if (!isCached)
 			{
 				object obj;
 				if (this.data.GetDataPresent(format, autoConvert))
 					obj = this.data.GetData(format, autoConvert);
-				else if (this.data.GetWrappedDataPresent(format))
-					obj = this.data.GetWrappedData(format);
+				else if (this.data.GetWrappedDataPresent(format, DataFormat.Reference))
+					obj = this.data.GetWrappedData(format, DataFormat.Reference);
 				else
 					obj = null;
 
@@ -61,7 +61,7 @@ namespace Duality.Editor
 		{
 			return 
 				this.data.GetDataPresent(format, autoConvert) || 
-				this.data.GetWrappedDataPresent(format);
+				this.data.GetWrappedDataPresent(format, DataFormat.Reference);
 		}
 
 		string[] IDataObject.GetFormats()

--- a/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
+++ b/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
@@ -35,18 +35,18 @@ namespace Duality.Editor
 		{
 			bool isCached = 
 				this.dataCache.GetDataPresent(format, autoConvert) || 
-				this.dataCache.GetWrappedDataPresent(format, DataFormat.Reference) ||
-				this.dataCache.GetWrappedDataPresent(format, DataFormat.Value);
+				this.dataCache.GetWrappedDataPresent(format, DataType.Reference) ||
+				this.dataCache.GetWrappedDataPresent(format, DataType.Value);
 
 			if (!isCached)
 			{
 				object obj;
 				if (this.data.GetDataPresent(format, autoConvert))
 					obj = this.data.GetData(format, autoConvert);
-				else if (this.data.GetWrappedDataPresent(format, DataFormat.Reference))
-					obj = this.data.GetWrappedData(format, DataFormat.Reference);
-				else if (this.data.GetWrappedDataPresent(format, DataFormat.Value))
-					obj = this.data.GetWrappedData(format, DataFormat.Value);
+				else if (this.data.GetWrappedDataPresent(format, DataType.Reference))
+					obj = this.data.GetWrappedData(format, DataType.Reference);
+				else if (this.data.GetWrappedDataPresent(format, DataType.Value))
+					obj = this.data.GetWrappedData(format, DataType.Value);
 				else
 					obj = null;
 
@@ -64,8 +64,8 @@ namespace Duality.Editor
 		{
 			return 
 				this.data.GetDataPresent(format, autoConvert) || 
-				this.data.GetWrappedDataPresent(format, DataFormat.Reference) ||
-				this.data.GetWrappedDataPresent(format, DataFormat.Value);
+				this.data.GetWrappedDataPresent(format, DataType.Reference) ||
+				this.data.GetWrappedDataPresent(format, DataType.Value);
 		}
 
 		string[] IDataObject.GetFormats()

--- a/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
+++ b/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
@@ -44,17 +44,9 @@ namespace Duality.Editor
 				if (this.data.GetDataPresent(format, autoConvert))
 					obj = this.data.GetData(format, autoConvert);
 				else if (this.data.GetWrappedDataPresent(format, DataFormat.Reference))
-				{
-					// TODO: should ConversionData care that GetWrappedData now returns an array?
-					object[] wrappedData = this.data.GetWrappedData(format, DataFormat.Reference);
-					obj = wrappedData == null ? null : wrappedData[0];
-				}
+					obj = this.data.GetWrappedData(format, DataFormat.Reference);
 				else if (this.data.GetWrappedDataPresent(format, DataFormat.Value))
-				{
-					// TODO: should ConversionData care that GetWrappedData now returns an array?
-					object[] wrappedData = this.data.GetWrappedData(format, DataFormat.Value);
-					obj = wrappedData == null ? null : wrappedData[0];
-				}
+					obj = this.data.GetWrappedData(format, DataFormat.Value);
 				else
 					obj = null;
 

--- a/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
+++ b/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
@@ -44,9 +44,17 @@ namespace Duality.Editor
 				if (this.data.GetDataPresent(format, autoConvert))
 					obj = this.data.GetData(format, autoConvert);
 				else if (this.data.GetWrappedDataPresent(format, DataFormat.Reference))
-					obj = this.data.GetWrappedData(format, DataFormat.Reference); // TODO: should ConversionData care that GetWrappedData now returns an array?
+				{
+					// TODO: should ConversionData care that GetWrappedData now returns an array?
+					object[] wrappedData = this.data.GetWrappedData(format, DataFormat.Reference);
+					obj = wrappedData == null ? null : wrappedData[0];
+				}
 				else if (this.data.GetWrappedDataPresent(format, DataFormat.Value))
-					obj = this.data.GetWrappedData(format, DataFormat.Value); // TODO: should ConversionData care that GetWrappedData now returns an array?
+				{
+					// TODO: should ConversionData care that GetWrappedData now returns an array?
+					object[] wrappedData = this.data.GetWrappedData(format, DataFormat.Value);
+					obj = wrappedData == null ? null : wrappedData[0];
+				}
 				else
 					obj = null;
 

--- a/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
+++ b/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
@@ -44,9 +44,9 @@ namespace Duality.Editor
 				if (this.data.GetDataPresent(format, autoConvert))
 					obj = this.data.GetData(format, autoConvert);
 				else if (this.data.GetWrappedDataPresent(format, DataObjectStorage.Reference))
-					obj = this.data.GetWrappedData(format, DataObjectStorage.Reference);
+					obj = this.data.GetWrappedData(format, DataObjectStorage.Reference).First();
 				else if (this.data.GetWrappedDataPresent(format, DataObjectStorage.Value))
-					obj = this.data.GetWrappedData(format, DataObjectStorage.Value);
+					obj = this.data.GetWrappedData(format, DataObjectStorage.Value).First();
 				else
 					obj = null;
 

--- a/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
+++ b/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
@@ -8,6 +8,7 @@ using Duality;
 
 namespace Duality.Editor
 {
+	// TODO: handle Value formatted data?
 	public class ConversionData : IDataObject
 	{
 		private	IDataObject data      = null;
@@ -43,7 +44,7 @@ namespace Duality.Editor
 				if (this.data.GetDataPresent(format, autoConvert))
 					obj = this.data.GetData(format, autoConvert);
 				else if (this.data.GetWrappedDataPresent(format, DataFormat.Reference))
-					obj = this.data.GetWrappedData(format, DataFormat.Reference);
+					obj = this.data.GetWrappedData(format, DataFormat.Reference); // TODO: should ConversionData care that GetWrappedData now returns an array?
 				else
 					obj = null;
 

--- a/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
+++ b/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
@@ -8,7 +8,6 @@ using Duality;
 
 namespace Duality.Editor
 {
-	// TODO: handle Value formatted data?
 	public class ConversionData : IDataObject
 	{
 		private	IDataObject data      = null;
@@ -36,7 +35,8 @@ namespace Duality.Editor
 		{
 			bool isCached = 
 				this.dataCache.GetDataPresent(format, autoConvert) || 
-				this.dataCache.GetWrappedDataPresent(format, DataFormat.Reference);
+				this.dataCache.GetWrappedDataPresent(format, DataFormat.Reference) ||
+				this.dataCache.GetWrappedDataPresent(format, DataFormat.Value);
 
 			if (!isCached)
 			{
@@ -45,6 +45,8 @@ namespace Duality.Editor
 					obj = this.data.GetData(format, autoConvert);
 				else if (this.data.GetWrappedDataPresent(format, DataFormat.Reference))
 					obj = this.data.GetWrappedData(format, DataFormat.Reference); // TODO: should ConversionData care that GetWrappedData now returns an array?
+				else if (this.data.GetWrappedDataPresent(format, DataFormat.Value))
+					obj = this.data.GetWrappedData(format, DataFormat.Value); // TODO: should ConversionData care that GetWrappedData now returns an array?
 				else
 					obj = null;
 
@@ -62,7 +64,8 @@ namespace Duality.Editor
 		{
 			return 
 				this.data.GetDataPresent(format, autoConvert) || 
-				this.data.GetWrappedDataPresent(format, DataFormat.Reference);
+				this.data.GetWrappedDataPresent(format, DataFormat.Reference) ||
+				this.data.GetWrappedDataPresent(format, DataFormat.Value);
 		}
 
 		string[] IDataObject.GetFormats()

--- a/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
+++ b/Source/Editor/DualityEditor/Extensibility/DataConversion/ConversionData.cs
@@ -35,18 +35,18 @@ namespace Duality.Editor
 		{
 			bool isCached = 
 				this.dataCache.GetDataPresent(format, autoConvert) || 
-				this.dataCache.GetWrappedDataPresent(format, DataType.Reference) ||
-				this.dataCache.GetWrappedDataPresent(format, DataType.Value);
+				this.dataCache.GetWrappedDataPresent(format, DataObjectStorage.Reference) ||
+				this.dataCache.GetWrappedDataPresent(format, DataObjectStorage.Value);
 
 			if (!isCached)
 			{
 				object obj;
 				if (this.data.GetDataPresent(format, autoConvert))
 					obj = this.data.GetData(format, autoConvert);
-				else if (this.data.GetWrappedDataPresent(format, DataType.Reference))
-					obj = this.data.GetWrappedData(format, DataType.Reference);
-				else if (this.data.GetWrappedDataPresent(format, DataType.Value))
-					obj = this.data.GetWrappedData(format, DataType.Value);
+				else if (this.data.GetWrappedDataPresent(format, DataObjectStorage.Reference))
+					obj = this.data.GetWrappedData(format, DataObjectStorage.Reference);
+				else if (this.data.GetWrappedDataPresent(format, DataObjectStorage.Value))
+					obj = this.data.GetWrappedData(format, DataObjectStorage.Value);
 				else
 					obj = null;
 
@@ -64,8 +64,8 @@ namespace Duality.Editor
 		{
 			return 
 				this.data.GetDataPresent(format, autoConvert) || 
-				this.data.GetWrappedDataPresent(format, DataType.Reference) ||
-				this.data.GetWrappedDataPresent(format, DataType.Value);
+				this.data.GetWrappedDataPresent(format, DataObjectStorage.Reference) ||
+				this.data.GetWrappedDataPresent(format, DataObjectStorage.Value);
 		}
 
 		string[] IDataObject.GetFormats()

--- a/Source/Editor/DualityEditor/Extensibility/DataConversion/ConvertOperation.cs
+++ b/Source/Editor/DualityEditor/Extensibility/DataConversion/ConvertOperation.cs
@@ -246,13 +246,15 @@ namespace Duality.Editor
 			}
 			if (fittingData == null)
 			{
-				// ComponentRefs
-				if (this.data.ContainsComponents(target)) fittingData = this.data.GetComponents(target);
+				// Components
+				Component[] comps;
+				if (this.data.TryGetComponents(target, out comps)) fittingData = comps;
 			}
 			if (fittingData == null)
 			{
 				// ContentRefs
-				if (this.data.ContainsContentRefs(target)) fittingData = this.data.GetContentRefs(target).Res();
+				IContentRef[] content;
+				if (this.data.TryGetContentRefs(target, out content)) fittingData = content.Res();
 			}
 			
 			// If something fitting was found, directly add it to the operation results

--- a/Source/Editor/DualityEditor/Extensibility/DataConversion/ConvertOperation.cs
+++ b/Source/Editor/DualityEditor/Extensibility/DataConversion/ConvertOperation.cs
@@ -248,7 +248,7 @@ namespace Duality.Editor
 			{
 				// Components
 				Component[] comps;
-				if (this.data.TryGetComponents(target, out comps)) fittingData = comps;
+				if (this.data.TryGetComponents(target, DataObjectStorage.Reference, out comps)) fittingData = comps;
 			}
 			if (fittingData == null)
 			{

--- a/Source/Editor/DualityEditor/Extensibility/DataConversion/ConvertOperation.cs
+++ b/Source/Editor/DualityEditor/Extensibility/DataConversion/ConvertOperation.cs
@@ -206,7 +206,7 @@ namespace Duality.Editor
 			if (!result && this.data.GetDataPresent(target)) result = true;
 			if (!result && this.data.GetDataPresent(target.MakeArrayType())) result = true;
 			if (!result && this.data.ContainsContentRefs(target)) result = true;
-			if (!result && this.data.ContainsComponentRefs(target)) result = true;
+			if (!result && this.data.ContainsComponents(target)) result = true;
 			if (!result)
 			{
 				result = GetConverters(target).Any(s => !this.usedConverters.Contains(s) && s.CanConvertFrom(this));
@@ -247,7 +247,7 @@ namespace Duality.Editor
 			if (fittingData == null)
 			{
 				// ComponentRefs
-				if (this.data.ContainsComponentRefs(target)) fittingData = this.data.GetComponentRefs(target);
+				if (this.data.ContainsComponents(target)) fittingData = this.data.GetComponents(target);
 			}
 			if (fittingData == null)
 			{

--- a/Source/Editor/DualityEditor/Extensibility/DataConversion/ConvertOperation.cs
+++ b/Source/Editor/DualityEditor/Extensibility/DataConversion/ConvertOperation.cs
@@ -268,9 +268,9 @@ namespace Duality.Editor
 			// No result yet? Search suitable converters
 			if (!fittingDataFound)
 			{
-				var converterQuery = GetConverters(target);
+				IEnumerable<DataConverter> converterQuery = GetConverters(target);
 				List<ConvComplexityEntry> converters = new List<ConvComplexityEntry>();
-				foreach (var c in converterQuery)
+				foreach (DataConverter c in converterQuery)
 				{
 					this.maxComplexity = 0;
 					if (this.usedConverters.Contains(c)) continue;
@@ -282,7 +282,7 @@ namespace Duality.Editor
 				try
 				{
 					converters.StableSort((c1, c2) => (c2.Converter.Priority - c1.Converter.Priority) * 10000 + (c1.Complexity - c2.Complexity));
-					foreach (var c in converters)
+					foreach (ConvComplexityEntry c in converters)
 					{
 						this.usedConverters.Add(c.Converter);
 						bool handled = c.Converter.Convert(this);
@@ -306,7 +306,7 @@ namespace Duality.Editor
 
 			// Convert back to Resource requests
 			if (typeof(IContentRef).IsAssignableFrom(originalType))
-				returnValue = result.OfType<Resource>().Select(r => r.GetContentRef());
+				returnValue = this.result.OfType<Resource>().Select(r => r.GetContentRef());
 
 			returnValue = returnValue ?? (IEnumerable<object>)Array.CreateInstance(originalType, 0);
 			returnValue = returnValue.Where(originalType.IsInstanceOfType);

--- a/Source/Editor/DualityEditor/Utility/Extensions/DataObjectStorage.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/DataObjectStorage.cs
@@ -15,17 +15,21 @@ namespace Duality.Editor
 	public enum DataObjectStorage
 	{
 		/// <summary>
-		/// Use this type when storing an object reference in a DataObject.
-		/// The reference will be maintained even after serialization.
-		/// Note that storing a .Net value type (ex. Vector3) with this data type
-		/// will still lead to a copy of the data. Data stored with this type
-		/// can be automatically converted to value typed data (uses deep cloning).
+		/// Indicates that an object is stored by reference inside a <see cref="DataObject"/>,
+		/// so it will not be cloned or copied when moved to the <see cref="Clipboard"/>.
+		/// 
+		/// Note that storing a value type (ex. <see cref="Vector3"/>) by reference
+		/// will still lead to a "copy" of the data due to boxing and unboxing operations.
+		/// 
+		/// Objects stored with this storage type can still be retrieved as <see cref="Value"/>
+		/// items, although a deep clone operation will be done internally in order to make sure
+		/// the result will be an otherwise unused instance.
 		/// </summary>
 		Reference,
 		/// <summary>
-		/// Use this type when storing an object in a DataObject that is
-		/// not meant to be a reference to an existing object. This type
-		/// of data cannot be automatically converted to reference typed data.
+		/// Indicates that an object is stored by value inside a <see cref="DataObject"/>,
+		/// so any retrieved instance will essentially be a clone of the original, but
+		/// not the original itself.
 		/// </summary>
 		Value
 	}

--- a/Source/Editor/DualityEditor/Utility/Extensions/DataObjectStorage.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/DataObjectStorage.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using System.IO;
+using Duality.Cloning;
+using Duality.Drawing;
+
+namespace Duality.Editor
+{
+	/// <summary>
+	/// Indicates whether an object is stored inside a <see cref="DataObject"/> as 
+	/// a reference or serialized value.
+	/// </summary>
+	public enum DataObjectStorage
+	{
+		/// <summary>
+		/// Use this type when storing an object reference in a DataObject.
+		/// The reference will be maintained even after serialization.
+		/// Note that storing a .Net value type (ex. Vector3) with this data type
+		/// will still lead to a copy of the data. Data stored with this type
+		/// can be automatically converted to value typed data (uses deep cloning).
+		/// </summary>
+		Reference,
+		/// <summary>
+		/// Use this type when storing an object in a DataObject that is
+		/// not meant to be a reference to an existing object. This type
+		/// of data cannot be automatically converted to reference typed data.
+		/// </summary>
+		Value
+	}
+}

--- a/Source/Editor/DualityEditor/Utility/Extensions/DataObjectStorage.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/DataObjectStorage.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Forms;
-using System.IO;
-using Duality.Cloning;
-using Duality.Drawing;
+﻿using System.Windows.Forms;
 
 namespace Duality.Editor
 {

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -45,8 +45,7 @@ namespace Duality.Editor
 		{
 			string prefix = storage == DataObjectStorage.Reference ? ReferencePrefix : ValuePrefix;
 			bool defaultFormatPresent = data.GetDataPresent(prefix + dataFormat);
-			if (defaultFormatPresent)
-				return defaultFormatPresent;
+			if (defaultFormatPresent) return true;
 
 			// If retrieving by-value failed, try retrieving by-reference and cloning the result
 			if (storage == DataObjectStorage.Value && data.GetWrappedDataPresent(dataFormat, DataObjectStorage.Reference))

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -319,7 +319,6 @@ namespace Duality.Editor
 				batches = null;
 				return false;
 			}
-
 			batches = data.GetBatchInfos();
 			return batches != null;
 		}

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -337,15 +337,15 @@ namespace Duality.Editor
 		public static void SetBatchInfos(this IDataObject data, IEnumerable<BatchInfo> obj)
 		{
 			BatchInfo[] objArray = obj.ToArray();
-			if (objArray.Length > 0) data.SetWrappedData(objArray, DataFormat.Reference);
+			if (objArray.Length > 0) data.SetWrappedData(objArray, DataFormat.Value);
 		}
 		public static bool ContainsBatchInfos(this IDataObject data)
 		{
-			return data.GetWrappedDataPresent(typeof(BatchInfo[]), DataFormat.Reference);
+			return data.GetWrappedDataPresent(typeof(BatchInfo[]), DataFormat.Value);
 		}
 		public static BatchInfo[] GetBatchInfos(this IDataObject data)
 		{
-			object[] batchArray = data.GetWrappedData(typeof(BatchInfo[]), DataFormat.Reference);
+			object[] batchArray = data.GetWrappedData(typeof(BatchInfo[]), DataFormat.Value);
 			return batchArray == null ? null : batchArray.OfType<BatchInfo>().Select(b => new BatchInfo(b)).ToArray();
 		}
 		public static bool TryGetBatchInfos(this IDataObject data, out BatchInfo[] batches)

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -48,8 +48,8 @@ namespace Duality.Editor
 		{
 			string prefix = format == DataFormat.Reference ? ReferencePrefix : ValuePrefix;
 			SerializableWrapper wrapper = format == DataFormat.Reference
-				? new SerializableReferenceWrapper(value)
-				: new SerializableWrapper(value);
+				? new SerializableReferenceWrapper(new [] { value })
+				: new SerializableWrapper(new[] { value });
 
 			data.SetData(prefix + value.GetType().FullName, wrapper);
 		}
@@ -90,13 +90,13 @@ namespace Duality.Editor
 		/// Retrieves the specified non-<see cref="SerializableAttribute"/> data from the specified data object using a serializable wrapper.
 		/// </summary>
 		/// <param name="data"></param>
-		/// <param name="format"></param>
+		/// <param name="type"></param>
 		/// <param name="formatType"></param>
 		/// <param name="allowConversion"></param>
 		/// <returns></returns>
-		public static object GetWrappedData(this IDataObject data, Type format, DataFormat formatType, bool allowConversion = true)
+		public static object GetWrappedData(this IDataObject data, Type type, DataFormat formatType, bool allowConversion = true)
 		{
-			return GetWrappedData(data, format.FullName, formatType, allowConversion);
+			return GetWrappedData(data, type.FullName, formatType, allowConversion);
 		}
 		/// <summary>
 		/// Retrieves the specified non-<see cref="SerializableAttribute"/> data from the specified data object using a serializable wrapper.
@@ -110,7 +110,7 @@ namespace Duality.Editor
 		{
 			string prefix = formatType == DataFormat.Reference ? ReferencePrefix : ValuePrefix;
 			SerializableWrapper wrapper = data.GetData(prefix + format) as SerializableWrapper;
-			if (wrapper != null) return wrapper.Data;
+			if (wrapper != null) return wrapper.Data[0];
 			if (!allowConversion) return null;
 
 			// Getting in the given format failed.

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -11,10 +11,25 @@ using Duality.Resources;
 
 namespace Duality.Editor
 {
-	// TODO: document
+	/// <summary>
+	/// Data formats than can be used when storing data
+	/// inside a <see cref="DataObject"/>
+	/// </summary>
 	public enum DataFormat
 	{
+		/// <summary>
+		/// Use this format when storing an object reference in a DataObject.
+		/// The reference will be maintained even after serialization.
+		/// Note that storing a value type (ex. Vector3) in reference format
+		/// will still lead to a copy of the data. Data stored in this format
+		/// can be automatically converted to value formatted data (uses deep cloning).
+		/// </summary>
 		Reference,
+		/// <summary>
+		/// Use this format when storing an object in a DataObject that is 
+		/// not meant to be a reference to an existing object. This format 
+		/// of data cannot be automatically converted to reference format.
+		/// </summary>
 		Value
 	}
 

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -33,7 +33,6 @@ namespace Duality.Editor
 		Value
 	}
 
-	// TODO: document parameters and such
 	public static class ExtMethodsDataObject
 	{
 		private const string ReferencePrefix = "SerializableReferenceWrapper:";
@@ -50,16 +49,16 @@ namespace Duality.Editor
 			SerializableWrapper wrapper = format == DataFormat.Reference
 				? new SerializableReferenceWrapper(values)
 				: new SerializableWrapper(values);
-
+			Log.Editor.Write(values.GetType().FullName);
 			data.SetData(prefix + elementType.FullName, wrapper);
 		}
 		/// <summary>
 		/// Determines whether the specified type of wrapped non-<see cref="SerializableAttribute"/> data is available in the data object.
 		/// </summary>
 		/// <param name="data"></param>
-		/// <param name="format"></param>
-		/// <param name="formatType"></param>
-		/// <param name="allowConversion"></param>
+		/// <param name="format">The type of elements in the wrapped data array</param>
+		/// <param name="formatType">The format the data is stored in</param>
+		/// <param name="allowConversion">Whether or not to attempt converting data from other formats</param>
 		/// <returns></returns>
 		public static bool GetWrappedDataPresent(this IDataObject data, Type elementType, DataFormat format, bool allowConversion = true)
 		{
@@ -69,9 +68,9 @@ namespace Duality.Editor
 		/// Determines whether the specified type of wrapped non-<see cref="SerializableAttribute"/> data is available in the data object.
 		/// </summary>
 		/// <param name="data"></param>
-		/// <param name="format"></param>
-		/// <param name="formatType"></param>
-		/// <param name="allowConversion"></param>
+		/// <param name="format">Describes the format of the data. Usually denotes the .Net type of the data.</param>
+		/// <param name="formatType">The format the data is stored in</param>
+		/// <param name="allowConversion">Whether or not to attempt converting data from other formats</param>
 		/// <returns></returns>
 		public static bool GetWrappedDataPresent(this IDataObject data, string format, DataFormat formatType, bool allowConversion = true)
 		{
@@ -90,9 +89,9 @@ namespace Duality.Editor
 		/// Retrieves the specified non-<see cref="SerializableAttribute"/> data from the specified data object using a serializable wrapper.
 		/// </summary>
 		/// <param name="data"></param>
-		/// <param name="elementType"></param>
-		/// <param name="formatType"></param>
-		/// <param name="allowConversion"></param>
+		/// <param name="elementType">The type of elements in the wrapped data array</param>
+		/// <param name="formatType">The format to retrieve the data in</param>
+		/// <param name="allowConversion">Whether or not to attempt converting data from other formats</param>
 		/// <returns></returns>
 		public static object[] GetWrappedData(this IDataObject data, Type elementType, DataFormat formatType, bool allowConversion = true)
 		{
@@ -102,9 +101,9 @@ namespace Duality.Editor
 		/// Retrieves the specified non-<see cref="SerializableAttribute"/> data from the specified data object using a serializable wrapper.
 		/// </summary>
 		/// <param name="data"></param>
-		/// <param name="format"></param>
-		/// <param name="formatType"></param>
-		/// <param name="allowConversion"></param>
+		/// <param name="format">Describes the format of the data. Usually denotes the .Net type of the data.</param>
+		/// <param name="formatType">The format to retrieve the data in</param>
+		/// <param name="allowConversion">Whether or not to attempt converting data from other formats</param>
 		/// <returns></returns>
 		public static object[] GetWrappedData(this IDataObject data, string format, DataFormat formatType, bool allowConversion = true)
 		{

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -113,10 +113,6 @@ namespace Duality.Editor
 			if (cmpType == null) cmpType = typeof(Component);
 			return wrappedData.Any(c => cmpType.IsInstanceOfType(c));
 		}
-		public static Component[] GetComponents(this IDataObject data, DataObjectStorage storage = DataObjectStorage.Reference)
-		{
-			return data.GetComponents(typeof(Component), storage);
-		}
 		public static Component[] GetComponents(this IDataObject data, Type cmpType, DataObjectStorage storage = DataObjectStorage.Reference)
 		{
 			IEnumerable<object> wrappedData = data.GetWrappedData(ComponentFormat, storage);
@@ -124,11 +120,6 @@ namespace Duality.Editor
 
 			if (cmpType == null) cmpType = typeof(Component);
 			return wrappedData.Where(c => cmpType.IsInstanceOfType(c)).OfType<Component>().ToArray();
-		}
-		public static bool TryGetComponents(this IDataObject data, DataObjectStorage storage, out Component[] comps)
-		{
-			comps = data.GetComponents(storage);
-			return comps != null;
 		}
 		public static bool TryGetComponents(this IDataObject data, Type cmpType, DataObjectStorage storage, out Component[] comps)
 		{
@@ -166,13 +157,6 @@ namespace Duality.Editor
 			IContentRef[] contentArr = content.ToArray();
 			if (contentArr.Length > 0) data.SetWrappedData(contentArr, ContentRefFormat, DataObjectStorage.Value);
 		}
-		public static bool ContainsContentRefs<T>(this IDataObject data) where T : Resource
-		{
-			IEnumerable<object> wrappedData;
-			if (!data.TryGetWrappedData(ContentRefFormat, DataObjectStorage.Value, out wrappedData))
-				return false;
-			return wrappedData.OfType<IContentRef>().Any(r => r.Is<T>());
-		}
 		public static bool ContainsContentRefs(this IDataObject data, Type resType = null)
 		{
 			IEnumerable<object> wrappedData;
@@ -181,15 +165,6 @@ namespace Duality.Editor
 
 			if (resType == null) resType = typeof(Resource);
 			return wrappedData.OfType<IContentRef>().Any(r => r.Is(resType));
-		}
-		public static ContentRef<T>[] GetContentRefs<T>(this IDataObject data) where T : Resource
-		{
-			IEnumerable<object> wrappedData;
-			if (!data.TryGetWrappedData(ContentRefFormat, DataObjectStorage.Value, out wrappedData))
-				return null;
-
-			return wrappedData.OfType<IContentRef>()
-				.Where(r => r.Is<T>()).Select(r => r.As<T>()).ToArray();
 		}
 		public static IContentRef[] GetContentRefs(this IDataObject data, Type resType = null)
 		{
@@ -204,11 +179,6 @@ namespace Duality.Editor
 		public static bool TryGetContentRefs(this IDataObject data, Type resType, out IContentRef[] content)
 		{
 			content = data.GetContentRefs(resType);
-			return content != null;
-		}
-		public static bool TryGetContentRefs<T>(this IDataObject data, out ContentRef<T>[] content) where T : Resource
-		{
-			content = data.GetContentRefs<T>();
 			return content != null;
 		}
 

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -35,7 +35,6 @@ namespace Duality.Editor
 	}
 
 	// TODO: document parameters and such
-	// TODO: address the different in that GetGameObjects returns new GameObject[0] on fail while GetComponents returns null. Should have one convention.
 	public static class ExtMethodsDataObject
 	{
 		private const string ReferencePrefix = "SerializableReferenceWrapper:";
@@ -222,11 +221,11 @@ namespace Duality.Editor
 				&& !data.GetWrappedDataPresent(typeof(GameObject[]), DataFormat.Value, false))
 			{
 				GameObject[] refArray = data.GetWrappedData(typeof(GameObject[]), DataFormat.Reference, false) as GameObject[];
-				if (refArray == null) return new GameObject[0];
+				if (refArray == null) return null;
 				return refArray.Select(r => r.DeepClone()).ToArray();
 			}
 
-			return data.GetWrappedData(typeof(GameObject[]), format) as GameObject[] ?? new GameObject[0];
+			return data.GetWrappedData(typeof(GameObject[]), format) as GameObject[];
 		}
 
 		public static void SetContentRefs(this IDataObject data, IEnumerable<IContentRef> content)

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -40,17 +40,16 @@ namespace Duality.Editor
 		/// <param name="data"></param>
 		/// <param name="dataFormat">The format of data to look for</param>
 		/// <param name="storage">Whether to look for stored references or values</param>
-		/// <param name="allowStorageConversion">Whether or not to attempt converting data from other <see cref="DataObjectStorage"/>s</param>
 		/// <returns></returns>
-		public static bool GetWrappedDataPresent(this IDataObject data, string dataFormat, DataObjectStorage storage, bool allowStorageConversion = true)
+		public static bool GetWrappedDataPresent(this IDataObject data, string dataFormat, DataObjectStorage storage)
 		{
 			string prefix = storage == DataObjectStorage.Reference ? ReferencePrefix : ValuePrefix;
 			bool defaultFormatPresent = data.GetDataPresent(prefix + dataFormat);
-			if (defaultFormatPresent || !allowStorageConversion)
+			if (defaultFormatPresent)
 				return defaultFormatPresent;
 
 			// If retrieving by-value failed, try retrieving by-reference and cloning the result
-			if (storage == DataObjectStorage.Value && data.GetWrappedDataPresent(dataFormat, DataObjectStorage.Reference, false))
+			if (storage == DataObjectStorage.Value && data.GetWrappedDataPresent(dataFormat, DataObjectStorage.Reference))
 				return true;
 
 			return false;
@@ -63,16 +62,15 @@ namespace Duality.Editor
 		/// <param name="storage">Whether to look for stored references or values</param>
 		/// <param name="allowStorageConversion">Whether or not to attempt converting data from other <see cref="DataObjectStorage"/>s</param>
 		/// <returns></returns>
-		public static IEnumerable<object> GetWrappedData(this IDataObject data, string dataFormat, DataObjectStorage storage, bool allowStorageConversion = true)
+		public static IEnumerable<object> GetWrappedData(this IDataObject data, string dataFormat, DataObjectStorage storage)
 		{
 			string prefix = storage == DataObjectStorage.Reference ? ReferencePrefix : ValuePrefix;
 			SerializableWrapper wrapper = data.GetData(prefix + dataFormat) as SerializableWrapper;
 			if (wrapper != null) return wrapper.Data;
-			if (!allowStorageConversion) return null;
 
 			// If retrieving by-value failed, try retrieving by-reference and cloning the result
 			IEnumerable<object> converted;
-			if (storage == DataObjectStorage.Value && (converted = data.GetWrappedData(dataFormat, DataObjectStorage.Reference, false)) != null)
+			if (storage == DataObjectStorage.Value && (converted = data.GetWrappedData(dataFormat, DataObjectStorage.Reference)) != null)
 			{
 				return converted.Select(obj => obj.DeepClone());
 			}
@@ -81,16 +79,12 @@ namespace Duality.Editor
 		}
 		public static bool TryGetWrappedData(this IDataObject data, string dataFormat, DataObjectStorage storage, out IEnumerable<object> wrappedData)
 		{
-			return data.TryGetWrappedData(dataFormat, storage, true, out wrappedData);
-		}
-		public static bool TryGetWrappedData(this IDataObject data, string dataFormat, DataObjectStorage storage, bool allowStorageConversion, out IEnumerable<object> wrappedData)
-		{
-			if (!data.GetWrappedDataPresent(dataFormat, storage, allowStorageConversion))
+			if (!data.GetWrappedDataPresent(dataFormat, storage))
 			{
 				wrappedData = null;
 				return false;
 			}
-			wrappedData = data.GetWrappedData(dataFormat, storage, allowStorageConversion);
+			wrappedData = data.GetWrappedData(dataFormat, storage);
 			return wrappedData != null;
 		}
 

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -309,7 +309,8 @@ namespace Duality.Editor
 		}
 		public static BatchInfo[] GetBatchInfos(this IDataObject data)
 		{
-			return (data.GetWrappedData(typeof(BatchInfo), DataFormat.Reference) as BatchInfo[]).Select(b => new BatchInfo(b)).ToArray();
+			object[] batchArray = data.GetWrappedData(typeof(BatchInfo), DataFormat.Reference);
+			return batchArray == null ? null : batchArray.OfType<BatchInfo>().Select(b => new BatchInfo(b)).ToArray();
 		}
 
 		public static void SetIColorData(this IDataObject data, IEnumerable<IColorData> color)

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -41,28 +41,27 @@ namespace Duality.Editor
 		/// <summary>
 		/// Stores the specified non-<see cref="SerializableAttribute"/> data inside the specified data object using a serializable wrapper.
 		/// </summary>
-		/// <param name="elementType">The type of the given IEnumerable elements</param>
 		/// <param name="format">The format to store the data in</param>
-		public static void SetWrappedData(this IDataObject data, IEnumerable<object> values, Type elementType, DataFormat format)
+		public static void SetWrappedData(this IDataObject data, IEnumerable<object> values, DataFormat format)
 		{
 			string prefix = format == DataFormat.Reference ? ReferencePrefix : ValuePrefix;
 			SerializableWrapper wrapper = format == DataFormat.Reference
 				? new SerializableReferenceWrapper(values)
 				: new SerializableWrapper(values);
-			Log.Editor.Write(values.GetType().FullName);
-			data.SetData(prefix + elementType.FullName, wrapper);
+
+			data.SetData(prefix + values.GetType().FullName, wrapper);
 		}
 		/// <summary>
 		/// Determines whether the specified type of wrapped non-<see cref="SerializableAttribute"/> data is available in the data object.
 		/// </summary>
 		/// <param name="data"></param>
-		/// <param name="format">The type of elements in the wrapped data array</param>
+		/// <param name="format">The type of wrapped data to look for</param>
 		/// <param name="formatType">The format the data is stored in</param>
 		/// <param name="allowConversion">Whether or not to attempt converting data from other formats</param>
 		/// <returns></returns>
-		public static bool GetWrappedDataPresent(this IDataObject data, Type elementType, DataFormat format, bool allowConversion = true)
+		public static bool GetWrappedDataPresent(this IDataObject data, Type type, DataFormat format, bool allowConversion = true)
 		{
-			return GetWrappedDataPresent(data, elementType.FullName, format, allowConversion);
+			return GetWrappedDataPresent(data, type.FullName, format, allowConversion);
 		}
 		/// <summary>
 		/// Determines whether the specified type of wrapped non-<see cref="SerializableAttribute"/> data is available in the data object.
@@ -89,13 +88,13 @@ namespace Duality.Editor
 		/// Retrieves the specified non-<see cref="SerializableAttribute"/> data from the specified data object using a serializable wrapper.
 		/// </summary>
 		/// <param name="data"></param>
-		/// <param name="elementType">The type of elements in the wrapped data array</param>
+		/// <param name="type">The type of wrapped data to retrieve</param>
 		/// <param name="formatType">The format to retrieve the data in</param>
 		/// <param name="allowConversion">Whether or not to attempt converting data from other formats</param>
 		/// <returns></returns>
-		public static object[] GetWrappedData(this IDataObject data, Type elementType, DataFormat formatType, bool allowConversion = true)
+		public static object[] GetWrappedData(this IDataObject data, Type type, DataFormat formatType, bool allowConversion = true)
 		{
-			return GetWrappedData(data, elementType.FullName, formatType, allowConversion);
+			return GetWrappedData(data, type.FullName, formatType, allowConversion);
 		}
 		/// <summary>
 		/// Retrieves the specified non-<see cref="SerializableAttribute"/> data from the specified data object using a serializable wrapper.
@@ -139,12 +138,12 @@ namespace Duality.Editor
 		public static void SetComponents(this IDataObject data, IEnumerable<Component> cmp, DataFormat format = DataFormat.Reference)
 		{
 			Component[] cmpArray = cmp.ToArray();
-			if (cmpArray.Length > 0) data.SetWrappedData(cmpArray, typeof(Component), format);
+			if (cmpArray.Length > 0) data.SetWrappedData(cmpArray, format);
 		}
 		public static bool ContainsComponents<T>(this IDataObject data, DataFormat format = DataFormat.Reference) where T : Component
 		{
-			if (!data.GetWrappedDataPresent(typeof(Component), format)) return false;
-			object[] refArray = data.GetWrappedData(typeof(Component), format);
+			if (!data.GetWrappedDataPresent(typeof(Component[]), format)) return false;
+			object[] refArray = data.GetWrappedData(typeof(Component[]), format);
 			return refArray != null && refArray.Any(c => c is T);
 		}
 		public static bool ContainsComponents(this IDataObject data, DataFormat format = DataFormat.Reference)
@@ -153,14 +152,14 @@ namespace Duality.Editor
 		}
 		public static bool ContainsComponents(this IDataObject data, Type cmpType, DataFormat format = DataFormat.Reference)
 		{
-			if (cmpType == null) cmpType = typeof(Component);
-			if (!data.GetWrappedDataPresent(typeof(Component), format)) return false;
-			object[] refArray = data.GetWrappedData(typeof(Component), format);
+			if (cmpType == null) cmpType = typeof(Component[]);
+			if (!data.GetWrappedDataPresent(typeof(Component[]), format)) return false;
+			object[] refArray = data.GetWrappedData(typeof(Component[]), format);
 			return refArray != null && refArray.Any(c => cmpType.IsInstanceOfType(c));
 		}
 		public static T[] GetComponents<T>(this IDataObject data, DataFormat format = DataFormat.Reference) where T : Component
 		{
-			object[] compArray = data.GetWrappedData(typeof(Component), format);
+			object[] compArray = data.GetWrappedData(typeof(Component[]), format);
 			return compArray == null ? null : compArray.OfType<T>().ToArray();
 		}
 		public static Component[] GetComponents(this IDataObject data, DataFormat format = DataFormat.Reference)
@@ -169,9 +168,9 @@ namespace Duality.Editor
 		}
 		public static Component[] GetComponents(this IDataObject data, Type cmpType, DataFormat format = DataFormat.Reference)
 		{
-			if (cmpType == null) cmpType = typeof(Component);
+			if (cmpType == null) cmpType = typeof(Component[]);
 
-			object[] compArray = data.GetWrappedData(typeof(Component), format);
+			object[] compArray = data.GetWrappedData(typeof(Component[]), format);
 			if (compArray == null)
 				return null;
 
@@ -215,15 +214,15 @@ namespace Duality.Editor
 		public static void SetGameObjects(this IDataObject data, IEnumerable<GameObject> obj, DataFormat format = DataFormat.Reference)
 		{
 			GameObject[] objArray = obj.ToArray();
-			if (objArray.Length > 0) data.SetWrappedData(objArray, typeof(GameObject), format);
+			if (objArray.Length > 0) data.SetWrappedData(objArray, format);
 		}
 		public static bool ContainsGameObjects(this IDataObject data, DataFormat format = DataFormat.Reference)
 		{
-			return data.GetWrappedDataPresent(typeof(GameObject), format);
+			return data.GetWrappedDataPresent(typeof(GameObject[]), format);
 		}
 		public static GameObject[] GetGameObjects(this IDataObject data, DataFormat format = DataFormat.Reference)
 		{
-			object[] objects = data.GetWrappedData(typeof(GameObject), format);
+			object[] objects = data.GetWrappedData(typeof(GameObject[]), format);
 			if (objects == null) return null;
 			return objects.OfType<GameObject>().ToArray();
 		}
@@ -251,33 +250,33 @@ namespace Duality.Editor
 		public static void SetContentRefs(this IDataObject data, IEnumerable<IContentRef> content)
 		{
 			if (!content.Any()) return;
-			data.SetWrappedData(content.ToArray(), typeof(IContentRef), DataFormat.Value);
+			data.SetWrappedData(content.ToArray(), DataFormat.Value);
 		}
 		public static bool ContainsContentRefs<T>(this IDataObject data) where T : Resource
 		{
-			if (!data.GetWrappedDataPresent(typeof(IContentRef), DataFormat.Value)) return false;
-			object[] refArray = data.GetWrappedData(typeof(IContentRef), DataFormat.Value);
+			if (!data.GetWrappedDataPresent(typeof(IContentRef[]), DataFormat.Value)) return false;
+			object[] refArray = data.GetWrappedData(typeof(IContentRef[]), DataFormat.Value);
 			return refArray != null && refArray.OfType<IContentRef>().Any(r => r.Is<T>());
 		}
 		public static bool ContainsContentRefs(this IDataObject data, Type resType = null)
 		{
 			if (resType == null) resType = typeof(Resource);
-			if (!data.GetWrappedDataPresent(typeof(IContentRef), DataFormat.Value)) return false;
-			object[] refArray = data.GetWrappedData(typeof(IContentRef), DataFormat.Value);
+			if (!data.GetWrappedDataPresent(typeof(IContentRef[]), DataFormat.Value)) return false;
+			object[] refArray = data.GetWrappedData(typeof(IContentRef[]), DataFormat.Value);
 			return refArray != null && refArray.OfType<IContentRef>().Any(r => r.Is(resType));
 		}
 		public static ContentRef<T>[] GetContentRefs<T>(this IDataObject data) where T : Resource
 		{
-			if (!data.GetWrappedDataPresent(typeof(IContentRef), DataFormat.Value)) return null;
-			object[] refArray = data.GetWrappedData(typeof(IContentRef), DataFormat.Value);
+			if (!data.GetWrappedDataPresent(typeof(IContentRef[]), DataFormat.Value)) return null;
+			object[] refArray = data.GetWrappedData(typeof(IContentRef[]), DataFormat.Value);
 			return refArray == null ? null : refArray.OfType<IContentRef>()
 				.Where(r => r.Is<T>()).Select(r => r.As<T>()).ToArray();
 		}
 		public static IContentRef[] GetContentRefs(this IDataObject data, Type resType = null)
 		{
 			if (resType == null) resType = typeof(Resource);
-			if (!data.GetWrappedDataPresent(typeof(IContentRef), DataFormat.Value)) return null;
-			object[] refArray = data.GetWrappedData(typeof(IContentRef), DataFormat.Value);
+			if (!data.GetWrappedDataPresent(typeof(IContentRef[]), DataFormat.Value)) return null;
+			object[] refArray = data.GetWrappedData(typeof(IContentRef[]), DataFormat.Value);
 			return refArray == null ? null : refArray.OfType<IContentRef>()
 				.Where(r => r.Is(resType)).ToArray();
 		}
@@ -300,15 +299,15 @@ namespace Duality.Editor
 		public static void SetBatchInfos(this IDataObject data, IEnumerable<BatchInfo> obj)
 		{
 			BatchInfo[] objArray = obj.ToArray();
-			if (objArray.Length > 0) data.SetWrappedData(objArray, typeof(BatchInfo), DataFormat.Reference);
+			if (objArray.Length > 0) data.SetWrappedData(objArray, DataFormat.Reference);
 		}
 		public static bool ContainsBatchInfos(this IDataObject data)
 		{
-			return data.GetWrappedDataPresent(typeof(BatchInfo), DataFormat.Reference);
+			return data.GetWrappedDataPresent(typeof(BatchInfo[]), DataFormat.Reference);
 		}
 		public static BatchInfo[] GetBatchInfos(this IDataObject data)
 		{
-			object[] batchArray = data.GetWrappedData(typeof(BatchInfo), DataFormat.Reference);
+			object[] batchArray = data.GetWrappedData(typeof(BatchInfo[]), DataFormat.Reference);
 			return batchArray == null ? null : batchArray.OfType<BatchInfo>().Select(b => new BatchInfo(b)).ToArray();
 		}
 		public static bool TryGetBatchInfos(this IDataObject data, out BatchInfo[] batches)
@@ -326,14 +325,14 @@ namespace Duality.Editor
 		{
 			IColorData[] clrArray = color.ToArray();
 			if (clrArray.Length == 0) return;
-			data.SetWrappedData(clrArray, typeof(IColorData), DataFormat.Value);
+			data.SetWrappedData(clrArray, DataFormat.Value);
 
 			var rgbaQuery = clrArray.Select(c => c.ConvertTo<ColorRgba>());
 			data.SetString(rgbaQuery.ToString(c => string.Format("{0},{1},{2},{3}", c.R, c.G, c.B, c.A), ", "));
 		}
 		public static bool ContainsIColorData(this IDataObject data)
 		{
-			if (data.GetWrappedDataPresent(typeof(IColorData), DataFormat.Value))
+			if (data.GetWrappedDataPresent(typeof(IColorData[]), DataFormat.Value))
 				return true;
 
 			if (data.ContainsString())
@@ -348,9 +347,9 @@ namespace Duality.Editor
 		public static T[] GetIColorData<T>(this IDataObject data) where T : IColorData
 		{
 			IColorData[] clrArray = null;
-			if (data.GetWrappedDataPresent(typeof(IColorData), DataFormat.Value))
+			if (data.GetWrappedDataPresent(typeof(IColorData[]), DataFormat.Value))
 			{
-				object[] wrappedArr = data.GetWrappedData(typeof(IColorData), DataFormat.Value);
+				object[] wrappedArr = data.GetWrappedData(typeof(IColorData[]), DataFormat.Value);
 				if (wrappedArr != null)
 				{
 					clrArray = wrappedArr.OfType<IColorData>().ToArray();

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -130,6 +130,34 @@ namespace Duality.Editor
 
 			return null;
 		}
+		public static bool TryGetWrappedData(this IDataObject data, Type type, DataFormat formatType, out object[] wrappedData)
+		{
+			return data.TryGetWrappedData(type, formatType, true, out wrappedData);
+		}
+		public static bool TryGetWrappedData(this IDataObject data, Type type, DataFormat formatType, bool allowConversion, out object[] wrappedData)
+		{
+			if (!data.GetWrappedDataPresent(type, formatType, allowConversion))
+			{
+				wrappedData = null;
+				return false;
+			}
+			wrappedData = data.GetWrappedData(type, formatType, allowConversion);
+			return true;
+		}
+		public static bool TryGetWrappedData(this IDataObject data, string format, DataFormat formatType, out object[] wrappedData)
+		{
+			return data.TryGetWrappedData(format, formatType, true, out wrappedData);
+		}
+		public static bool TryGetWrappedData(this IDataObject data, string format, DataFormat formatType, bool allowConversion, out object[] wrappedData)
+		{
+			if (!data.GetWrappedDataPresent(format, formatType, allowConversion))
+			{
+				wrappedData = null;
+				return false;
+			}
+			wrappedData = data.GetWrappedData(format, formatType, allowConversion);
+			return true;
+		}
 
 		public static void SetAllowedConvertOp(this IDataObject data, ConvertOperation.Operation allowedOp)
 		{
@@ -150,8 +178,8 @@ namespace Duality.Editor
 		}
 		public static bool ContainsComponents<T>(this IDataObject data, DataFormat format = DataFormat.Reference) where T : Component
 		{
-			if (!data.GetWrappedDataPresent(typeof(Component[]), format)) return false;
-			object[] refArray = data.GetWrappedData(typeof(Component[]), format);
+			object[] refArray;
+			if (!data.TryGetWrappedData(typeof(Component[]), format, out refArray)) return false;
 			return refArray != null && refArray.Any(c => c is T);
 		}
 		public static bool ContainsComponents(this IDataObject data, DataFormat format = DataFormat.Reference)
@@ -160,9 +188,9 @@ namespace Duality.Editor
 		}
 		public static bool ContainsComponents(this IDataObject data, Type cmpType, DataFormat format = DataFormat.Reference)
 		{
-			if (cmpType == null) cmpType = typeof(Component[]);
-			if (!data.GetWrappedDataPresent(typeof(Component[]), format)) return false;
-			object[] refArray = data.GetWrappedData(typeof(Component[]), format);
+			if (cmpType == null) cmpType = typeof(Component);
+			object[] refArray;
+			if (!data.TryGetWrappedData(typeof(Component[]), format, out refArray)) return false;
 			return refArray != null && refArray.Any(c => cmpType.IsInstanceOfType(c));
 		}
 		public static T[] GetComponents<T>(this IDataObject data, DataFormat format = DataFormat.Reference) where T : Component

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -37,17 +37,15 @@ namespace Duality.Editor
 		/// <summary>
 		/// Determines whether the specified format of wrapped non-<see cref="SerializableAttribute"/> data is available in the data object.
 		/// </summary>
-		/// <param name="data"></param>
 		/// <param name="dataFormat">The format of data to look for</param>
 		/// <param name="storage">Whether to look for stored references or values</param>
-		/// <returns></returns>
 		public static bool GetWrappedDataPresent(this IDataObject data, string dataFormat, DataObjectStorage storage)
 		{
 			string prefix = storage == DataObjectStorage.Reference ? ReferencePrefix : ValuePrefix;
 			bool defaultFormatPresent = data.GetDataPresent(prefix + dataFormat);
 			if (defaultFormatPresent) return true;
 
-			// If retrieving by-value failed, try retrieving by-reference and cloning the result
+			// If retrieving by-value failed, try retrieving a reference which can be cloned later
 			if (storage == DataObjectStorage.Value && data.GetWrappedDataPresent(dataFormat, DataObjectStorage.Reference))
 				return true;
 
@@ -56,11 +54,8 @@ namespace Duality.Editor
 		/// <summary>
 		/// Retrieves the specified non-<see cref="SerializableAttribute"/> data from the specified data object using a serializable wrapper.
 		/// </summary>
-		/// <param name="data"></param>
 		/// <param name="dataFormat">The format of the data being retrieved</param>
 		/// <param name="storage">Whether to look for stored references or values</param>
-		/// <param name="allowStorageConversion">Whether or not to attempt converting data from other <see cref="DataObjectStorage"/>s</param>
-		/// <returns></returns>
 		public static IEnumerable<object> GetWrappedData(this IDataObject data, string dataFormat, DataObjectStorage storage)
 		{
 			string prefix = storage == DataObjectStorage.Reference ? ReferencePrefix : ValuePrefix;

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -231,11 +231,21 @@ namespace Duality.Editor
 		}
 		public static bool TryGetGameObjects(this IDataObject data, out GameObject[] objects)
 		{
+			if (!data.ContainsGameObjects())
+			{
+				objects = null;
+				return false;
+			}
 			objects = data.GetGameObjects();
 			return objects != null;
 		}
 		public static bool TryGetGameObjects(this IDataObject data, DataFormat format, out GameObject[] objects)
 		{
+			if (!data.ContainsGameObjects(format))
+			{
+				objects = null;
+				return false;
+			}
 			objects = data.GetGameObjects(format);
 			return objects != null;
 		}

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -171,9 +171,10 @@ namespace Duality.Editor
 				return refArray.OfType<T>().Select(r => r.DeepClone()).ToArray();
 			}
 
-			// TODO: can this be removed?
-			if (!data.GetWrappedDataPresent(typeof(Component[]), format)) return null;
-			Component[] compArray = data.GetWrappedData(typeof(Component[]), format) as Component[] ?? new Component[0];
+			Component[] compArray = data.GetWrappedData(typeof(Component[]), format) as Component[];
+			if (compArray == null)
+				return null;
+
 			return compArray.OfType<T>().ToArray();
 		}
 		public static Component[] GetComponents(this IDataObject data, DataFormat format = DataFormat.Reference)
@@ -194,9 +195,10 @@ namespace Duality.Editor
 				return refArray.Select(r => r.DeepClone()).ToArray();
 			}
 
-			// TODO: can this be removed?
-			if (!data.GetWrappedDataPresent(typeof(Component[]), format)) return null;
-			Component[] compArray = data.GetWrappedData(typeof(Component[]), format) as Component[] ?? new Component[0];
+			Component[] compArray = data.GetWrappedData(typeof(Component[]), format) as Component[];
+			if (compArray == null)
+				return null;
+
 			return (
 				from c in compArray
 				where cmpType.IsInstanceOfType(c)

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -189,7 +189,9 @@ namespace Duality.Editor
 		public static bool ContainsComponents(this IDataObject data, Type cmpType, DataFormat format = DataFormat.Reference)
 		{
 			object[] refArray;
-			if (!data.TryGetWrappedData(typeof(Component[]), format, out refArray)) return false;
+			if (!data.TryGetWrappedData(typeof(Component[]), format, out refArray))
+				return false;
+
 			if (cmpType == null) cmpType = typeof(Component);
 			return refArray.Any(c => cmpType.IsInstanceOfType(c));
 		}
@@ -204,17 +206,11 @@ namespace Duality.Editor
 		}
 		public static Component[] GetComponents(this IDataObject data, Type cmpType, DataFormat format = DataFormat.Reference)
 		{
-			if (cmpType == null) cmpType = typeof(Component[]);
-
 			object[] compArray = data.GetWrappedData(typeof(Component[]), format);
-			if (compArray == null)
-				return null;
+			if (compArray == null) return null;
 
-			return (
-				from c in compArray
-				where cmpType.IsInstanceOfType(c)
-				select c as Component
-				).ToArray();
+			if (cmpType == null) cmpType = typeof(Component[]);
+			return compArray.Where(c => cmpType.IsInstanceOfType(c)).OfType<Component>().ToArray();
 		}
 		public static bool TryGetComponents<T>(this IDataObject data, out T[] comps) where T : Component
 		{
@@ -308,6 +304,7 @@ namespace Duality.Editor
 			object[] refArray;
 			if (!data.TryGetWrappedData(typeof(IContentRef[]), DataFormat.Value, out refArray))
 				return null;
+
 			return refArray.OfType<IContentRef>()
 				.Where(r => r.Is<T>()).Select(r => r.As<T>()).ToArray();
 		}
@@ -319,7 +316,7 @@ namespace Duality.Editor
 
 			if (resType == null) resType = typeof(Resource);
 			return refArray.OfType<IContentRef>()
-				.Where(r => r.Is(resType)).ToArray().ToArray();
+				.Where(r => r.Is(resType)).ToArray();
 		}
 		public static bool TryGetContentRefs(this IDataObject data, out IContentRef[] content)
 		{
@@ -390,13 +387,9 @@ namespace Duality.Editor
 			IColorData[] clrArray = null;
 			object[] wrappedArr;
 			if (data.TryGetWrappedData(typeof(IColorData[]), DataFormat.Value, out wrappedArr))
-			{
 				clrArray = wrappedArr.OfType<IColorData>().ToArray();
-			}
 			else if (data.ContainsString())
-			{
 				clrArray = ParseIColorData(data.GetString());
-			}
 
 			if (clrArray != null)
 			{

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -250,23 +250,9 @@ namespace Duality.Editor
 
 			if (data.ContainsString())
 			{
-				string valString = data.GetString();
-				string[] token = valString.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-				byte[] valToken = new byte[4];
-				valToken[3] = 255;
-
-				bool success = true;
-				for (int i = 0; i < token.Length; i++)
-				{
-					token[i] = token[i].Trim();
-					if (!byte.TryParse(token[i], out valToken[i]))
-					{
-						success = false;
-						break;
-					}
-				}
-
-				if (success) return true;
+				IColorData[] clrArray;
+				if (TryParseIColorData(data.GetString(), out clrArray))
+					return true;
 			}
 
 			return false;
@@ -280,23 +266,7 @@ namespace Duality.Editor
 			}
 			else if (data.ContainsString())
 			{
-				string valString = data.GetString();
-				string[] token = valString.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-				byte[] valToken = new byte[4];
-				valToken[3] = 255;
-
-				bool success = true;
-				for (int i = 0; i < token.Length; i++)
-				{
-					token[i] = token[i].Trim();
-					if (!byte.TryParse(token[i], out valToken[i]))
-					{
-						success = false;
-						break;
-					}
-				}
-
-				if (success) clrArray = new IColorData[] { new ColorRgba(valToken[0], valToken[1], valToken[2], valToken[3]) };
+				clrArray = ParseIColorData(data.GetString());
 			}
 
 			if (clrArray != null)
@@ -346,6 +316,29 @@ namespace Duality.Editor
 				}
 			}
 			if (sc.Count > 0) data.SetFileDropList(sc);
+		}
+
+		private static bool TryParseIColorData(string valString, out IColorData[] colorArray)
+		{
+			colorArray = ParseIColorData(valString);
+			return colorArray != null;
+		}
+		private static IColorData[] ParseIColorData(string valString)
+		{
+			string[] token = valString.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+			byte[] valToken = new byte[4];
+			valToken[3] = 255;
+
+			for (int i = 0; i < token.Length; i++)
+			{
+				token[i] = token[i].Trim();
+				if (!byte.TryParse(token[i], out valToken[i]))
+				{
+					return null;
+				}
+			}
+
+			return new IColorData[] { new ColorRgba(valToken[0], valToken[1], valToken[2], valToken[3]) };
 		}
 	}
 }

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -105,16 +105,6 @@ namespace Duality.Editor
 			Component[] cmpArray = cmp.ToArray();
 			if (cmpArray.Length > 0) data.SetWrappedData(cmpArray, ComponentFormat, storage);
 		}
-		public static bool ContainsComponents<T>(this IDataObject data, DataObjectStorage storage = DataObjectStorage.Reference) where T : Component
-		{
-			IEnumerable<object> wrappedData;
-			if (!data.TryGetWrappedData(ComponentFormat, storage, out wrappedData)) return false;
-			return wrappedData.Any(c => c is T);
-		}
-		public static bool ContainsComponents(this IDataObject data, DataObjectStorage storage = DataObjectStorage.Reference)
-		{
-			return data.ContainsComponents(typeof(Component), storage);
-		}
 		public static bool ContainsComponents(this IDataObject data, Type cmpType, DataObjectStorage storage = DataObjectStorage.Reference)
 		{
 			IEnumerable<object> wrappedData;
@@ -123,11 +113,6 @@ namespace Duality.Editor
 
 			if (cmpType == null) cmpType = typeof(Component);
 			return wrappedData.Any(c => cmpType.IsInstanceOfType(c));
-		}
-		public static T[] GetComponents<T>(this IDataObject data, DataObjectStorage storage = DataObjectStorage.Reference) where T : Component
-		{
-			IEnumerable<object> wrappedData = data.GetWrappedData(ComponentFormat, storage);
-			return wrappedData == null ? null : wrappedData.OfType<T>().ToArray();
 		}
 		public static Component[] GetComponents(this IDataObject data, DataObjectStorage storage = DataObjectStorage.Reference)
 		{
@@ -141,29 +126,9 @@ namespace Duality.Editor
 			if (cmpType == null) cmpType = typeof(Component);
 			return wrappedData.Where(c => cmpType.IsInstanceOfType(c)).OfType<Component>().ToArray();
 		}
-		public static bool TryGetComponents<T>(this IDataObject data, out T[] comps) where T : Component
-		{
-			comps = data.GetComponents<T>();
-			return comps != null;
-		}
-		public static bool TryGetComponents<T>(this IDataObject data, DataObjectStorage storage, out T[] comps) where T : Component
-		{
-			comps = data.GetComponents<T>(storage);
-			return comps != null;
-		}
-		public static bool TryGetComponents(this IDataObject data, out Component[] comps)
-		{
-			comps = data.GetComponents();
-			return comps != null;
-		}
 		public static bool TryGetComponents(this IDataObject data, DataObjectStorage storage, out Component[] comps)
 		{
 			comps = data.GetComponents(storage);
-			return comps != null;
-		}
-		public static bool TryGetComponents(this IDataObject data, Type cmpType, out Component[] comps)
-		{
-			comps = data.GetComponents(cmpType);
 			return comps != null;
 		}
 		public static bool TryGetComponents(this IDataObject data, Type cmpType, DataObjectStorage storage, out Component[] comps)
@@ -185,16 +150,6 @@ namespace Duality.Editor
 		{
 			IEnumerable<object> wrappedData = data.GetWrappedData(GameObjectFormat, storage);
 			return wrappedData == null ? null : wrappedData.OfType<GameObject>().ToArray();
-		}
-		public static bool TryGetGameObjects(this IDataObject data, out GameObject[] objects)
-		{
-			if (!data.ContainsGameObjects())
-			{
-				objects = null;
-				return false;
-			}
-			objects = data.GetGameObjects();
-			return objects != null;
 		}
 		public static bool TryGetGameObjects(this IDataObject data, DataObjectStorage storage, out GameObject[] objects)
 		{
@@ -246,11 +201,6 @@ namespace Duality.Editor
 			if (resType == null) resType = typeof(Resource);
 			return wrappedData.OfType<IContentRef>()
 				.Where(r => r.Is(resType)).ToArray();
-		}
-		public static bool TryGetContentRefs(this IDataObject data, out IContentRef[] content)
-		{
-			content = data.GetContentRefs();
-			return content != null;
 		}
 		public static bool TryGetContentRefs(this IDataObject data, Type resType, out IContentRef[] content)
 		{

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -167,15 +167,11 @@ namespace Duality.Editor
 				&& !data.GetWrappedDataPresent(typeof(Component[]), DataFormat.Value, false))
 			{
 				Component[] refArray = data.GetWrappedData(typeof(Component[]), DataFormat.Reference, false) as Component[];
-				if (refArray == null) return new T[0];
-				return refArray.OfType<T>().Select(r => r.DeepClone()).ToArray();
+				return refArray == null ? null : refArray.OfType<T>().Select(r => r.DeepClone()).ToArray();
 			}
 
 			Component[] compArray = data.GetWrappedData(typeof(Component[]), format) as Component[];
-			if (compArray == null)
-				return null;
-
-			return compArray.OfType<T>().ToArray();
+			return compArray == null ? null : compArray.OfType<T>().ToArray();
 		}
 		public static Component[] GetComponents(this IDataObject data, DataFormat format = DataFormat.Reference)
 		{
@@ -191,8 +187,7 @@ namespace Duality.Editor
 				&& !data.GetWrappedDataPresent(typeof(Component[]), DataFormat.Value, false))
 			{
 				Component[] refArray = data.GetWrappedData(typeof(Component[]), DataFormat.Reference, false) as Component[];
-				if (refArray == null) return new Component[0];
-				return refArray.Select(r => r.DeepClone()).ToArray();
+				return refArray == null ? null : refArray.Select(r => r.DeepClone()).ToArray();
 			}
 
 			Component[] compArray = data.GetWrappedData(typeof(Component[]), format) as Component[];
@@ -223,8 +218,7 @@ namespace Duality.Editor
 				&& !data.GetWrappedDataPresent(typeof(GameObject[]), DataFormat.Value, false))
 			{
 				GameObject[] refArray = data.GetWrappedData(typeof(GameObject[]), DataFormat.Reference, false) as GameObject[];
-				if (refArray == null) return null;
-				return refArray.Select(r => r.DeepClone()).ToArray();
+				return refArray == null ? null : refArray.Select(r => r.DeepClone()).ToArray();
 			}
 
 			return data.GetWrappedData(typeof(GameObject[]), format) as GameObject[];

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Windows.Forms;
 using System.IO;
@@ -299,7 +300,7 @@ namespace Duality.Editor
 			if (clrArray.Length == 0) return;
 			data.SetWrappedData(clrArray, ColorDataFormat, DataObjectStorage.Value);
 
-			var rgbaQuery = clrArray.Select(c => c.ConvertTo<ColorRgba>());
+			IEnumerable<ColorRgba> rgbaQuery = clrArray.Select(c => c.ConvertTo<ColorRgba>());
 			data.SetString(rgbaQuery.ToString(c => string.Format("{0},{1},{2},{3}", c.R, c.G, c.B, c.A), ", "));
 		}
 		public static bool ContainsIColorData(this IDataObject data)
@@ -372,7 +373,7 @@ namespace Duality.Editor
 
 		public static void SetFiles(this DataObject data, IEnumerable<string> files)
 		{
-			var sc = new System.Collections.Specialized.StringCollection();
+			StringCollection sc = new StringCollection();
 			foreach (string file in files)
 			{
 				string path = Path.GetFullPath(file);

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -200,6 +200,36 @@ namespace Duality.Editor
 				select c
 				).ToArray();
 		}
+		public static bool TryGetComponents<T>(this IDataObject data, out T[] comps) where T : Component
+		{
+			comps = data.GetComponents<T>();
+			return comps != null;
+		}
+		public static bool TryGetComponents<T>(this IDataObject data, DataFormat format, out T[] comps) where T : Component
+		{
+			comps = data.GetComponents<T>(format);
+			return comps != null;
+		}
+		public static bool TryGetComponents(this IDataObject data, out Component[] comps)
+		{
+			comps = data.GetComponents();
+			return comps != null;
+		}
+		public static bool TryGetComponents(this IDataObject data, DataFormat format, out Component[] comps)
+		{
+			comps = data.GetComponents(format);
+			return comps != null;
+		}
+		public static bool TryGetComponents(this IDataObject data, Type cmpType, out Component[] comps)
+		{
+			comps = data.GetComponents(cmpType);
+			return comps != null;
+		}
+		public static bool TryGetComponents(this IDataObject data, Type cmpType, DataFormat format, out Component[] comps)
+		{
+			comps = data.GetComponents(cmpType, format);
+			return comps != null;
+		}
 
 		public static void SetGameObjects(this IDataObject data, IEnumerable<GameObject> obj, DataFormat format = DataFormat.Reference)
 		{
@@ -222,6 +252,16 @@ namespace Duality.Editor
 			}
 
 			return data.GetWrappedData(typeof(GameObject[]), format) as GameObject[];
+		}
+		public static bool TryGetGameObjects(this IDataObject data, out GameObject[] objects)
+		{
+			objects = data.GetGameObjects();
+			return objects != null;
+		}
+		public static bool TryGetGameObjects(this IDataObject data, DataFormat format, out GameObject[] objects)
+		{
+			objects = data.GetGameObjects(format);
+			return objects != null;
 		}
 
 		public static void SetContentRefs(this IDataObject data, IEnumerable<IContentRef> content)

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -42,6 +42,14 @@ namespace Duality.Editor
 		/// Stores the specified non-<see cref="SerializableAttribute"/> data inside the specified data object using a serializable wrapper.
 		/// </summary>
 		/// <param name="format">The format to store the data in</param>
+		/// <remarks>
+		/// Note that the type of the passed in values object must match exactly the type that is then passed to 
+		/// <see cref="GetWrappedDataPresent(IDataObject,Type,DataFormat,bool)"/>
+		/// or
+		/// <see cref="GetWrappedData(IDataObject,Type,DataFormat,bool)"/>.
+		/// For example, if you pass the result of a LINQ query of type IEnumerable<Component>
+		/// and then call GetWrappedData with 'typeof(Component[])' it will fail.
+		/// </remarks>
 		public static void SetWrappedData(this IDataObject data, IEnumerable<object> values, DataFormat format)
 		{
 			string prefix = format == DataFormat.Reference ? ReferencePrefix : ValuePrefix;

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -233,13 +233,14 @@ namespace Duality.Editor
 
 		public static void SetIColorData(this IDataObject data, IEnumerable<IColorData> color)
 		{
-			if (!color.Any()) return;
-			data.SetWrappedData(color.ToArray(), DataFormat.Value);
+			IColorData[] clrArray = color.ToArray();
+			if (clrArray.Length == 0) return;
+			data.SetWrappedData(clrArray, DataFormat.Value);
 
 			DataObject dataObj = data as DataObject;
 			if (dataObj != null)
 			{
-				var rgbaQuery = color.Select(c => c.ConvertTo<ColorRgba>());
+				var rgbaQuery = clrArray.Select(c => c.ConvertTo<ColorRgba>());
 				dataObj.SetText(rgbaQuery.ToString(c => string.Format("{0},{1},{2},{3}", c.R, c.G, c.B, c.A), ", "));
 			}
 		}

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 using System.IO;
-
 using Duality;
 using Duality.Cloning;
 using Duality.Drawing;
@@ -258,38 +257,47 @@ namespace Duality.Editor
 		public static bool ContainsContentRefs<T>(this IDataObject data) where T : Resource
 		{
 			if (!data.GetWrappedDataPresent(typeof(IContentRef), DataFormat.Value)) return false;
-			IContentRef[] refArray = data.GetWrappedData(typeof(IContentRef), DataFormat.Value) as IContentRef[];
-			return refArray != null && refArray.Any(r => r.Is<T>());
+			object[] refArray = data.GetWrappedData(typeof(IContentRef), DataFormat.Value);
+			return refArray != null && refArray.OfType<IContentRef>().Any(r => r.Is<T>());
 		}
 		public static bool ContainsContentRefs(this IDataObject data, Type resType = null)
 		{
 			if (resType == null) resType = typeof(Resource);
 			if (!data.GetWrappedDataPresent(typeof(IContentRef), DataFormat.Value)) return false;
-			IContentRef[] refArray = data.GetWrappedData(typeof(IContentRef), DataFormat.Value) as IContentRef[];
-			return refArray != null && refArray.Any(r => r.Is(resType));
+			object[] refArray = data.GetWrappedData(typeof(IContentRef), DataFormat.Value);
+			return refArray != null && refArray.OfType<IContentRef>().Any(r => r.Is(resType));
 		}
 		public static ContentRef<T>[] GetContentRefs<T>(this IDataObject data) where T : Resource
 		{
 			if (!data.GetWrappedDataPresent(typeof(IContentRef), DataFormat.Value)) return null;
-			IContentRef[] refArray = data.GetWrappedData(typeof(IContentRef), DataFormat.Value) as IContentRef[] ?? new IContentRef[0];
-			return (
-				from r in refArray
-				where r.Is<T>()
-				select r.As<T>()
-				).ToArray();
+			object[] refArray = data.GetWrappedData(typeof(IContentRef), DataFormat.Value);
+			return refArray == null ? null : refArray.OfType<IContentRef>()
+				.Where(r => r.Is<T>()).Select(r => r.As<T>()).ToArray();
 		}
 		public static IContentRef[] GetContentRefs(this IDataObject data, Type resType = null)
 		{
 			if (resType == null) resType = typeof(Resource);
 			if (!data.GetWrappedDataPresent(typeof(IContentRef), DataFormat.Value)) return null;
-			IContentRef[] refArray = data.GetWrappedData(typeof(IContentRef), DataFormat.Value) as IContentRef[] ?? new IContentRef[0];
-			return (
-				from r in refArray
-				where r.Is(resType)
-				select r
-				).ToArray();
+			object[] refArray = data.GetWrappedData(typeof(IContentRef), DataFormat.Value);
+			return refArray == null ? null : refArray.OfType<IContentRef>()
+				.Where(r => r.Is(resType)).ToArray();
 		}
-		
+		public static bool TryGetContentRefs(this IDataObject data, out IContentRef[] content)
+		{
+			content = data.GetContentRefs();
+			return content != null;
+		}
+		public static bool TryGetContentRefs(this IDataObject data, Type resType, out IContentRef[] content)
+		{
+			content = data.GetContentRefs(resType);
+			return content != null;
+		}
+		public static bool TryGetContentRefs<T>(this IDataObject data, out ContentRef<T>[] content) where T : Resource
+		{
+			content = data.GetContentRefs<T>();
+			return content != null;
+		}
+
 		public static void SetBatchInfos(this IDataObject data, IEnumerable<BatchInfo> obj)
 		{
 			BatchInfo[] objArray = obj.ToArray();

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -63,13 +63,13 @@ namespace Duality.Editor
 		/// Determines whether the specified type of wrapped non-<see cref="SerializableAttribute"/> data is available in the data object.
 		/// </summary>
 		/// <param name="data"></param>
-		/// <param name="format">The type of wrapped data to look for</param>
+		/// <param name="type">The type of wrapped data to look for</param>
 		/// <param name="formatType">The format the data is stored in</param>
 		/// <param name="allowConversion">Whether or not to attempt converting data from other formats</param>
 		/// <returns></returns>
-		public static bool GetWrappedDataPresent(this IDataObject data, Type type, DataFormat format, bool allowConversion = true)
+		public static bool GetWrappedDataPresent(this IDataObject data, Type type, DataFormat formatType, bool allowConversion = true)
 		{
-			return GetWrappedDataPresent(data, type.FullName, format, allowConversion);
+			return GetWrappedDataPresent(data, type.FullName, formatType, allowConversion);
 		}
 		/// <summary>
 		/// Determines whether the specified type of wrapped non-<see cref="SerializableAttribute"/> data is available in the data object.

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -325,5 +325,144 @@ namespace Duality.Editor
 
 			return new IColorData[] { new ColorRgba(valToken[0], valToken[1], valToken[2], valToken[3]) };
 		}
+
+
+		#region Obsolete API
+
+		/// <summary>
+		/// Stores the specified non-<see cref="SerializableAttribute"/> data inside the specified data object using a serializable wrapper.
+		/// </summary>
+		/// <param name="data"></param>
+		/// <param name="value"></param>
+		/// <param name="byReference">Whether or not to store the value as a reference or to perform a clone of the value</param>
+		[Obsolete("Obselete and will be removed in v3.0. Please use SetWrappedData(IEnumerable<object>, string, DataObjectStorage) instead.")]
+		public static void SetWrappedData(this IDataObject data, object value, bool byReference = false)
+		{
+			data.SetWrappedData(new []{value}, value.GetType().FullName, byReference ? DataObjectStorage.Reference : DataObjectStorage.Value);
+		}
+		/// <summary>
+		/// Determines whether the specified type of wrapped non-<see cref="SerializableAttribute"/> data is available in the data object.
+		/// </summary>
+		/// <param name="data"></param>
+		/// <param name="format"></param>
+		/// <returns></returns>
+		[Obsolete("Obselete and will be removed in v3.0. Please use GetWrappedDataPresent(string, DataObjectStorage) instead.")]
+		public static bool GetWrappedDataPresent(this IDataObject data, Type format)
+		{
+			return data.GetWrappedDataPresent(format.FullName, DataObjectStorage.Reference);
+		}
+		/// <summary>
+		/// Determines whether the specified type of wrapped non-<see cref="SerializableAttribute"/> data is available in the data object.
+		/// </summary>
+		/// <param name="data"></param>
+		/// <param name="format"></param>
+		/// <returns></returns>
+		[Obsolete("Obselete and will be removed in v3.0. Please use GetWrappedDataPresent(string, DataObjectStorage) instead.")]
+		public static bool GetWrappedDataPresent(this IDataObject data, string format)
+		{
+			return data.GetWrappedDataPresent(format, DataObjectStorage.Reference);
+		}
+		/// <summary>
+		/// Retrieves the specified non-<see cref="SerializableAttribute"/> data from the specified data object using a serializable wrapper.
+		/// </summary>
+		/// <param name="data"></param>
+		/// <param name="format"></param>
+		/// <returns></returns>
+		[Obsolete("Obselete and will be removed in v3.0. Please use GetWrappedData(string, DataObjectStorage) instead.")]
+		public static object GetWrappedData(this IDataObject data, Type format)
+		{
+			return data.GetWrappedData(format.FullName, DataObjectStorage.Reference).First();
+		}
+		/// <summary>
+		/// Retrieves the specified non-<see cref="SerializableAttribute"/> data from the specified data object using a serializable wrapper.
+		/// </summary>
+		/// <param name="data"></param>
+		/// <param name="format"></param>
+		/// <returns></returns>
+		[Obsolete("Obselete and will be removed in v3.0. Please use GetWrappedData(string, DataObjectStorage) instead.")]
+		public static object GetWrappedData(this IDataObject data, string format)
+		{
+			return data.GetWrappedData(format, DataObjectStorage.Reference).First();
+		}
+		[Obsolete("Obselete and will be removed in v3.0. Please use SetComponents(IEnumerable<Component>, DataObjectStorage) instead.")]
+		public static void SetComponentRefs(this IDataObject data, IEnumerable<Component> cmp)
+		{
+			Component[] cmpArray = cmp.ToArray();
+			if (cmpArray.Length > 0) data.SetWrappedData(cmpArray, true);
+		}
+		[Obsolete("Obselete and will be removed in v3.0. Please use ContainsComponents(Type, DataObjectStorage) instead.")]
+		public static bool ContainsComponentRefs<T>(this IDataObject data) where T : Component
+		{
+			if (!data.GetWrappedDataPresent(typeof(Component[]))) return false;
+			Component[] refArray = data.GetWrappedData(typeof(Component[])) as Component[];
+			return refArray != null && refArray.Any(c => c is T);
+		}
+		[Obsolete("Obselete and will be removed in v3.0. Please use ContainsComponents(Type, DataObjectStorage) instead.")]
+		public static bool ContainsComponentRefs(this IDataObject data, Type cmpType = null)
+		{
+			if (cmpType == null) cmpType = typeof(Component);
+			if (!data.GetWrappedDataPresent(typeof(Component[]))) return false;
+			Component[] refArray = data.GetWrappedData(typeof(Component[])) as Component[];
+			return refArray != null && refArray.Any(c => cmpType.IsInstanceOfType(c));
+		}
+		[Obsolete("Obselete and will be removed in v3.0. Please use GetComponents(Type, DataObjectStorage) instead.")]
+		public static T[] GetComponentRefs<T>(this IDataObject data) where T : Component
+		{
+			if (!data.GetWrappedDataPresent(typeof(Component[]))) return null;
+			Component[] refArray = data.GetWrappedData(typeof(Component[])) as Component[] ?? new Component[0];
+			return (
+				from r in refArray
+				where r is T
+				select r as T
+			).ToArray();
+		}
+		[Obsolete("Obselete and will be removed in v3.0. Please use GetComponents(Type, DataObjectStorage) instead.")]
+		public static Component[] GetComponentRefs(this IDataObject data, Type cmpType = null)
+		{
+			if (cmpType == null) cmpType = typeof(Component);
+			if (!data.GetWrappedDataPresent(typeof(Component[]))) return null;
+			Component[] refArray = data.GetWrappedData(typeof(Component[])) as Component[] ?? new Component[0];
+			return (
+				from c in refArray
+				where cmpType.IsInstanceOfType(c)
+				select c
+			).ToArray();
+		}
+		[Obsolete("Obselete and will be removed in v3.0. Please use SetGameObjects(IEnumerable<GameObject>, DataObjectStorage) instead.")]
+		public static void SetGameObjectRefs(this IDataObject data, IEnumerable<GameObject> obj)
+		{
+			GameObject[] objArray = obj.ToArray();
+			if (objArray.Length > 0) data.SetWrappedData(objArray, true);
+		}
+		[Obsolete("Obselete and will be removed in v3.0. Please use ContainsGameObjects(DataObjectStorage) instead.")]
+		public static bool ContainsGameObjectRefs(this IDataObject data)
+		{
+			return data.GetWrappedDataPresent(typeof(GameObject[]));
+		}
+		[Obsolete("Obselete and will be removed in v3.0. Please use GetGameObjects(DataObjectStorage) instead.")]
+		public static GameObject[] GetGameObjectRefs(this IDataObject data)
+		{
+			return data.GetWrappedData(typeof(GameObject[])) as GameObject[] ?? new GameObject[0];
+		}
+		[Obsolete("Obselete and will be removed in v3.0. Please use CotnainsContentRefs(Type) instead.")]
+		public static bool ContainsContentRefs<T>(this IDataObject data) where T : Resource
+		{
+			if (!data.GetWrappedDataPresent(typeof(IContentRef[]))) return false;
+			IContentRef[] refArray = data.GetWrappedData(typeof(IContentRef[])) as IContentRef[];
+			return refArray != null && refArray.Any(r => r.Is<T>());
+		}
+		[Obsolete("Obselete and will be removed in v3.0. Please use GetContentRefs(Type) instead.")]
+		public static ContentRef<T>[] GetContentRefs<T>(this IDataObject data) where T : Resource
+		{
+			if (!data.GetWrappedDataPresent(typeof(IContentRef[]))) return null;
+			IContentRef[] refArray = data.GetWrappedData(typeof(IContentRef[])) as IContentRef[] ?? new IContentRef[0];
+			return (
+				from r in refArray
+				where r.Is<T>()
+				select r.As<T>()
+			).ToArray();
+		}
+
+		#endregion
 	}
 }

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -14,11 +14,11 @@ namespace Duality.Editor
 		private const string ReferencePrefix = "SerializableReferenceWrapper:";
 		private const string ValuePrefix = "SerializableWrapper:";
 
-		public const string ComponentFormat = "Component";
-		public const string GameObjectFormat = "GameObject";
-		public const string ContentRefFormat = "ContentRef";
-		public const string BatchInfoFormat = "BatchInfo";
-		public const string ColorDataFormat = "ColorData";
+		public static readonly string ComponentFormat = typeof(Component).FullName;
+		public static readonly string GameObjectFormat = typeof(GameObject).FullName;
+		public static readonly string ContentRefFormat = typeof(IContentRef).FullName;
+		public static readonly string BatchInfoFormat = typeof(BatchInfo).FullName;
+		public static readonly string ColorDataFormat = typeof(IColorData).FullName;
 
 		/// <summary>
 		/// Stores the specified non-<see cref="SerializableAttribute"/> data inside the specified data object using a serializable wrapper.
@@ -123,8 +123,14 @@ namespace Duality.Editor
 		}
 		public static bool TryGetComponents(this IDataObject data, Type cmpType, DataObjectStorage storage, out Component[] comps)
 		{
-			comps = data.GetComponents(cmpType, storage);
-			return comps != null;
+			Component[] results = data.GetComponents(cmpType, storage);
+			if (results == null || results.Length == 0)
+			{
+				comps = null;
+				return false;
+			}
+			comps = results;
+			return true;
 		}
 
 		public static void SetGameObjects(this IDataObject data, IEnumerable<GameObject> obj, DataObjectStorage storage = DataObjectStorage.Reference)
@@ -178,8 +184,14 @@ namespace Duality.Editor
 		}
 		public static bool TryGetContentRefs(this IDataObject data, Type resType, out IContentRef[] content)
 		{
-			content = data.GetContentRefs(resType);
-			return content != null;
+			IContentRef[] results = data.GetContentRefs(resType);
+			if (results == null || results.Length == 0)
+			{
+				content = null;
+				return false;
+			}
+			content = results;
+			return true;
 		}
 
 		public static void SetBatchInfos(this IDataObject data, IEnumerable<BatchInfo> obj)

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -145,11 +145,7 @@ namespace Duality.Editor
 		{
 			if (!data.GetWrappedDataPresent(typeof(Component[]), format)) return null;
 			Component[] refArray = data.GetWrappedData(typeof(Component[]), format) as Component[] ?? new Component[0];
-			return (
-				from r in refArray
-				where r is T
-				select r as T
-				).ToArray();
+			return refArray.OfType<T>().ToArray();
 		}
 		public static Component[] GetComponents(this IDataObject data, DataFormat format = DataFormat.Reference)
 		{

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -312,6 +312,17 @@ namespace Duality.Editor
 			object[] batchArray = data.GetWrappedData(typeof(BatchInfo), DataFormat.Reference);
 			return batchArray == null ? null : batchArray.OfType<BatchInfo>().Select(b => new BatchInfo(b)).ToArray();
 		}
+		public static bool TryGetBatchInfos(this IDataObject data, out BatchInfo[] batches)
+		{
+			if (!data.ContainsBatchInfos())
+			{
+				batches = null;
+				return false;
+			}
+
+			batches = data.GetBatchInfos();
+			return batches != null;
+		}
 
 		public static void SetIColorData(this IDataObject data, IEnumerable<IColorData> color)
 		{

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -119,39 +119,47 @@ namespace Duality.Editor
 				return ConvertOperation.Operation.All;
 		}
 
-		public static void SetComponentRefs(this IDataObject data, IEnumerable<Component> cmp)
+		public static void SetComponents(this IDataObject data, IEnumerable<Component> cmp, DataFormat format = DataFormat.Reference)
 		{
 			Component[] cmpArray = cmp.ToArray();
-			if (cmpArray.Length > 0) data.SetWrappedData(cmpArray, DataFormat.Reference);
+			if (cmpArray.Length > 0) data.SetWrappedData(cmpArray, format);
 		}
-		public static bool ContainsComponentRefs<T>(this IDataObject data) where T : Component
+		public static bool ContainsComponents<T>(this IDataObject data, DataFormat format = DataFormat.Reference) where T : Component
 		{
-			if (!data.GetWrappedDataPresent(typeof(Component[]), DataFormat.Reference)) return false;
-			Component[] refArray = data.GetWrappedData(typeof(Component[]), DataFormat.Reference) as Component[];
+			if (!data.GetWrappedDataPresent(typeof(Component[]), format)) return false;
+			Component[] refArray = data.GetWrappedData(typeof(Component[]), format) as Component[];
 			return refArray != null && refArray.Any(c => c is T);
 		}
-		public static bool ContainsComponentRefs(this IDataObject data, Type cmpType = null)
+		public static bool ContainsComponents(this IDataObject data, DataFormat format = DataFormat.Reference)
+		{
+			return data.ContainsComponents(typeof(Component), format);
+		}
+		public static bool ContainsComponents(this IDataObject data, Type cmpType, DataFormat format = DataFormat.Reference)
 		{
 			if (cmpType == null) cmpType = typeof(Component);
-			if (!data.GetWrappedDataPresent(typeof(Component[]), DataFormat.Reference)) return false;
-			Component[] refArray = data.GetWrappedData(typeof(Component[]), DataFormat.Reference) as Component[];
+			if (!data.GetWrappedDataPresent(typeof(Component[]), format)) return false;
+			Component[] refArray = data.GetWrappedData(typeof(Component[]), format) as Component[];
 			return refArray != null && refArray.Any(c => cmpType.IsInstanceOfType(c));
 		}
-		public static T[] GetComponentRefs<T>(this IDataObject data) where T : Component
+		public static T[] GetComponents<T>(this IDataObject data, DataFormat format = DataFormat.Reference) where T : Component
 		{
-			if (!data.GetWrappedDataPresent(typeof(Component[]), DataFormat.Reference)) return null;
-			Component[] refArray = data.GetWrappedData(typeof(Component[]), DataFormat.Reference) as Component[] ?? new Component[0];
+			if (!data.GetWrappedDataPresent(typeof(Component[]), format)) return null;
+			Component[] refArray = data.GetWrappedData(typeof(Component[]), format) as Component[] ?? new Component[0];
 			return (
 				from r in refArray
 				where r is T
 				select r as T
 				).ToArray();
 		}
-		public static Component[] GetComponentRefs(this IDataObject data, Type cmpType = null)
+		public static Component[] GetComponents(this IDataObject data, DataFormat format = DataFormat.Reference)
+		{
+			return data.GetComponents(typeof(Component), format);
+		}
+		public static Component[] GetComponents(this IDataObject data, Type cmpType, DataFormat format = DataFormat.Reference)
 		{
 			if (cmpType == null) cmpType = typeof(Component);
-			if (!data.GetWrappedDataPresent(typeof(Component[]), DataFormat.Reference)) return null;
-			Component[] refArray = data.GetWrappedData(typeof(Component[]), DataFormat.Reference) as Component[] ?? new Component[0];
+			if (!data.GetWrappedDataPresent(typeof(Component[]), format)) return null;
+			Component[] refArray = data.GetWrappedData(typeof(Component[]), format) as Component[] ?? new Component[0];
 			return (
 				from c in refArray
 				where cmpType.IsInstanceOfType(c)
@@ -159,18 +167,18 @@ namespace Duality.Editor
 				).ToArray();
 		}
 
-		public static void SetGameObjectRefs(this IDataObject data, IEnumerable<GameObject> obj)
+		public static void SetGameObjects(this IDataObject data, IEnumerable<GameObject> obj, DataFormat format = DataFormat.Reference)
 		{
 			GameObject[] objArray = obj.ToArray();
-			if (objArray.Length > 0) data.SetWrappedData(objArray, DataFormat.Reference);
+			if (objArray.Length > 0) data.SetWrappedData(objArray, format);
 		}
-		public static bool ContainsGameObjectRefs(this IDataObject data)
+		public static bool ContainsGameObjects(this IDataObject data, DataFormat format = DataFormat.Reference)
 		{
-			return data.GetWrappedDataPresent(typeof(GameObject[]), DataFormat.Reference);
+			return data.GetWrappedDataPresent(typeof(GameObject[]), format);
 		}
-		public static GameObject[] GetGameObjectRefs(this IDataObject data)
+		public static GameObject[] GetGameObjects(this IDataObject data, DataFormat format = DataFormat.Reference)
 		{
-			return data.GetWrappedData(typeof(GameObject[]), DataFormat.Reference) as GameObject[] ?? new GameObject[0];
+			return data.GetWrappedData(typeof(GameObject[]), format) as GameObject[] ?? new GameObject[0];
 		}
 
 		public static void SetContentRefs(this IDataObject data, IEnumerable<IContentRef> content)

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -43,9 +43,9 @@ namespace Duality.Editor
 		/// <summary>
 		/// Stores the specified non-<see cref="SerializableAttribute"/> data inside the specified data object using a serializable wrapper.
 		/// </summary>
-		/// <param name="elementType"></param>
+		/// <param name="elementType">The type of the given IEnumerable elements</param>
 		/// <param name="format">The format to store the data in</param>
-		public static void SetWrappedData(this IDataObject data, object[] values, Type elementType, DataFormat format)
+		public static void SetWrappedData(this IDataObject data, IEnumerable<object> values, Type elementType, DataFormat format)
 		{
 			string prefix = format == DataFormat.Reference ? ReferencePrefix : ValuePrefix;
 			SerializableWrapper wrapper = format == DataFormat.Reference
@@ -53,14 +53,6 @@ namespace Duality.Editor
 				: new SerializableWrapper(values);
 
 			data.SetData(prefix + elementType.FullName, wrapper);
-		}
-		/// <summary>
-		/// Stores the specified non-<see cref="SerializableAttribute"/> data inside the specified data object using a serializable wrapper.
-		/// </summary>
-		/// <param name="format">The format to store the data in</param>
-		public static void SetWrappedData<T>(this IDataObject data, T[] values, DataFormat format)
-		{
-			data.SetWrappedData(values.OfType<object>().ToArray(), typeof(T), format);
 		}
 		/// <summary>
 		/// Determines whether the specified type of wrapped non-<see cref="SerializableAttribute"/> data is available in the data object.
@@ -119,7 +111,7 @@ namespace Duality.Editor
 		{
 			string prefix = formatType == DataFormat.Reference ? ReferencePrefix : ValuePrefix;
 			SerializableWrapper wrapper = data.GetData(prefix + format) as SerializableWrapper;
-			if (wrapper != null) return wrapper.Data;
+			if (wrapper != null) return wrapper.Data.ToArray();
 			if (!allowConversion) return null;
 
 			// Getting in the given format failed.
@@ -149,7 +141,7 @@ namespace Duality.Editor
 		public static void SetComponents(this IDataObject data, IEnumerable<Component> cmp, DataFormat format = DataFormat.Reference)
 		{
 			Component[] cmpArray = cmp.ToArray();
-			if (cmpArray.Length > 0) data.SetWrappedData(cmpArray, format);
+			if (cmpArray.Length > 0) data.SetWrappedData(cmpArray, typeof(Component), format);
 		}
 		public static bool ContainsComponents<T>(this IDataObject data, DataFormat format = DataFormat.Reference) where T : Component
 		{
@@ -225,7 +217,7 @@ namespace Duality.Editor
 		public static void SetGameObjects(this IDataObject data, IEnumerable<GameObject> obj, DataFormat format = DataFormat.Reference)
 		{
 			GameObject[] objArray = obj.ToArray();
-			if (objArray.Length > 0) data.SetWrappedData(objArray, format);
+			if (objArray.Length > 0) data.SetWrappedData(objArray, typeof(GameObject), format);
 		}
 		public static bool ContainsGameObjects(this IDataObject data, DataFormat format = DataFormat.Reference)
 		{
@@ -251,7 +243,7 @@ namespace Duality.Editor
 		public static void SetContentRefs(this IDataObject data, IEnumerable<IContentRef> content)
 		{
 			if (!content.Any()) return;
-			data.SetWrappedData(content.ToArray(), DataFormat.Value);
+			data.SetWrappedData(content.ToArray(), typeof(IContentRef), DataFormat.Value);
 		}
 		public static bool ContainsContentRefs<T>(this IDataObject data) where T : Resource
 		{
@@ -291,7 +283,7 @@ namespace Duality.Editor
 		public static void SetBatchInfos(this IDataObject data, IEnumerable<BatchInfo> obj)
 		{
 			BatchInfo[] objArray = obj.ToArray();
-			if (objArray.Length > 0) data.SetWrappedData(objArray, DataFormat.Reference);
+			if (objArray.Length > 0) data.SetWrappedData(objArray, typeof(BatchInfo), DataFormat.Reference);
 		}
 		public static bool ContainsBatchInfos(this IDataObject data)
 		{
@@ -306,7 +298,7 @@ namespace Duality.Editor
 		{
 			IColorData[] clrArray = color.ToArray();
 			if (clrArray.Length == 0) return;
-			data.SetWrappedData(clrArray, DataFormat.Value);
+			data.SetWrappedData(clrArray, typeof(IColorData), DataFormat.Value);
 
 			DataObject dataObj = data as DataObject;
 			if (dataObj != null)

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -438,6 +438,11 @@ namespace Duality.Editor
 			byte[] valToken = new byte[4];
 			valToken[3] = 255;
 
+			// Prevent incorrect lengths of comma-separated values 
+			// (which couldn't be a color) from being parsed
+			if (!(token.Length == 3 || token.Length == 4))
+				return null;
+
 			for (int i = 0; i < token.Length; i++)
 			{
 				token[i] = token[i].Trim();

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsDataObject.cs
@@ -8,28 +8,6 @@ using Duality.Drawing;
 
 namespace Duality.Editor
 {
-	/// <summary>
-	/// Indicates whether an object is stored inside a <see cref="DataObject"/> as 
-	/// a reference or serialized value.
-	/// </summary>
-	public enum DataObjectStorage
-	{
-		/// <summary>
-		/// Use this type when storing an object reference in a DataObject.
-		/// The reference will be maintained even after serialization.
-		/// Note that storing a .Net value type (ex. Vector3) with this data type
-		/// will still lead to a copy of the data. Data stored with this type
-		/// can be automatically converted to value typed data (uses deep cloning).
-		/// </summary>
-		Reference,
-		/// <summary>
-		/// Use this type when storing an object in a DataObject that is
-		/// not meant to be a reference to an existing object. This type
-		/// of data cannot be automatically converted to reference typed data.
-		/// </summary>
-		Value
-	}
-
 	public static class ExtMethodsDataObject
 	{
 		private const string ReferencePrefix = "SerializableReferenceWrapper:";

--- a/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
@@ -18,7 +18,7 @@ namespace Duality.Editor
 
 		private long[] ids = null;
 
-		public sealed override IEnumerable<object> Data
+		public sealed override IReadOnlyList<object> Data
 		{
 			get
 			{

--- a/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
@@ -15,9 +15,9 @@ namespace Duality.Editor
 		private static readonly Dictionary<long, object> referenceMap = new Dictionary<long, object>();
 		private static readonly long contextID = unchecked(DateTime.Now.Ticks * (long)Process.GetCurrentProcess().Id);
 
-		private long id = -1;
+		private long[] ids = null;
 
-		public sealed override object Data
+		public sealed override object[] Data
 		{
 			get
 			{
@@ -28,49 +28,62 @@ namespace Duality.Editor
 				// Invalidate the ID in use. Could
 				// occur if this SerializableReferenceWrapper
 				// is being reused
-				this.id = -1;
+				this.ids = null;
 				base.Data = value;
 			}
 		}
 
-		public SerializableReferenceWrapper(object data) : base(data) { }
+		public SerializableReferenceWrapper(object[] data) : base(data) { }
 		private SerializableReferenceWrapper(SerializationInfo info, StreamingContext context)
 		{
 			try
 			{
-				long referenceID = info.GetInt64("data");
+				long[] referenceIDs = info.GetValue("data", typeof(long[])) as long[];
 				long referenceContext = info.GetInt64("context");
 
-				// Retrieve reference, but safeguard against IDs from a different
+				List<object> retrievedReferences = new List<object>();
+				List<long> retrievedIDs = new List<long>();
+
+				// Retrieve references, but safeguard against IDs from a different
 				// application instance, or invalid / unavailable IDs.
-				object reference;
-				if (referenceContext != contextID || !referenceMap.TryGetValue(referenceID, out reference))
+				if (referenceContext == contextID)
 				{
-					reference = null;
-					referenceID = -1;
+					foreach (long id in referenceIDs)
+					{
+						object reference;
+						if (referenceMap.TryGetValue(id, out reference))
+						{
+							retrievedReferences.Add(reference);
+							retrievedIDs.Add(id);
+						}
+					}
 				}
 
-				this.data = reference;
-				this.id = referenceID;
+				this.data = retrievedReferences.ToArray();
+				this.ids = retrievedIDs.ToArray();
 			}
 			catch (Exception)
 			{
 				this.data = null;
-				this.id = -1;
+				this.ids = null;
 			}
 		}
 
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
-			// First time this object is being serialized. Give it an ID in the reference map
-			// so we can look it up when deserializing the object and get the same reference
-			if (this.id < 0)
+			// First time these objects are being serialized. Give them an ID in the reference map
+			// so we can look it up when deserializing the objects and get the same reference
+			if (this.ids == null)
 			{
-				this.id = nextID++;
-				referenceMap[this.id] = this.data;
+				this.ids = new long[this.data.Length];
+				for (int i = 0; i < this.data.Length; i++)
+				{
+					this.ids[i] = nextID++;
+					referenceMap[this.ids[i]] = this.data[i];
+				}
 			}
 
-			info.AddValue("data", this.id);
+			info.AddValue("data", this.ids);
 			info.AddValue("context", contextID);
 		}
 	}

--- a/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
@@ -17,7 +17,7 @@ namespace Duality.Editor
 
 		private long[] ids = null;
 
-		public sealed override object[] Data
+		public sealed override IEnumerable<object> Data
 		{
 			get
 			{
@@ -33,7 +33,7 @@ namespace Duality.Editor
 			}
 		}
 
-		public SerializableReferenceWrapper(object[] data) : base(data) { }
+		public SerializableReferenceWrapper(IEnumerable<object> data) : base(data) { }
 		private SerializableReferenceWrapper(SerializationInfo info, StreamingContext context)
 		{
 			try

--- a/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableReferenceWrapper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 
 namespace Duality.Editor
@@ -21,7 +22,7 @@ namespace Duality.Editor
 		{
 			get
 			{
-				return base.Data;
+				return this.data;
 			}
 			set
 			{
@@ -29,11 +30,14 @@ namespace Duality.Editor
 				// occur if this SerializableReferenceWrapper
 				// is being reused
 				this.ids = null;
-				base.Data = value;
+				this.data = value.ToArray();
 			}
 		}
 
-		public SerializableReferenceWrapper(IEnumerable<object> data) : base(data) { }
+		public SerializableReferenceWrapper(IEnumerable<object> data) : base(null)
+		{
+			this.data = data == null ? null : data.ToArray();
+		}
 		private SerializableReferenceWrapper(SerializationInfo info, StreamingContext context)
 		{
 			try

--- a/Source/Editor/DualityEditor/Utility/SerializableWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableWrapper.cs
@@ -22,13 +22,20 @@ namespace Duality.Editor
 		public virtual IEnumerable<object> Data
 		{
 			get { return this.data; }
-			set { this.data = value.ToArray(); }
+			set
+			{
+				// Clone the objects first to make sure they are isolated and don't
+				// drag a whole Scene (or so) into the serialization graph.
+				this.data = value.Select(o => o.DeepClone()).ToArray();
+			}
 		}
 
 		public SerializableWrapper() : this(null) { }
 		public SerializableWrapper(IEnumerable<object> data)
 		{
-			this.data = data == null ? null : data.ToArray();
+			// Clone the objects first to make sure they are isolated and don't
+			// drag a whole Scene (or so) into the serialization graph.
+			this.data = data == null ? null : data.Select(o => o.DeepClone()).ToArray();
 		}
 		private SerializableWrapper(SerializationInfo info, StreamingContext context)
 		{
@@ -58,12 +65,8 @@ namespace Duality.Editor
 		{
 			using (MemoryStream stream = new MemoryStream())
 			{
-				// Clone the object first to make sure it's isolated and doesn't 
-				// drag a whole Scene (or so) into the serialization graph.
-				object[] isolatedObjs = this.data.Select(obj => obj.DeepClone()).ToArray();
-
 				// Now serialize the isolated object
-				Serializer.WriteObject(isolatedObjs, stream, typeof(BinarySerializer));
+				Serializer.WriteObject(this.data, stream, typeof(BinarySerializer));
 				byte[] serializedData = stream.ToArray();
 				info.AddValue("data", serializedData);
 			}

--- a/Source/Editor/DualityEditor/Utility/SerializableWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableWrapper.cs
@@ -19,7 +19,7 @@ namespace Duality.Editor
 	{
 		protected object[] data;
 
-		public virtual IEnumerable<object> Data
+		public virtual IReadOnlyList<object> Data
 		{
 			get { return this.data; }
 			set

--- a/Source/Editor/DualityEditor/Utility/SerializableWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableWrapper.cs
@@ -17,16 +17,16 @@ namespace Duality.Editor
 	[Serializable]
 	public class SerializableWrapper : ISerializable
 	{
-		protected object data;
+		protected object[] data;
 
-		public virtual object Data
+		public virtual object[] Data
 		{
 			get { return this.data; }
 			set { this.data = value; }
 		}
 
 		public SerializableWrapper() : this(null) { }
-		public SerializableWrapper(object data)
+		public SerializableWrapper(object[] data)
 		{
 			this.data = data;
 		}
@@ -50,7 +50,7 @@ namespace Duality.Editor
 
 			using (MemoryStream stream = new MemoryStream(serializedData))
 			{
-				this.data = Serializer.TryReadObject<object>(stream);
+				this.data = Serializer.TryReadObject<object[]>(stream);
 			}
 		}
 
@@ -60,10 +60,10 @@ namespace Duality.Editor
 			{
 				// Clone the object first to make sure it's isolated and doesn't 
 				// drag a whole Scene (or so) into the serialization graph.
-				object isolatedObj = this.data.DeepClone();
+				object[] isolatedObjs = this.data.Select(obj => obj.DeepClone()).ToArray();
 
 				// Now serialize the isolated object
-				Serializer.WriteObject(isolatedObj, stream, typeof(BinarySerializer));
+				Serializer.WriteObject(isolatedObjs, stream, typeof(BinarySerializer));
 				byte[] serializedData = stream.ToArray();
 				info.AddValue("data", serializedData);
 			}

--- a/Source/Editor/DualityEditor/Utility/SerializableWrapper.cs
+++ b/Source/Editor/DualityEditor/Utility/SerializableWrapper.cs
@@ -19,16 +19,16 @@ namespace Duality.Editor
 	{
 		protected object[] data;
 
-		public virtual object[] Data
+		public virtual IEnumerable<object> Data
 		{
 			get { return this.data; }
-			set { this.data = value; }
+			set { this.data = value.ToArray(); }
 		}
 
 		public SerializableWrapper() : this(null) { }
-		public SerializableWrapper(object[] data)
+		public SerializableWrapper(IEnumerable<object> data)
 		{
-			this.data = data;
+			this.data = data == null ? null : data.ToArray();
 		}
 		private SerializableWrapper(SerializationInfo info, StreamingContext context)
 		{

--- a/Source/Plugins/EditorBase/DataConverters/GameObjFromPrefab.cs
+++ b/Source/Plugins/EditorBase/DataConverters/GameObjFromPrefab.cs
@@ -28,15 +28,15 @@ namespace Duality.Editor.Plugins.Base.DataConverters
 		{
 			return 
 				convert.AllowedOperations.HasFlag(ConvertOperation.Operation.CreateObj) && 
-				convert.Data.ContainsContentRefs<Prefab>();
+				convert.Data.ContainsContentRefs(typeof(Prefab));
 		}
 		public override bool Convert(ConvertOperation convert)
 		{
-			ContentRef<Prefab>[] dropData;
-			if (convert.Data.TryGetContentRefs<Prefab>(out dropData))
+			IContentRef[] dropData;
+			if (convert.Data.TryGetContentRefs(typeof(Prefab), out dropData))
 			{
 				// Instantiate Prefabs
-				foreach (ContentRef<Prefab> pRef in dropData)
+				foreach (ContentRef<Prefab> pRef in dropData.OfType<ContentRef<Prefab>>())
 				{
 					if (convert.IsObjectHandled(pRef.Res)) continue;
 					if (!pRef.IsAvailable) continue;

--- a/Source/Plugins/EditorBase/DataConverters/GameObjFromPrefab.cs
+++ b/Source/Plugins/EditorBase/DataConverters/GameObjFromPrefab.cs
@@ -32,12 +32,11 @@ namespace Duality.Editor.Plugins.Base.DataConverters
 		}
 		public override bool Convert(ConvertOperation convert)
 		{
-			if (convert.Data.ContainsContentRefs<Prefab>())
+			ContentRef<Prefab>[] dropData;
+			if (convert.Data.TryGetContentRefs<Prefab>(out dropData))
 			{
-				ContentRef<Prefab>[] dropdata = convert.Data.GetContentRefs<Prefab>();
-
 				// Instantiate Prefabs
-				foreach (ContentRef<Prefab> pRef in dropdata)
+				foreach (ContentRef<Prefab> pRef in dropData)
 				{
 					if (convert.IsObjectHandled(pRef.Res)) continue;
 					if (!pRef.IsAvailable) continue;

--- a/Source/Plugins/EditorBase/DataConverters/PrefabFromGameObject.cs
+++ b/Source/Plugins/EditorBase/DataConverters/PrefabFromGameObject.cs
@@ -36,7 +36,7 @@ namespace Duality.Editor.Plugins.Base.DataConverters
 			bool finishConvertOp = false;
 
 			GameObject[] draggedObjArray;
-			if (convert.Data.TryGetGameObjects(out draggedObjArray))
+			if (convert.Data.TryGetGameObjects(DataObjectStorage.Reference, out draggedObjArray))
 			{
 				// Filter out GameObjects that are children of others
 				draggedObjArray = draggedObjArray.Where(o => !draggedObjArray.Any(o2 => o.IsChildOf(o2))).ToArray();

--- a/Source/Plugins/EditorBase/DataConverters/PrefabFromGameObject.cs
+++ b/Source/Plugins/EditorBase/DataConverters/PrefabFromGameObject.cs
@@ -35,9 +35,9 @@ namespace Duality.Editor.Plugins.Base.DataConverters
 		{
 			bool finishConvertOp = false;
 
-			if (convert.Data.ContainsGameObjects())
+			GameObject[] draggedObjArray;
+			if (convert.Data.TryGetGameObjects(out draggedObjArray))
 			{
-				GameObject[] draggedObjArray = convert.Data.GetGameObjects();
 				if (draggedObjArray != null)
 				{
 					// Filter out GameObjects that are children of others

--- a/Source/Plugins/EditorBase/DataConverters/PrefabFromGameObject.cs
+++ b/Source/Plugins/EditorBase/DataConverters/PrefabFromGameObject.cs
@@ -38,26 +38,28 @@ namespace Duality.Editor.Plugins.Base.DataConverters
 			if (convert.Data.ContainsGameObjects())
 			{
 				GameObject[] draggedObjArray = convert.Data.GetGameObjects();
-
-				// Filter out GameObjects that are children of others
-				draggedObjArray = draggedObjArray.Where(o => !draggedObjArray.Any(o2 => o.IsChildOf(o2))).ToArray();
-
-				// Generate Prefabs
-				foreach (GameObject draggedObj in draggedObjArray)
+				if (draggedObjArray != null)
 				{
-					if (convert.IsObjectHandled(draggedObj)) continue;
+					// Filter out GameObjects that are children of others
+					draggedObjArray = draggedObjArray.Where(o => !draggedObjArray.Any(o2 => o.IsChildOf(o2))).ToArray();
 
-					// Create Prefab
-					Prefab prefab = new Prefab(draggedObj);
+					// Generate Prefabs
+					foreach (GameObject draggedObj in draggedObjArray)
+					{
+						if (convert.IsObjectHandled(draggedObj)) continue;
 
-					// Add a name hint that may be used as indicator to select a Resource name later
-					prefab.AssetInfo = new AssetInfo();
-					prefab.AssetInfo.NameHint = draggedObj.Name;
+						// Create Prefab
+						Prefab prefab = new Prefab(draggedObj);
 
-					// Mark GameObject as handled
-					convert.MarkObjectHandled(draggedObj);						
-					convert.AddResult(prefab);
-					finishConvertOp = true;
+						// Add a name hint that may be used as indicator to select a Resource name later
+						prefab.AssetInfo = new AssetInfo();
+						prefab.AssetInfo.NameHint = draggedObj.Name;
+
+						// Mark GameObject as handled
+						convert.MarkObjectHandled(draggedObj);
+						convert.AddResult(prefab);
+						finishConvertOp = true;
+					}
 				}
 			}
 

--- a/Source/Plugins/EditorBase/DataConverters/PrefabFromGameObject.cs
+++ b/Source/Plugins/EditorBase/DataConverters/PrefabFromGameObject.cs
@@ -29,15 +29,15 @@ namespace Duality.Editor.Plugins.Base.DataConverters
 		{
 			return 
 				convert.AllowedOperations.HasFlag(ConvertOperation.Operation.CreateRes) && 
-				convert.Data.ContainsGameObjectRefs();
+				convert.Data.ContainsGameObjects();
 		}
 		public override bool Convert(ConvertOperation convert)
 		{
 			bool finishConvertOp = false;
 
-			if (convert.Data.ContainsGameObjectRefs())
+			if (convert.Data.ContainsGameObjects())
 			{
-				GameObject[] draggedObjArray = convert.Data.GetGameObjectRefs();
+				GameObject[] draggedObjArray = convert.Data.GetGameObjects();
 
 				// Filter out GameObjects that are children of others
 				draggedObjArray = draggedObjArray.Where(o => !draggedObjArray.Any(o2 => o.IsChildOf(o2))).ToArray();

--- a/Source/Plugins/EditorBase/DataConverters/PrefabFromGameObject.cs
+++ b/Source/Plugins/EditorBase/DataConverters/PrefabFromGameObject.cs
@@ -38,28 +38,25 @@ namespace Duality.Editor.Plugins.Base.DataConverters
 			GameObject[] draggedObjArray;
 			if (convert.Data.TryGetGameObjects(out draggedObjArray))
 			{
-				if (draggedObjArray != null)
+				// Filter out GameObjects that are children of others
+				draggedObjArray = draggedObjArray.Where(o => !draggedObjArray.Any(o2 => o.IsChildOf(o2))).ToArray();
+
+				// Generate Prefabs
+				foreach (GameObject draggedObj in draggedObjArray)
 				{
-					// Filter out GameObjects that are children of others
-					draggedObjArray = draggedObjArray.Where(o => !draggedObjArray.Any(o2 => o.IsChildOf(o2))).ToArray();
+					if (convert.IsObjectHandled(draggedObj)) continue;
 
-					// Generate Prefabs
-					foreach (GameObject draggedObj in draggedObjArray)
-					{
-						if (convert.IsObjectHandled(draggedObj)) continue;
+					// Create Prefab
+					Prefab prefab = new Prefab(draggedObj);
 
-						// Create Prefab
-						Prefab prefab = new Prefab(draggedObj);
+					// Add a name hint that may be used as indicator to select a Resource name later
+					prefab.AssetInfo = new AssetInfo();
+					prefab.AssetInfo.NameHint = draggedObj.Name;
 
-						// Add a name hint that may be used as indicator to select a Resource name later
-						prefab.AssetInfo = new AssetInfo();
-						prefab.AssetInfo.NameHint = draggedObj.Name;
-
-						// Mark GameObject as handled
-						convert.MarkObjectHandled(draggedObj);
-						convert.AddResult(prefab);
-						finishConvertOp = true;
-					}
+					// Mark GameObject as handled
+					convert.MarkObjectHandled(draggedObj);
+					convert.AddResult(prefab);
+					finishConvertOp = true;
 				}
 			}
 

--- a/Source/Plugins/EditorBase/PropertyEditors/ComponentRefPropertyEditor.cs
+++ b/Source/Plugins/EditorBase/PropertyEditors/ComponentRefPropertyEditor.cs
@@ -97,7 +97,7 @@ namespace Duality.Editor.Plugins.Base.PropertyEditors
 		
 		protected override void SerializeToData(DataObject data)
 		{
-			data.SetComponentRefs(new[] { this.component });
+			data.SetComponents(new[] { this.component });
 		}
 		protected override void DeserializeFromData(DataObject data)
 		{

--- a/Source/Plugins/EditorBase/PropertyEditors/GameObjectRefPropertyEditor.cs
+++ b/Source/Plugins/EditorBase/PropertyEditors/GameObjectRefPropertyEditor.cs
@@ -95,7 +95,7 @@ namespace Duality.Editor.Plugins.Base.PropertyEditors
 		
 		protected override void SerializeToData(DataObject data)
 		{
-			data.SetGameObjectRefs(new[] { this.gameObj });
+			data.SetGameObjects(new[] { this.gameObj });
 		}
 		protected override void DeserializeFromData(DataObject data)
 		{

--- a/Source/Plugins/EditorBase/PropertyEditors/ObjectRefPropertyEditor.cs
+++ b/Source/Plugins/EditorBase/PropertyEditors/ObjectRefPropertyEditor.cs
@@ -411,11 +411,11 @@ namespace Duality.Editor.Plugins.Base.PropertyEditors
 				}
 				else if (this.ReferenceType == typeof(GameObject))
 				{
-					dataObject.SetGameObjectRefs(new[] { resourceSelectionForm.GameObjectReference });
+					dataObject.SetGameObjects(new[] { resourceSelectionForm.GameObjectReference });
 				}
 				else
 				{
-					dataObject.SetComponentRefs(new[] { resourceSelectionForm.ComponentReference });
+					dataObject.SetComponents(new[] { resourceSelectionForm.ComponentReference });
 				}
 
 				DeserializeFromData(dataObject);

--- a/Source/Plugins/EditorModules/ProjectView/Modules/ProjectFolderView.cs
+++ b/Source/Plugins/EditorModules/ProjectView/Modules/ProjectFolderView.cs
@@ -1001,6 +1001,7 @@ namespace Duality.Editor.Plugins.ProjectView
 			ConvertOperation.Operation convOp = data.GetAllowedConvertOp();
 			if (data != null)
 			{
+				GameObject[] draggedObjects;
 				// Dragging files around
 				if (data.ContainsFileDropList())
 				{
@@ -1032,10 +1033,10 @@ namespace Duality.Editor.Plugins.ProjectView
 				// Dragging a single GameObject to Prefab
 				else if (
 					e.AllowedEffect.HasFlag(DragDropEffects.Link) &&
-					data.ContainsGameObjects() &&
+					data.TryGetGameObjects(out draggedObjects) &&
+					draggedObjects.Length == 1 &&
 					targetResNode != null && 
-					targetResNode.ResLink.Is<Duality.Resources.Prefab>() && 
-					data.GetGameObjects().Length == 1)
+					targetResNode.ResLink.Is<Duality.Resources.Prefab>())
 				{
 					e.Effect = DragDropEffects.Link & e.AllowedEffect;
 				}
@@ -1071,6 +1072,7 @@ namespace Duality.Editor.Plugins.ProjectView
 			ConvertOperation.Operation convOp = data.GetAllowedConvertOp();
 			if (data != null)
 			{
+				GameObject[] draggedObjects;
 				// Dropping files
 				if (data.ContainsFileDropList())
 				{
@@ -1099,15 +1101,14 @@ namespace Duality.Editor.Plugins.ProjectView
 				// Dropping GameObject to Prefab
 				else if (
 					e.Effect.HasFlag(DragDropEffects.Link) &&
-					data.ContainsGameObjects() &&
+					data.TryGetGameObjects(out draggedObjects) &&
+					draggedObjects.Length == 1 && 
 					targetResNode != null && 
-					targetResNode.ResLink.Is<Duality.Resources.Prefab>() && 
-					data.GetGameObjects().Length == 1)
+					targetResNode.ResLink.Is<Duality.Resources.Prefab>())
 				{
 					Prefab prefab = targetResNode.ResLink.Res as Prefab;
 					if (prefab != null)
 					{
-						GameObject[] draggedObjects = data.GetGameObjects();
 						GameObject draggedObj = draggedObjects[0];
 
 						if (draggedObj != null)

--- a/Source/Plugins/EditorModules/ProjectView/Modules/ProjectFolderView.cs
+++ b/Source/Plugins/EditorModules/ProjectView/Modules/ProjectFolderView.cs
@@ -1033,7 +1033,7 @@ namespace Duality.Editor.Plugins.ProjectView
 				// Dragging a single GameObject to Prefab
 				else if (
 					e.AllowedEffect.HasFlag(DragDropEffects.Link) &&
-					data.TryGetGameObjects(out draggedObjects) &&
+					data.TryGetGameObjects(DataObjectStorage.Reference, out draggedObjects) &&
 					draggedObjects.Length == 1 &&
 					targetResNode != null && 
 					targetResNode.ResLink.Is<Duality.Resources.Prefab>())
@@ -1101,7 +1101,7 @@ namespace Duality.Editor.Plugins.ProjectView
 				// Dropping GameObject to Prefab
 				else if (
 					e.Effect.HasFlag(DragDropEffects.Link) &&
-					data.TryGetGameObjects(out draggedObjects) &&
+					data.TryGetGameObjects(DataObjectStorage.Reference, out draggedObjects) &&
 					draggedObjects.Length == 1 && 
 					targetResNode != null && 
 					targetResNode.ResLink.Is<Duality.Resources.Prefab>())

--- a/Source/Plugins/EditorModules/ProjectView/Modules/ProjectFolderView.cs
+++ b/Source/Plugins/EditorModules/ProjectView/Modules/ProjectFolderView.cs
@@ -1107,14 +1107,18 @@ namespace Duality.Editor.Plugins.ProjectView
 					Prefab prefab = targetResNode.ResLink.Res as Prefab;
 					if (prefab != null)
 					{
-						GameObject draggedObj = data.GetGameObjects()[0];
+						GameObject[] draggedObjects = data.GetGameObjects();
+						GameObject draggedObj = draggedObjects[0];
 
-						UndoRedoManager.BeginMacro();
-						// Prevent recursion
-						UndoRedoManager.Do(new BreakPrefabLinkAction(draggedObj.ChildrenDeep.Where(c => c.PrefabLink != null && c.PrefabLink.Prefab == prefab)));
-						// Inject GameObject to Prefab & Establish PrefabLink
-						UndoRedoManager.Do(new ApplyToPrefabAction(draggedObj, prefab));
-						UndoRedoManager.EndMacro(UndoRedoManager.MacroDeriveName.FromLast);
+						if (draggedObj != null)
+						{
+							UndoRedoManager.BeginMacro();
+							// Prevent recursion
+							UndoRedoManager.Do(new BreakPrefabLinkAction(draggedObj.ChildrenDeep.Where(c => c.PrefabLink != null && c.PrefabLink.Prefab == prefab)));
+							// Inject GameObject to Prefab & Establish PrefabLink
+							UndoRedoManager.Do(new ApplyToPrefabAction(draggedObj, prefab));
+							UndoRedoManager.EndMacro(UndoRedoManager.MacroDeriveName.FromLast);
+						}
 					}
 				}
 				// See if we can retrieve Resources from data

--- a/Source/Plugins/EditorModules/ProjectView/Modules/ProjectFolderView.cs
+++ b/Source/Plugins/EditorModules/ProjectView/Modules/ProjectFolderView.cs
@@ -1032,10 +1032,10 @@ namespace Duality.Editor.Plugins.ProjectView
 				// Dragging a single GameObject to Prefab
 				else if (
 					e.AllowedEffect.HasFlag(DragDropEffects.Link) &&
-					data.ContainsGameObjectRefs() &&
+					data.ContainsGameObjects() &&
 					targetResNode != null && 
 					targetResNode.ResLink.Is<Duality.Resources.Prefab>() && 
-					data.GetGameObjectRefs().Length == 1)
+					data.GetGameObjects().Length == 1)
 				{
 					e.Effect = DragDropEffects.Link & e.AllowedEffect;
 				}
@@ -1099,15 +1099,15 @@ namespace Duality.Editor.Plugins.ProjectView
 				// Dropping GameObject to Prefab
 				else if (
 					e.Effect.HasFlag(DragDropEffects.Link) &&
-					data.ContainsGameObjectRefs() &&
+					data.ContainsGameObjects() &&
 					targetResNode != null && 
 					targetResNode.ResLink.Is<Duality.Resources.Prefab>() && 
-					data.GetGameObjectRefs().Length == 1)
+					data.GetGameObjects().Length == 1)
 				{
 					Prefab prefab = targetResNode.ResLink.Res as Prefab;
 					if (prefab != null)
 					{
-						GameObject draggedObj = data.GetGameObjectRefs()[0];
+						GameObject draggedObj = data.GetGameObjects()[0];
 
 						UndoRedoManager.BeginMacro();
 						// Prevent recursion
@@ -1158,7 +1158,7 @@ namespace Duality.Editor.Plugins.ProjectView
 						// If we happened to generate a Prefab, link possible existing GameObjects to it
 						if (resList.OfType<Prefab>().Any())
 						{
-							UndoRedoManager.Do(new ApplyToPrefabAction(data.GetGameObjectRefs(), resList.OfType<Prefab>().Ref()));
+							UndoRedoManager.Do(new ApplyToPrefabAction(data.GetGameObjects(), resList.OfType<Prefab>().Ref()));
 						}
 
 					}

--- a/Source/Plugins/EditorModules/SceneView/Modules/SceneView.cs
+++ b/Source/Plugins/EditorModules/SceneView/Modules/SceneView.cs
@@ -581,11 +581,11 @@ namespace Duality.Editor.Plugins.SceneView
 			if (!guardRequiredComponents)
 			{
 				data.SetData(nodes.ToArray());
-				data.SetComponentRefs(
+				data.SetComponents(
 					from c in nodes
 					where c.Tag is ComponentNode
 					select (c.Tag as ComponentNode).Component);
-				data.SetGameObjectRefs(
+				data.SetGameObjects(
 					from c in nodes
 					where c.Tag is GameObjectNode
 					select (c.Tag as GameObjectNode).Obj);
@@ -986,7 +986,7 @@ namespace Duality.Editor.Plugins.SceneView
 			if (data != null)
 			{
 				NodeBase dropParent = this.DragDropGetTargetNode();
-				if (data.ContainsGameObjectRefs())
+				if (data.ContainsGameObjects())
 				{
 					DragDropEffects effect;
 					if ((e.KeyState & 2) != 0)			// Right mouse button
@@ -1002,7 +1002,7 @@ namespace Duality.Editor.Plugins.SceneView
 					else if (dropParent is GameObjectNode)
 					{
 						GameObject dropObj = (dropParent as GameObjectNode).Obj;
-						GameObject[] draggedObj = data.GetGameObjectRefs();
+						GameObject[] draggedObj = data.GetGameObjects();
 						bool canDropHere = true;
 
 						// Can't drop in child of dragged objects
@@ -1020,7 +1020,7 @@ namespace Duality.Editor.Plugins.SceneView
 					else
 						e.Effect = DragDropEffects.None;
 				}
-				else if (data.ContainsComponentRefs())
+				else if (data.ContainsComponents(DataFormat.Value))
 				{
 					DragDropEffects effect;
 					if ((e.KeyState & 2) != 0)			// Right mouse button
@@ -1034,7 +1034,7 @@ namespace Duality.Editor.Plugins.SceneView
 					if (dropParent is GameObjectNode)
 					{
 						GameObject dropObj = (dropParent as GameObjectNode).Obj;
-						Component[] draggedObj = data.GetComponentRefs();
+						Component[] draggedObj = data.GetComponents(DataFormat.Value);
 						bool canDropHere = true;
 
 						canDropHere = canDropHere && draggedObj.All(c => dropObj.GetComponent(c.GetType()) == null);
@@ -1071,9 +1071,9 @@ namespace Duality.Editor.Plugins.SceneView
 			{
 				ConvertOperation convertOp = new ConvertOperation(data, ConvertOperation.Operation.All);
 				this.tempDropTarget = this.DragDropGetTargetNode();
-				if (data.ContainsGameObjectRefs())
+				if (data.ContainsGameObjects())
 				{
-					this.tempDropData = data.GetGameObjectRefs();
+					this.tempDropData = data.GetGameObjects();
 
 					// Display context menu if both moving and copying are availabled
 					if (effectMove && effectCopy)
@@ -1083,9 +1083,9 @@ namespace Duality.Editor.Plugins.SceneView
 					else if (effectMove)
 						this.moveHereToolStripMenuItem_Click(this, null);
 				}
-				else if (data.ContainsComponentRefs())
+				else if (data.ContainsComponents(DataFormat.Value))
 				{
-					this.tempDropData = data.GetComponentRefs();
+					this.tempDropData = data.GetComponents(DataFormat.Value);
 
 					// Display context menu if both moving and copying are availabled
 					if (effectMove && effectCopy)

--- a/Source/Plugins/EditorModules/SceneView/Modules/SceneView.cs
+++ b/Source/Plugins/EditorModules/SceneView/Modules/SceneView.cs
@@ -986,7 +986,9 @@ namespace Duality.Editor.Plugins.SceneView
 			if (data != null)
 			{
 				NodeBase dropParent = this.DragDropGetTargetNode();
-				if (data.ContainsGameObjects())
+				GameObject[] draggedObj;
+				Component[] draggedComp;
+				if (data.TryGetGameObjects(out draggedObj))
 				{
 					DragDropEffects effect;
 					if ((e.KeyState & 2) != 0)			// Right mouse button
@@ -1002,7 +1004,6 @@ namespace Duality.Editor.Plugins.SceneView
 					else if (dropParent is GameObjectNode)
 					{
 						GameObject dropObj = (dropParent as GameObjectNode).Obj;
-						GameObject[] draggedObj = data.GetGameObjects();
 						bool canDropHere = true;
 
 						// Can't drop in child of dragged objects
@@ -1020,7 +1021,7 @@ namespace Duality.Editor.Plugins.SceneView
 					else
 						e.Effect = DragDropEffects.None;
 				}
-				else if (data.ContainsComponents(DataFormat.Value))
+				else if (data.TryGetComponents(DataFormat.Value, out draggedComp))
 				{
 					DragDropEffects effect;
 					if ((e.KeyState & 2) != 0)			// Right mouse button
@@ -1034,11 +1035,10 @@ namespace Duality.Editor.Plugins.SceneView
 					if (dropParent is GameObjectNode)
 					{
 						GameObject dropObj = (dropParent as GameObjectNode).Obj;
-						Component[] draggedObj = data.GetComponents(DataFormat.Value);
 						bool canDropHere = true;
 
-						canDropHere = canDropHere && draggedObj.All(c => dropObj.GetComponent(c.GetType()) == null);
-						canDropHere = canDropHere && draggedObj.All(c => Component.RequireMap.IsRequirementMet(dropObj, c.GetType(), draggedObj.Select(d => d.GetType())));
+						canDropHere = canDropHere && draggedComp.All(c => dropObj.GetComponent(c.GetType()) == null);
+						canDropHere = canDropHere && draggedComp.All(c => Component.RequireMap.IsRequirementMet(dropObj, c.GetType(), draggedComp.Select(d => d.GetType())));
 
 						e.Effect = canDropHere ? effect : DragDropEffects.None;
 					}
@@ -1071,9 +1071,11 @@ namespace Duality.Editor.Plugins.SceneView
 			{
 				ConvertOperation convertOp = new ConvertOperation(data, ConvertOperation.Operation.All);
 				this.tempDropTarget = this.DragDropGetTargetNode();
-				if (data.ContainsGameObjects())
+				GameObject[] draggedObjects;
+				Component[] draggedComponents;
+				if (data.TryGetGameObjects(out draggedObjects))
 				{
-					this.tempDropData = data.GetGameObjects();
+					this.tempDropData = draggedObjects;
 
 					// Display context menu if both moving and copying are availabled
 					if (effectMove && effectCopy)
@@ -1083,9 +1085,9 @@ namespace Duality.Editor.Plugins.SceneView
 					else if (effectMove)
 						this.moveHereToolStripMenuItem_Click(this, null);
 				}
-				else if (data.ContainsComponents(DataFormat.Value))
+				else if (data.TryGetComponents(DataFormat.Value, out draggedComponents))
 				{
-					this.tempDropData = data.GetComponents(DataFormat.Value);
+					this.tempDropData = draggedComponents;
 
 					// Display context menu if both moving and copying are availabled
 					if (effectMove && effectCopy)

--- a/Source/Plugins/EditorModules/SceneView/Modules/SceneView.cs
+++ b/Source/Plugins/EditorModules/SceneView/Modules/SceneView.cs
@@ -1021,7 +1021,7 @@ namespace Duality.Editor.Plugins.SceneView
 					else
 						e.Effect = DragDropEffects.None;
 				}
-				else if (data.TryGetComponents(DataObjectStorage.Reference, out draggedComp))
+				else if (data.TryGetComponents(typeof(Component), DataObjectStorage.Reference, out draggedComp))
 				{
 					DragDropEffects effect;
 					if ((e.KeyState & 2) != 0)			// Right mouse button
@@ -1085,7 +1085,7 @@ namespace Duality.Editor.Plugins.SceneView
 					else if (effectMove)
 						this.moveHereToolStripMenuItem_Click(this, null);
 				}
-				else if (data.TryGetComponents(DataObjectStorage.Reference, out draggedComponents))
+				else if (data.TryGetComponents(typeof(Component), DataObjectStorage.Reference, out draggedComponents))
 				{
 					this.tempDropData = draggedComponents;
 

--- a/Source/Plugins/EditorModules/SceneView/Modules/SceneView.cs
+++ b/Source/Plugins/EditorModules/SceneView/Modules/SceneView.cs
@@ -1021,7 +1021,7 @@ namespace Duality.Editor.Plugins.SceneView
 					else
 						e.Effect = DragDropEffects.None;
 				}
-				else if (data.TryGetComponents(DataFormat.Value, out draggedComp))
+				else if (data.TryGetComponents(out draggedComp))
 				{
 					DragDropEffects effect;
 					if ((e.KeyState & 2) != 0)			// Right mouse button
@@ -1085,7 +1085,7 @@ namespace Duality.Editor.Plugins.SceneView
 					else if (effectMove)
 						this.moveHereToolStripMenuItem_Click(this, null);
 				}
-				else if (data.TryGetComponents(DataFormat.Value, out draggedComponents))
+				else if (data.TryGetComponents(out draggedComponents))
 				{
 					this.tempDropData = draggedComponents;
 

--- a/Source/Plugins/EditorModules/SceneView/Modules/SceneView.cs
+++ b/Source/Plugins/EditorModules/SceneView/Modules/SceneView.cs
@@ -988,7 +988,7 @@ namespace Duality.Editor.Plugins.SceneView
 				NodeBase dropParent = this.DragDropGetTargetNode();
 				GameObject[] draggedObj;
 				Component[] draggedComp;
-				if (data.TryGetGameObjects(out draggedObj))
+				if (data.TryGetGameObjects(DataObjectStorage.Reference, out draggedObj))
 				{
 					DragDropEffects effect;
 					if ((e.KeyState & 2) != 0)			// Right mouse button
@@ -1021,7 +1021,7 @@ namespace Duality.Editor.Plugins.SceneView
 					else
 						e.Effect = DragDropEffects.None;
 				}
-				else if (data.TryGetComponents(out draggedComp))
+				else if (data.TryGetComponents(DataObjectStorage.Reference, out draggedComp))
 				{
 					DragDropEffects effect;
 					if ((e.KeyState & 2) != 0)			// Right mouse button
@@ -1073,7 +1073,7 @@ namespace Duality.Editor.Plugins.SceneView
 				this.tempDropTarget = this.DragDropGetTargetNode();
 				GameObject[] draggedObjects;
 				Component[] draggedComponents;
-				if (data.TryGetGameObjects(out draggedObjects))
+				if (data.TryGetGameObjects(DataObjectStorage.Reference, out draggedObjects))
 				{
 					this.tempDropData = draggedObjects;
 
@@ -1085,7 +1085,7 @@ namespace Duality.Editor.Plugins.SceneView
 					else if (effectMove)
 						this.moveHereToolStripMenuItem_Click(this, null);
 				}
-				else if (data.TryGetComponents(out draggedComponents))
+				else if (data.TryGetComponents(DataObjectStorage.Reference, out draggedComponents))
 				{
 					this.tempDropData = draggedComponents;
 

--- a/Test/Editor/DualityEditorTests.csproj
+++ b/Test/Editor/DualityEditorTests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="PluginManager\MockEditorPlugin.cs" />
     <Compile Include="PluginManager\MockPluginLoader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utility\DataObjectExtensionsTest.cs" />
     <Compile Include="Utility\EventArgs\ObjectPropertyChangedEventArgsTest.cs" />
     <Compile Include="Utility\PathHelperTest.cs" />
   </ItemGroup>

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 
 namespace Duality.Editor.Tests
 {
-	[TestFixture, RequiresThread(ApartmentState.STA)]
+	[TestFixture]
 	public class DataObjectExtensionsTest
 	{
 		private class TestClass { }

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 
 namespace Duality.Editor.Tests
 {
-	[TestFixture]
+	[TestFixture, RequiresThread(ApartmentState.STA)]
 	public class DataObjectExtensionsTest
 	{
 		private class TestClass { }

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -2,7 +2,9 @@
 using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
+
 using Duality.Drawing;
+
 using NUnit.Framework;
 
 namespace Duality.Editor.Tests
@@ -10,17 +12,9 @@ namespace Duality.Editor.Tests
 	[TestFixture, RequiresThread(ApartmentState.STA)]
 	public class DataObjectExtensionsTest
 	{
-		private class TestClass
-		{
-		}
-
-		private class TestComponent : Component
-		{
-		}
-
-		private class TestResource : Resource
-		{
-		}
+		private class TestClass { }
+		private class TestComponent : Component { }
+		private class TestResource : Resource { }
 
 		[Test] public void WrappedDataReference()
 		{
@@ -32,17 +26,13 @@ namespace Duality.Editor.Tests
 
 			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Reference));
 			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value));
-			Assert.IsFalse(dataIn.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value, false));
 			Assert.AreSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Reference).First());
 			Assert.AreNotSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Value).First());
-			Assert.IsNull(dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Value, false));
 
 			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsFalse(dataIn.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, false, out outParam));
-			Assert.IsNull(outParam);
 			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
 			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataObjectStorage.Value, out outParam));
@@ -53,23 +43,18 @@ namespace Duality.Editor.Tests
 
 			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Reference));
 			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value));
-			Assert.IsFalse(dataOut.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value, false));
 			Assert.AreSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataObjectStorage.Reference).First());
 			Assert.AreNotSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataObjectStorage.Value).First());
-			Assert.IsNull(dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Value, false));
 
 			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsFalse(dataOut.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, false, out outParam));
-			Assert.IsNull(outParam);
 			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
 			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataObjectStorage.Value, out outParam));
 			Assert.IsNull(outParam);
 		}
-
 		[Test] public void WrappedDataValue()
 		{
 			DataObject dataIn = new DataObject();
@@ -80,17 +65,13 @@ namespace Duality.Editor.Tests
 
 			Assert.IsFalse(dataIn.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Reference));
 			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value));
-			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value, false));
 			Assert.IsNull(dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Reference));
 			// Even though we are retrieving a value, serialization has not occured yet
 			Assert.AreSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Value).First());
-			Assert.AreSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Value, false).First());
 
 			Assert.IsFalse(dataIn.TryGetWrappedData("CorrectFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
 			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, out outParam));
-			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, false, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
@@ -102,17 +83,13 @@ namespace Duality.Editor.Tests
 
 			Assert.IsFalse(dataOut.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Reference));
 			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value));
-			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value, false));
 			Assert.IsNull(dataOut.GetWrappedData("CorrectFormat", DataObjectStorage.Reference));
 			// DeepClone should have been done by now
 			Assert.AreNotSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataObjectStorage.Value).First());
-			Assert.AreNotSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataObjectStorage.Value, false).First());
 
 			Assert.IsFalse(dataOut.TryGetWrappedData("CorrectFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
 			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, out outParam));
-			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, false, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
@@ -214,7 +191,6 @@ namespace Duality.Editor.Tests
 			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
 		}
-
 		[Test] public void GetComponentStronglyTyped()
 		{
 			DataObject dataIn = new DataObject();
@@ -275,7 +251,6 @@ namespace Duality.Editor.Tests
 			// TestResource will not survive serialization.
 			Assert.IsFalse(dataOut.ContainsContentRefs(typeof(TestResource)));
 		}
-
 		[Test] public void GetContentRefsStronglyTyped()
 		{
 			DataObject dataIn = new DataObject();
@@ -336,7 +311,6 @@ namespace Duality.Editor.Tests
 			Assert.AreEqual(color, dataOut.GetIColorData<ColorRgba>()[0]);
 			Assert.AreEqual(color.ConvertTo<ColorHsva>(), dataOut.GetIColorData<ColorHsva>()[0]);
 		}
-
 		[Test] public void GetIColorDataString()
 		{
 			DataObject dataIn = new DataObject();

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -145,13 +145,9 @@ namespace Duality.Editor.Tests
 
 			Assert.IsTrue(dataIn.ContainsComponents(typeof(TestComponent), DataObjectStorage.Reference));
 			Assert.IsTrue(dataIn.ContainsComponents(typeof(TestComponent), DataObjectStorage.Value));
-			Assert.AreSame(comp, dataIn.GetComponents(DataObjectStorage.Reference)[0]);
-			Assert.AreNotSame(comp, dataIn.GetComponents(DataObjectStorage.Value)[0]);
+			Assert.AreSame(comp, dataIn.GetComponents(typeof(TestComponent), DataObjectStorage.Reference)[0]);
+			Assert.AreNotSame(comp, dataIn.GetComponents(typeof(TestComponent), DataObjectStorage.Value)[0]);
 
-			Assert.IsTrue(dataIn.TryGetComponents(DataObjectStorage.Reference, out outParam));
-			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents(DataObjectStorage.Value, out outParam));
-			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), DataObjectStorage.Value, out outParam));
@@ -163,13 +159,9 @@ namespace Duality.Editor.Tests
 
 			Assert.IsTrue(dataOut.ContainsComponents(typeof(TestComponent), DataObjectStorage.Reference));
 			Assert.IsTrue(dataOut.ContainsComponents(typeof(TestComponent), DataObjectStorage.Value));
-			Assert.AreSame(comp, dataOut.GetComponents(DataObjectStorage.Reference)[0]);
-			Assert.AreNotSame(comp, dataOut.GetComponents(DataObjectStorage.Value)[0]);
+			Assert.AreSame(comp, dataOut.GetComponents(typeof(TestComponent), DataObjectStorage.Reference)[0]);
+			Assert.AreNotSame(comp, dataOut.GetComponents(typeof(TestComponent), DataObjectStorage.Value)[0]);
 
-			Assert.IsTrue(dataOut.TryGetComponents(DataObjectStorage.Reference, out outParam));
-			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetComponents(DataObjectStorage.Value, out outParam));
-			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataObjectStorage.Value, out outParam));
@@ -198,26 +190,6 @@ namespace Duality.Editor.Tests
 			// This is false due to the fact that the reference to the locally created
 			// TestResource will not survive serialization.
 			Assert.IsFalse(dataOut.ContainsContentRefs(typeof(TestResource)));
-		}
-		[Test] public void GetContentRefsStronglyTyped()
-		{
-			DataObject dataIn = new DataObject();
-			TestResource res = new TestResource();
-			ContentRef<TestResource> contentRef = new ContentRef<TestResource>(res);
-
-			dataIn.SetContentRefs(new IContentRef[] { contentRef });
-
-			Assert.IsTrue(dataIn.ContainsContentRefs<TestResource>());
-
-			Assert.AreEqual(contentRef, dataIn.GetContentRefs<TestResource>()[0]);
-
-			Clipboard.SetDataObject(dataIn);
-
-			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
-
-			// This is false due to the fact that the reference to the locally created
-			// TestResource will not survive serialization.
-			Assert.IsFalse(dataOut.ContainsContentRefs<TestResource>());
 		}
 
 		[Test] public void GetBatchInfo()

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -134,7 +134,6 @@ namespace Duality.Editor.Tests
 			Assert.IsTrue(dataOut.TryGetGameObjects(DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
 		}
-
 		[Test] public void GetComponents()
 		{
 			DataObject dataIn = new DataObject();
@@ -165,7 +164,6 @@ namespace Duality.Editor.Tests
 			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
 		}
-
 		[Test] public void GetContentRefs()
 		{
 			DataObject dataIn = new DataObject();
@@ -187,7 +185,6 @@ namespace Duality.Editor.Tests
 			// TestResource will not survive serialization.
 			Assert.IsFalse(dataOut.ContainsContentRefs(typeof(TestResource)));
 		}
-
 		[Test] public void GetBatchInfo()
 		{
 			DataObject dataIn = new DataObject();
@@ -203,7 +200,6 @@ namespace Duality.Editor.Tests
 			Assert.IsTrue(dataOut.ContainsBatchInfos());
 			Assert.AreNotSame(batch, dataOut.GetBatchInfos()[0]);
 		}
-
 		[Test] public void GetIColorData()
 		{
 			DataObject dataIn = new DataObject();
@@ -248,7 +244,6 @@ namespace Duality.Editor.Tests
 			Assert.IsFalse(dataWrongForm.ContainsIColorData());
 			Assert.IsNull(dataWrongForm.GetIColorData<ColorRgba>());
 		}
-
 		[Test] public void GetString()
 		{
 			DataObject nullData = new DataObject();

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -15,12 +15,19 @@ namespace Duality.Editor.Tests
 		{
 		}
 
-		[Test] public void GetGameObjectAfterClipboard()
+		[Test] public void GetGameObjects()
 		{
 			DataObject dataIn = new DataObject();
 			GameObject gameObject = new GameObject();
 
 			dataIn.SetGameObjects(new [] { gameObject });
+
+			Assert.IsTrue(dataIn.ContainsGameObjects(DataFormat.Reference));
+			Assert.IsTrue(dataIn.ContainsGameObjects(DataFormat.Value));
+
+			Assert.AreSame(gameObject, dataIn.GetGameObjects(DataFormat.Reference)[0]);
+			Assert.AreNotSame(gameObject, dataIn.GetGameObjects(DataFormat.Value)[0]);
+
 			Clipboard.SetDataObject(dataIn);
 
 			DataObject dataOut = (DataObject) Clipboard.GetDataObject();
@@ -32,12 +39,19 @@ namespace Duality.Editor.Tests
 			Assert.AreNotSame(gameObject, dataOut.GetGameObjects(DataFormat.Value)[0]);
 		}
 
-		[Test] public void GetComponentAfterClipboard()
+		[Test] public void GetComponents()
 		{
 			DataObject dataIn = new DataObject();
 			TestComponent comp = new TestComponent();
 
 			dataIn.SetComponents(new[] { comp });
+
+			Assert.IsTrue(dataIn.ContainsComponents(DataFormat.Reference));
+			Assert.IsTrue(dataIn.ContainsComponents(DataFormat.Value));
+
+			Assert.AreSame(comp, dataIn.GetComponents(DataFormat.Reference)[0]);
+			Assert.AreNotSame(comp, dataIn.GetComponents(DataFormat.Value)[0]);
+
 			Clipboard.SetDataObject(dataIn);
 
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
@@ -49,12 +63,19 @@ namespace Duality.Editor.Tests
 			Assert.AreNotSame(comp, dataOut.GetComponents(DataFormat.Value)[0]);
 		}
 
-		[Test] public void GetComponentAfterClipboardStronglyTyped()
+		[Test] public void GetComponentStronglyTyped()
 		{
 			DataObject dataIn = new DataObject();
 			TestComponent comp = new TestComponent();
 
 			dataIn.SetComponents(new[] { comp });
+
+			Assert.IsTrue(dataIn.ContainsComponents<TestComponent>(DataFormat.Reference));
+			Assert.IsTrue(dataIn.ContainsComponents<TestComponent>(DataFormat.Value));
+
+			Assert.AreSame(comp, dataIn.GetComponents<TestComponent>(DataFormat.Reference)[0]);
+			Assert.AreNotSame(comp, dataIn.GetComponents<TestComponent>(DataFormat.Value)[0]);
+
 			Clipboard.SetDataObject(dataIn);
 
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Windows.Forms;
 using Duality.Drawing;
 using NUnit.Framework;
@@ -24,22 +26,22 @@ namespace Duality.Editor.Tests
 		{
 			DataObject dataIn = new DataObject();
 			TestClass dataOne = new TestClass();
-			object[] outParam;
+			IEnumerable<object> outParam;
 
-			dataIn.SetWrappedData(new [] { dataOne }, DataFormat.Reference);
+			dataIn.SetWrappedData(new [] { dataOne }, typeof(TestClass), DataFormat.Reference);
 
-			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Reference));
-			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value));
-			Assert.IsFalse(dataIn.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value, false));
-			Assert.AreSame(dataOne, dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Reference)[0]);
-			Assert.AreNotSame(dataOne, dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value)[0]);
-			Assert.IsNull(dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value, false));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass), DataFormat.Reference));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value));
+			Assert.IsFalse(dataIn.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value, false));
+			Assert.AreSame(dataOne, dataIn.GetWrappedData(typeof(TestClass), DataFormat.Reference).First());
+			Assert.AreNotSame(dataOne, dataIn.GetWrappedData(typeof(TestClass), DataFormat.Value).First());
+			Assert.IsNull(dataIn.GetWrappedData(typeof(TestClass), DataFormat.Value, false));
 
-			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass[]), DataFormat.Reference, out outParam));
+			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass), DataFormat.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass), DataFormat.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, false, out outParam));
+			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(TestClass), DataFormat.Value, false, out outParam));
 			Assert.IsNull(outParam);
 			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(object), DataFormat.Reference, out outParam));
 			Assert.IsNull(outParam);
@@ -49,18 +51,18 @@ namespace Duality.Editor.Tests
 			Clipboard.SetDataObject(dataIn);
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
 
-			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Reference));
-			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value));
-			Assert.IsFalse(dataOut.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value, false));
-			Assert.AreSame(dataOne, dataOut.GetWrappedData(typeof(TestClass[]), DataFormat.Reference)[0]);
-			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass[]), DataFormat.Value)[0]);
-			Assert.IsNull(dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value, false));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass), DataFormat.Reference));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value));
+			Assert.IsFalse(dataOut.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value, false));
+			Assert.AreSame(dataOne, dataOut.GetWrappedData(typeof(TestClass), DataFormat.Reference).First());
+			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass), DataFormat.Value).First());
+			Assert.IsNull(dataIn.GetWrappedData(typeof(TestClass), DataFormat.Value, false));
 
-			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass[]), DataFormat.Reference, out outParam));
+			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass), DataFormat.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, out outParam));
+			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass), DataFormat.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, false, out outParam));
+			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(TestClass), DataFormat.Value, false, out outParam));
 			Assert.IsNull(outParam);
 			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(object), DataFormat.Reference, out outParam));
 			Assert.IsNull(outParam);
@@ -72,23 +74,23 @@ namespace Duality.Editor.Tests
 		{
 			DataObject dataIn = new DataObject();
 			TestClass dataOne = new TestClass();
-			object[] outParam;
+			IEnumerable<object> outParam;
 
-			dataIn.SetWrappedData(new[] { dataOne }, DataFormat.Value);
+			dataIn.SetWrappedData(new[] { dataOne }, typeof(TestClass), DataFormat.Value);
 
-			Assert.IsFalse(dataIn.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Reference));
-			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value));
-			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value, false));
-			Assert.IsNull(dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Reference));
+			Assert.IsFalse(dataIn.GetWrappedDataPresent(typeof(TestClass), DataFormat.Reference));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value, false));
+			Assert.IsNull(dataIn.GetWrappedData(typeof(TestClass), DataFormat.Reference));
 			// Even though we are retrieving a value, serialization has not occured yet
-			Assert.AreSame(dataOne, dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value)[0]);
-			Assert.AreSame(dataOne, dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value, false)[0]);
+			Assert.AreSame(dataOne, dataIn.GetWrappedData(typeof(TestClass), DataFormat.Value).First());
+			Assert.AreSame(dataOne, dataIn.GetWrappedData(typeof(TestClass), DataFormat.Value, false).First());
 
-			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(TestClass[]), DataFormat.Reference, out outParam));
+			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(TestClass), DataFormat.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass), DataFormat.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, false, out outParam));
+			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass), DataFormat.Value, false, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(object), DataFormat.Reference, out outParam));
 			Assert.IsNull(outParam);
@@ -98,19 +100,19 @@ namespace Duality.Editor.Tests
 			Clipboard.SetDataObject(dataIn);
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
 
-			Assert.IsFalse(dataOut.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Reference));
-			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value));
-			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value, false));
-			Assert.IsNull(dataOut.GetWrappedData(typeof(TestClass[]), DataFormat.Reference));
+			Assert.IsFalse(dataOut.GetWrappedDataPresent(typeof(TestClass), DataFormat.Reference));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value, false));
+			Assert.IsNull(dataOut.GetWrappedData(typeof(TestClass), DataFormat.Reference));
 			// DeepClone should have been done by now
-			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass[]), DataFormat.Value)[0]);
-			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass[]), DataFormat.Value, false)[0]);
+			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass), DataFormat.Value).First());
+			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass), DataFormat.Value, false).First());
 
-			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(TestClass[]), DataFormat.Reference, out outParam));
+			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(TestClass), DataFormat.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, out outParam));
+			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass), DataFormat.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, false, out outParam));
+			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass), DataFormat.Value, false, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(object), DataFormat.Reference, out outParam));
 			Assert.IsNull(outParam);

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -1,10 +1,11 @@
-﻿using System.Windows.Forms;
+﻿using System.Threading;
+using System.Windows.Forms;
 using Duality.Drawing;
 using NUnit.Framework;
 
 namespace Duality.Editor.Tests
 {
-	[TestFixture]
+	[TestFixture, RequiresThread(ApartmentState.STA)]
 	public class DataObjectExtensionsTest
 	{
 		private class TestClass

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -15,6 +15,10 @@ namespace Duality.Editor.Tests
 		{
 		}
 
+		private class TestResource : Resource
+		{
+		}
+
 		[Test] public void GetGameObjects()
 		{
 			DataObject dataIn = new DataObject();
@@ -85,6 +89,52 @@ namespace Duality.Editor.Tests
 
 			Assert.AreSame(comp, dataOut.GetComponents<TestComponent>(DataFormat.Reference)[0]);
 			Assert.AreNotSame(comp, dataOut.GetComponents<TestComponent>(DataFormat.Value)[0]);
+		}
+
+		[Test] public void GetContentRefs()
+		{
+			DataObject dataIn = new DataObject();
+			TestResource res = new TestResource();
+			ContentRef<TestResource> contentRef = new ContentRef<TestResource>(res);
+
+			dataIn.SetContentRefs(new IContentRef[] { contentRef });
+
+			Assert.IsTrue(dataIn.ContainsContentRefs());
+			Assert.IsTrue(dataIn.ContainsContentRefs(typeof(TestResource)));
+
+			Assert.AreEqual(contentRef, dataIn.GetContentRefs()[0]);
+			Assert.AreEqual(contentRef, dataIn.GetContentRefs(typeof(TestResource))[0]);
+
+			Clipboard.SetDataObject(dataIn);
+
+			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
+
+			Assert.IsTrue(dataOut.ContainsContentRefs());
+
+			// This is false due to the fact that the reference to the locally created
+			// TestResource will not survive serialization.
+			Assert.IsFalse(dataOut.ContainsContentRefs(typeof(TestResource)));
+		}
+
+		[Test] public void GetContentRefsStronglyTyped()
+		{
+			DataObject dataIn = new DataObject();
+			TestResource res = new TestResource();
+			ContentRef<TestResource> contentRef = new ContentRef<TestResource>(res);
+
+			dataIn.SetContentRefs(new IContentRef[] { contentRef });
+
+			Assert.IsTrue(dataIn.ContainsContentRefs<TestResource>());
+
+			Assert.AreEqual(contentRef, dataIn.GetContentRefs<TestResource>()[0]);
+
+			Clipboard.SetDataObject(dataIn);
+
+			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
+
+			// This is false due to the fact that the reference to the locally created
+			// TestResource will not survive serialization.
+			Assert.IsFalse(dataOut.ContainsContentRefs<TestResource>());
 		}
 	}
 }

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -18,7 +18,7 @@ namespace Duality.Editor.Tests
 		[Test] public void GetGameObjectAfterClipboard()
 		{
 			DataObject dataIn = new DataObject();
-			GameObject gameObject = new GameObject("a");
+			GameObject gameObject = new GameObject();
 
 			dataIn.SetGameObjects(new [] { gameObject });
 			Clipboard.SetDataObject(dataIn);
@@ -32,8 +32,7 @@ namespace Duality.Editor.Tests
 			Assert.AreNotSame(gameObject, dataOut.GetGameObjects(DataFormat.Value)[0]);
 		}
 
-		[Test]
-		public void GetComponentAfterClipboard()
+		[Test] public void GetComponentAfterClipboard()
 		{
 			DataObject dataIn = new DataObject();
 			TestComponent comp = new TestComponent();
@@ -50,8 +49,7 @@ namespace Duality.Editor.Tests
 			Assert.AreNotSame(comp, dataOut.GetComponents(DataFormat.Value)[0]);
 		}
 
-		[Test]
-		public void GetComponentAfterClipboardStronglyTyped()
+		[Test] public void GetComponentAfterClipboardStronglyTyped()
 		{
 			DataObject dataIn = new DataObject();
 			TestComponent comp = new TestComponent();

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -111,14 +111,10 @@ namespace Duality.Editor.Tests
 			Assert.IsFalse(nullData.ContainsGameObjects(DataObjectStorage.Reference));
 			Assert.IsFalse(nullData.ContainsGameObjects(DataObjectStorage.Value));
 
-			Assert.IsTrue(dataIn.TryGetGameObjects(out outParam));
-			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataIn.TryGetGameObjects(DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataIn.TryGetGameObjects(DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsFalse(nullData.TryGetGameObjects(out outParam));
-			Assert.IsNull(outParam);
 			Assert.IsFalse(nullData.TryGetGameObjects(DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
 			Assert.IsFalse(nullData.TryGetGameObjects(DataObjectStorage.Value, out outParam));
@@ -133,8 +129,6 @@ namespace Duality.Editor.Tests
 			Assert.AreSame(gameObject, dataOut.GetGameObjects(DataObjectStorage.Reference)[0]);
 			Assert.AreNotSame(gameObject, dataOut.GetGameObjects(DataObjectStorage.Value)[0]);
 
-			Assert.IsTrue(dataOut.TryGetGameObjects(out outParam));
-			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataOut.TryGetGameObjects(DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataOut.TryGetGameObjects(DataObjectStorage.Value, out outParam));
@@ -149,15 +143,11 @@ namespace Duality.Editor.Tests
 
 			dataIn.SetComponents(new[] { comp });
 
-			Assert.IsTrue(dataIn.ContainsComponents(DataObjectStorage.Reference));
-			Assert.IsTrue(dataIn.ContainsComponents(DataObjectStorage.Value));
+			Assert.IsTrue(dataIn.ContainsComponents(typeof(TestComponent), DataObjectStorage.Reference));
+			Assert.IsTrue(dataIn.ContainsComponents(typeof(TestComponent), DataObjectStorage.Value));
 			Assert.AreSame(comp, dataIn.GetComponents(DataObjectStorage.Reference)[0]);
 			Assert.AreNotSame(comp, dataIn.GetComponents(DataObjectStorage.Value)[0]);
 
-			Assert.IsTrue(dataIn.TryGetComponents(out outParam));
-			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), out outParam));
-			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataIn.TryGetComponents(DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataIn.TryGetComponents(DataObjectStorage.Value, out outParam));
@@ -171,15 +161,11 @@ namespace Duality.Editor.Tests
 
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
 
-			Assert.IsTrue(dataOut.ContainsComponents(DataObjectStorage.Reference));
-			Assert.IsTrue(dataOut.ContainsComponents(DataObjectStorage.Value));
+			Assert.IsTrue(dataOut.ContainsComponents(typeof(TestComponent), DataObjectStorage.Reference));
+			Assert.IsTrue(dataOut.ContainsComponents(typeof(TestComponent), DataObjectStorage.Value));
 			Assert.AreSame(comp, dataOut.GetComponents(DataObjectStorage.Reference)[0]);
 			Assert.AreNotSame(comp, dataOut.GetComponents(DataObjectStorage.Value)[0]);
 
-			Assert.IsTrue(dataOut.TryGetComponents(out outParam));
-			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), out outParam));
-			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataOut.TryGetComponents(DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataOut.TryGetComponents(DataObjectStorage.Value, out outParam));
@@ -187,42 +173,6 @@ namespace Duality.Editor.Tests
 			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataObjectStorage.Value, out outParam));
-			Assert.IsNotNull(outParam);
-		}
-		[Test] public void GetComponentStronglyTyped()
-		{
-			DataObject dataIn = new DataObject();
-			TestComponent comp = new TestComponent();
-			TestComponent[] outParam;
-
-			dataIn.SetComponents(new[] { comp });
-
-			Assert.IsTrue(dataIn.ContainsComponents<TestComponent>(DataObjectStorage.Reference));
-			Assert.IsTrue(dataIn.ContainsComponents<TestComponent>(DataObjectStorage.Value));
-			Assert.AreSame(comp, dataIn.GetComponents<TestComponent>(DataObjectStorage.Reference)[0]);
-			Assert.AreNotSame(comp, dataIn.GetComponents<TestComponent>(DataObjectStorage.Value)[0]);
-
-			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(out outParam));
-			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataObjectStorage.Reference, out outParam));
-			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataObjectStorage.Value, out outParam));
-			Assert.IsNotNull(outParam);
-
-			Clipboard.SetDataObject(dataIn);
-
-			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
-
-			Assert.IsTrue(dataOut.ContainsComponents<TestComponent>(DataObjectStorage.Reference));
-			Assert.IsTrue(dataOut.ContainsComponents<TestComponent>(DataObjectStorage.Value));
-			Assert.AreSame(comp, dataOut.GetComponents<TestComponent>(DataObjectStorage.Reference)[0]);
-			Assert.AreNotSame(comp, dataOut.GetComponents<TestComponent>(DataObjectStorage.Value)[0]);
-
-			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(out outParam));
-			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataObjectStorage.Reference, out outParam));
-			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
 		}
 

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -7,12 +7,68 @@ namespace Duality.Editor.Tests
 	[TestFixture]
 	public class DataObjectExtensionsTest
 	{
+		private class TestClass
+		{
+		}
+
 		private class TestComponent : Component
 		{
 		}
 
 		private class TestResource : Resource
 		{
+		}
+
+		[Test] public void WrappedDataReference()
+		{
+			DataObject dataIn = new DataObject();
+			TestClass dataOne = new TestClass();
+
+			dataIn.SetWrappedData(new [] { dataOne }, DataFormat.Reference);
+
+			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Reference));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value));
+			Assert.IsFalse(dataIn.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value, false));
+			Assert.AreSame(dataOne, dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Reference)[0]);
+			Assert.AreNotSame(dataOne, dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value)[0]);
+			Assert.IsNull(dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value, false));
+
+			Clipboard.SetDataObject(dataIn);
+			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
+
+			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Reference));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value));
+			Assert.IsFalse(dataOut.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value, false));
+			Assert.AreSame(dataOne, dataOut.GetWrappedData(typeof(TestClass[]), DataFormat.Reference)[0]);
+			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass[]), DataFormat.Value)[0]);
+			Assert.IsNull(dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value, false));
+		}
+
+		[Test] public void WrappedDataValue()
+		{
+			DataObject dataIn = new DataObject();
+			TestClass dataOne = new TestClass();
+
+			dataIn.SetWrappedData(new[] { dataOne }, DataFormat.Value);
+
+			Assert.IsFalse(dataIn.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Reference));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value, false));
+			Assert.IsNull(dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Reference));
+			// Even though we are retrieving a value, serialization has not occured yet
+			Assert.AreSame(dataOne, dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value)[0]);
+			Assert.AreSame(dataOne, dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value, false)[0]);
+
+			Clipboard.SetDataObject(dataIn);
+			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
+
+			Assert.IsFalse(dataOut.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Reference));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass[]), DataFormat.Value, false));
+			Assert.IsNull(dataOut.GetWrappedData(typeof(TestClass[]), DataFormat.Reference));
+			// DeepClone should have been done by now
+			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass[]), DataFormat.Value)[0]);
+			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass[]), DataFormat.Value, false)[0]);
 		}
 
 		[Test] public void GetGameObjects()

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using NUnit.Framework;
+
+namespace Duality.Editor.Tests
+{
+	[TestFixture]
+	public class DataObjectExtensionsTest
+	{
+		private class TestComponent : Component
+		{
+		}
+
+		[Test] public void GetGameObjectAfterClipboard()
+		{
+			DataObject dataIn = new DataObject();
+			GameObject gameObject = new GameObject("a");
+
+			dataIn.SetGameObjects(new [] { gameObject });
+			Clipboard.SetDataObject(dataIn);
+
+			DataObject dataOut = (DataObject) Clipboard.GetDataObject();
+
+			Assert.IsTrue(dataOut.ContainsGameObjects(DataFormat.Reference));
+			Assert.IsTrue(dataOut.ContainsGameObjects(DataFormat.Value));
+
+			Assert.AreSame(gameObject, dataOut.GetGameObjects(DataFormat.Reference)[0]);
+			Assert.AreNotSame(gameObject, dataOut.GetGameObjects(DataFormat.Value)[0]);
+		}
+
+		[Test]
+		public void GetComponentAfterClipboard()
+		{
+			DataObject dataIn = new DataObject();
+			TestComponent comp = new TestComponent();
+
+			dataIn.SetComponents(new[] { comp });
+			Clipboard.SetDataObject(dataIn);
+
+			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
+
+			Assert.IsTrue(dataOut.ContainsComponents(DataFormat.Reference));
+			Assert.IsTrue(dataOut.ContainsComponents(DataFormat.Value));
+
+			Assert.AreSame(comp, dataOut.GetComponents(DataFormat.Reference)[0]);
+			Assert.AreNotSame(comp, dataOut.GetComponents(DataFormat.Value)[0]);
+		}
+
+		[Test]
+		public void GetComponentAfterClipboardStronglyTyped()
+		{
+			DataObject dataIn = new DataObject();
+			TestComponent comp = new TestComponent();
+
+			dataIn.SetComponents(new[] { comp });
+			Clipboard.SetDataObject(dataIn);
+
+			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
+
+			Assert.IsTrue(dataOut.ContainsComponents<TestComponent>(DataFormat.Reference));
+			Assert.IsTrue(dataOut.ContainsComponents<TestComponent>(DataFormat.Value));
+
+			Assert.AreSame(comp, dataOut.GetComponents<TestComponent>(DataFormat.Reference)[0]);
+			Assert.AreNotSame(comp, dataOut.GetComponents<TestComponent>(DataFormat.Value)[0]);
+		}
+	}
+}

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -23,6 +23,7 @@ namespace Duality.Editor.Tests
 		{
 			DataObject dataIn = new DataObject();
 			TestClass dataOne = new TestClass();
+			object[] outParam;
 
 			dataIn.SetWrappedData(new [] { dataOne }, DataFormat.Reference);
 
@@ -33,6 +34,17 @@ namespace Duality.Editor.Tests
 			Assert.AreNotSame(dataOne, dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value)[0]);
 			Assert.IsNull(dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value, false));
 
+			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass[]), DataFormat.Reference, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, false, out outParam));
+			Assert.IsNull(outParam);
+			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(object), DataFormat.Reference, out outParam));
+			Assert.IsNull(outParam);
+			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(object), DataFormat.Value, out outParam));
+			Assert.IsNull(outParam);
+
 			Clipboard.SetDataObject(dataIn);
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
 
@@ -42,12 +54,24 @@ namespace Duality.Editor.Tests
 			Assert.AreSame(dataOne, dataOut.GetWrappedData(typeof(TestClass[]), DataFormat.Reference)[0]);
 			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass[]), DataFormat.Value)[0]);
 			Assert.IsNull(dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value, false));
+
+			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass[]), DataFormat.Reference, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, false, out outParam));
+			Assert.IsNull(outParam);
+			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(object), DataFormat.Reference, out outParam));
+			Assert.IsNull(outParam);
+			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(object), DataFormat.Value, out outParam));
+			Assert.IsNull(outParam);
 		}
 
 		[Test] public void WrappedDataValue()
 		{
 			DataObject dataIn = new DataObject();
 			TestClass dataOne = new TestClass();
+			object[] outParam;
 
 			dataIn.SetWrappedData(new[] { dataOne }, DataFormat.Value);
 
@@ -59,6 +83,17 @@ namespace Duality.Editor.Tests
 			Assert.AreSame(dataOne, dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value)[0]);
 			Assert.AreSame(dataOne, dataIn.GetWrappedData(typeof(TestClass[]), DataFormat.Value, false)[0]);
 
+			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(TestClass[]), DataFormat.Reference, out outParam));
+			Assert.IsNull(outParam);
+			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, false, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(object), DataFormat.Reference, out outParam));
+			Assert.IsNull(outParam);
+			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(object), DataFormat.Value, out outParam));
+			Assert.IsNull(outParam);
+
 			Clipboard.SetDataObject(dataIn);
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
 
@@ -69,20 +104,47 @@ namespace Duality.Editor.Tests
 			// DeepClone should have been done by now
 			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass[]), DataFormat.Value)[0]);
 			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass[]), DataFormat.Value, false)[0]);
+
+			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(TestClass[]), DataFormat.Reference, out outParam));
+			Assert.IsNull(outParam);
+			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass[]), DataFormat.Value, false, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(object), DataFormat.Reference, out outParam));
+			Assert.IsNull(outParam);
+			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(object), DataFormat.Value, out outParam));
+			Assert.IsNull(outParam);
 		}
 
 		[Test] public void GetGameObjects()
 		{
+			DataObject nullData = new DataObject();
 			DataObject dataIn = new DataObject();
 			GameObject gameObject = new GameObject();
+			GameObject[] outParam;
 
 			dataIn.SetGameObjects(new [] { gameObject });
 
 			Assert.IsTrue(dataIn.ContainsGameObjects(DataFormat.Reference));
 			Assert.IsTrue(dataIn.ContainsGameObjects(DataFormat.Value));
-
 			Assert.AreSame(gameObject, dataIn.GetGameObjects(DataFormat.Reference)[0]);
 			Assert.AreNotSame(gameObject, dataIn.GetGameObjects(DataFormat.Value)[0]);
+			Assert.IsFalse(nullData.ContainsGameObjects(DataFormat.Reference));
+			Assert.IsFalse(nullData.ContainsGameObjects(DataFormat.Value));
+
+			Assert.IsTrue(dataIn.TryGetGameObjects(out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataIn.TryGetGameObjects(DataFormat.Reference, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataIn.TryGetGameObjects(DataFormat.Value, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsFalse(nullData.TryGetGameObjects(out outParam));
+			Assert.IsNull(outParam);
+			Assert.IsFalse(nullData.TryGetGameObjects(DataFormat.Reference, out outParam));
+			Assert.IsNull(outParam);
+			Assert.IsFalse(nullData.TryGetGameObjects(DataFormat.Value, out outParam));
+			Assert.IsNull(outParam);
 
 			Clipboard.SetDataObject(dataIn);
 
@@ -90,23 +152,42 @@ namespace Duality.Editor.Tests
 
 			Assert.IsTrue(dataOut.ContainsGameObjects(DataFormat.Reference));
 			Assert.IsTrue(dataOut.ContainsGameObjects(DataFormat.Value));
-
 			Assert.AreSame(gameObject, dataOut.GetGameObjects(DataFormat.Reference)[0]);
 			Assert.AreNotSame(gameObject, dataOut.GetGameObjects(DataFormat.Value)[0]);
+
+			Assert.IsTrue(dataOut.TryGetGameObjects(out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataOut.TryGetGameObjects(DataFormat.Reference, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataOut.TryGetGameObjects(DataFormat.Value, out outParam));
+			Assert.IsNotNull(outParam);
 		}
 
 		[Test] public void GetComponents()
 		{
 			DataObject dataIn = new DataObject();
 			TestComponent comp = new TestComponent();
+			Component[] outParam;
 
 			dataIn.SetComponents(new[] { comp });
 
 			Assert.IsTrue(dataIn.ContainsComponents(DataFormat.Reference));
 			Assert.IsTrue(dataIn.ContainsComponents(DataFormat.Value));
-
 			Assert.AreSame(comp, dataIn.GetComponents(DataFormat.Reference)[0]);
 			Assert.AreNotSame(comp, dataIn.GetComponents(DataFormat.Value)[0]);
+
+			Assert.IsTrue(dataIn.TryGetComponents(out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataIn.TryGetComponents(DataFormat.Reference, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataIn.TryGetComponents(DataFormat.Value, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), DataFormat.Reference, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), DataFormat.Value, out outParam));
+			Assert.IsNotNull(outParam);
 
 			Clipboard.SetDataObject(dataIn);
 
@@ -114,23 +195,42 @@ namespace Duality.Editor.Tests
 
 			Assert.IsTrue(dataOut.ContainsComponents(DataFormat.Reference));
 			Assert.IsTrue(dataOut.ContainsComponents(DataFormat.Value));
-
 			Assert.AreSame(comp, dataOut.GetComponents(DataFormat.Reference)[0]);
 			Assert.AreNotSame(comp, dataOut.GetComponents(DataFormat.Value)[0]);
+
+			Assert.IsTrue(dataOut.TryGetComponents(out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataOut.TryGetComponents(DataFormat.Reference, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataOut.TryGetComponents(DataFormat.Value, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataFormat.Reference, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataFormat.Value, out outParam));
+			Assert.IsNotNull(outParam);
 		}
 
 		[Test] public void GetComponentStronglyTyped()
 		{
 			DataObject dataIn = new DataObject();
 			TestComponent comp = new TestComponent();
+			TestComponent[] outParam;
 
 			dataIn.SetComponents(new[] { comp });
 
 			Assert.IsTrue(dataIn.ContainsComponents<TestComponent>(DataFormat.Reference));
 			Assert.IsTrue(dataIn.ContainsComponents<TestComponent>(DataFormat.Value));
-
 			Assert.AreSame(comp, dataIn.GetComponents<TestComponent>(DataFormat.Reference)[0]);
 			Assert.AreNotSame(comp, dataIn.GetComponents<TestComponent>(DataFormat.Value)[0]);
+
+			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataFormat.Reference, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataFormat.Value, out outParam));
+			Assert.IsNotNull(outParam);
 
 			Clipboard.SetDataObject(dataIn);
 
@@ -138,9 +238,15 @@ namespace Duality.Editor.Tests
 
 			Assert.IsTrue(dataOut.ContainsComponents<TestComponent>(DataFormat.Reference));
 			Assert.IsTrue(dataOut.ContainsComponents<TestComponent>(DataFormat.Value));
-
 			Assert.AreSame(comp, dataOut.GetComponents<TestComponent>(DataFormat.Reference)[0]);
 			Assert.AreNotSame(comp, dataOut.GetComponents<TestComponent>(DataFormat.Value)[0]);
+
+			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataFormat.Reference, out outParam));
+			Assert.IsNotNull(outParam);
+			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataFormat.Value, out outParam));
+			Assert.IsNotNull(outParam);
 		}
 
 		[Test] public void GetContentRefs()
@@ -153,7 +259,6 @@ namespace Duality.Editor.Tests
 
 			Assert.IsTrue(dataIn.ContainsContentRefs());
 			Assert.IsTrue(dataIn.ContainsContentRefs(typeof(TestResource)));
-
 			Assert.AreEqual(contentRef, dataIn.GetContentRefs()[0]);
 			Assert.AreEqual(contentRef, dataIn.GetContentRefs(typeof(TestResource))[0]);
 
@@ -215,14 +320,18 @@ namespace Duality.Editor.Tests
 			dataIn.SetIColorData(new[] { (IColorData)color });
 
 			Assert.IsTrue(dataIn.ContainsIColorData());
+			Assert.AreEqual(color, dataIn.GetIColorData<IColorData>()[0]);
 			Assert.AreEqual(color, dataIn.GetIColorData<ColorRgba>()[0]);
+			Assert.AreEqual(color.ConvertTo<ColorHsva>(), dataIn.GetIColorData<ColorHsva>()[0]);
 
 			Clipboard.SetDataObject(dataIn);
 
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
 
 			Assert.IsTrue(dataOut.ContainsIColorData());
+			Assert.AreEqual(color, dataOut.GetIColorData<IColorData>()[0]);
 			Assert.AreEqual(color, dataOut.GetIColorData<ColorRgba>()[0]);
+			Assert.AreEqual(color.ConvertTo<ColorHsva>(), dataOut.GetIColorData<ColorHsva>()[0]);
 		}
 
 		[Test] public void GetIColorDataString()
@@ -241,6 +350,41 @@ namespace Duality.Editor.Tests
 
 			Assert.IsTrue(dataOut.ContainsIColorData());
 			Assert.AreEqual(color, dataOut.GetIColorData<ColorRgba>()[0]);
+
+			DataObject dataTooLong = new DataObject();
+			dataTooLong.SetString("10,10,10,10,10");
+			Assert.IsFalse(dataTooLong.ContainsIColorData());
+			Assert.IsNull(dataTooLong.GetIColorData<ColorRgba>());
+
+			DataObject dataWrongForm = new DataObject();
+			dataWrongForm.SetString("error,a,b");
+			Assert.IsFalse(dataWrongForm.ContainsIColorData());
+			Assert.IsNull(dataWrongForm.GetIColorData<ColorRgba>());
+		}
+
+		[Test] public void GetString()
+		{
+			DataObject nullData = new DataObject();
+			DataObject textData = new DataObject("Text", "test");
+			DataObject unicodeData = new DataObject("UnicodeText", "test");
+			DataObject typedData = new DataObject();
+			typedData.SetData(typeof(string), "test");
+			DataObject setData = new DataObject();
+			setData.SetString("test");
+
+			Assert.IsFalse(nullData.ContainsString());
+			Assert.IsTrue(textData.ContainsString());
+			Assert.IsTrue(unicodeData.ContainsString());
+			Assert.IsTrue(typedData.ContainsString());
+			Assert.IsTrue(setData.ContainsString());
+
+			Assert.AreEqual(null, nullData.GetString());
+			Assert.AreEqual("test", textData.GetString());
+			Assert.AreEqual("test", unicodeData.GetString());
+			Assert.AreEqual("test", typedData.GetString());
+			Assert.AreEqual("test", setData.GetString());
+			Assert.AreEqual("test", setData.GetData("Text") as string);
+			Assert.AreEqual("test", setData.GetData("UnicodeText") as string);
 		}
 	}
 }

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
+﻿using System.Windows.Forms;
 using Duality.Drawing;
 using NUnit.Framework;
 
@@ -138,8 +133,7 @@ namespace Duality.Editor.Tests
 			Assert.IsFalse(dataOut.ContainsContentRefs<TestResource>());
 		}
 
-		[Test]
-		public void GetBatchInfo()
+		[Test] public void GetBatchInfo()
 		{
 			DataObject dataIn = new DataObject();
 			BatchInfo batch = new BatchInfo();
@@ -155,6 +149,42 @@ namespace Duality.Editor.Tests
 
 			Assert.IsTrue(dataOut.ContainsBatchInfos());
 			Assert.AreNotSame(batch, dataOut.GetBatchInfos()[0]);
+		}
+
+		[Test] public void GetIColorData()
+		{
+			DataObject dataIn = new DataObject();
+			ColorRgba color = new ColorRgba(10, 10, 10, 10);
+
+			dataIn.SetIColorData(new[] { (IColorData)color });
+
+			Assert.IsTrue(dataIn.ContainsIColorData());
+			Assert.AreEqual(color, dataIn.GetIColorData<ColorRgba>()[0]);
+
+			Clipboard.SetDataObject(dataIn);
+
+			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
+
+			Assert.IsTrue(dataOut.ContainsIColorData());
+			Assert.AreEqual(color, dataOut.GetIColorData<ColorRgba>()[0]);
+		}
+
+		[Test] public void GetIColorDataString()
+		{
+			DataObject dataIn = new DataObject();
+			ColorRgba color = new ColorRgba(10, 10, 10, 10);
+
+			dataIn.SetString("10,10,10,10");
+
+			Assert.IsTrue(dataIn.ContainsIColorData());
+			Assert.AreEqual(color, dataIn.GetIColorData<ColorRgba>()[0]);
+
+			Clipboard.SetDataObject(dataIn);
+
+			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
+
+			Assert.IsTrue(dataOut.ContainsIColorData());
+			Assert.AreEqual(color, dataOut.GetIColorData<ColorRgba>()[0]);
 		}
 	}
 }

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -66,8 +66,7 @@ namespace Duality.Editor.Tests
 			Assert.IsFalse(dataIn.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Reference));
 			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value));
 			Assert.IsNull(dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Reference));
-			// Even though we are retrieving a value, serialization has not occured yet
-			Assert.AreSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Value).First());
+			Assert.AreNotSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Value).First());
 
 			Assert.IsFalse(dataIn.TryGetWrappedData("CorrectFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
@@ -84,7 +83,6 @@ namespace Duality.Editor.Tests
 			Assert.IsFalse(dataOut.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Reference));
 			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value));
 			Assert.IsNull(dataOut.GetWrappedData("CorrectFormat", DataObjectStorage.Reference));
-			// DeepClone should have been done by now
 			Assert.AreNotSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataObjectStorage.Value).First());
 
 			Assert.IsFalse(dataOut.TryGetWrappedData("CorrectFormat", DataObjectStorage.Reference, out outParam));

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Duality.Drawing;
 using NUnit.Framework;
 
 namespace Duality.Editor.Tests
@@ -135,6 +136,25 @@ namespace Duality.Editor.Tests
 			// This is false due to the fact that the reference to the locally created
 			// TestResource will not survive serialization.
 			Assert.IsFalse(dataOut.ContainsContentRefs<TestResource>());
+		}
+
+		[Test]
+		public void GetBatchInfo()
+		{
+			DataObject dataIn = new DataObject();
+			BatchInfo batch = new BatchInfo();
+
+			dataIn.SetBatchInfos(new[] { batch });
+
+			Assert.IsTrue(dataIn.ContainsBatchInfos());
+			Assert.AreNotSame(batch, dataIn.GetBatchInfos()[0]);
+
+			Clipboard.SetDataObject(dataIn);
+
+			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
+
+			Assert.IsTrue(dataOut.ContainsBatchInfos());
+			Assert.AreNotSame(batch, dataOut.GetBatchInfos()[0]);
 		}
 	}
 }

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -28,45 +28,45 @@ namespace Duality.Editor.Tests
 			TestClass dataOne = new TestClass();
 			IEnumerable<object> outParam;
 
-			dataIn.SetWrappedData(new [] { dataOne }, typeof(TestClass), DataFormat.Reference);
+			dataIn.SetWrappedData(new [] { dataOne }, "CorrectFormat", DataType.Reference);
 
-			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass), DataFormat.Reference));
-			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value));
-			Assert.IsFalse(dataIn.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value, false));
-			Assert.AreSame(dataOne, dataIn.GetWrappedData(typeof(TestClass), DataFormat.Reference).First());
-			Assert.AreNotSame(dataOne, dataIn.GetWrappedData(typeof(TestClass), DataFormat.Value).First());
-			Assert.IsNull(dataIn.GetWrappedData(typeof(TestClass), DataFormat.Value, false));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataType.Reference));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataType.Value));
+			Assert.IsFalse(dataIn.GetWrappedDataPresent("CorrectFormat", DataType.Value, false));
+			Assert.AreSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataType.Reference).First());
+			Assert.AreNotSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataType.Value).First());
+			Assert.IsNull(dataIn.GetWrappedData("CorrectFormat", DataType.Value, false));
 
-			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass), DataFormat.Reference, out outParam));
+			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataType.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass), DataFormat.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataType.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(TestClass), DataFormat.Value, false, out outParam));
+			Assert.IsFalse(dataIn.TryGetWrappedData("CorrectFormat", DataType.Value, false, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(object), DataFormat.Reference, out outParam));
+			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataType.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(object), DataFormat.Value, out outParam));
+			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataType.Value, out outParam));
 			Assert.IsNull(outParam);
 
 			Clipboard.SetDataObject(dataIn);
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
 
-			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass), DataFormat.Reference));
-			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value));
-			Assert.IsFalse(dataOut.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value, false));
-			Assert.AreSame(dataOne, dataOut.GetWrappedData(typeof(TestClass), DataFormat.Reference).First());
-			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass), DataFormat.Value).First());
-			Assert.IsNull(dataIn.GetWrappedData(typeof(TestClass), DataFormat.Value, false));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataType.Reference));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataType.Value));
+			Assert.IsFalse(dataOut.GetWrappedDataPresent("CorrectFormat", DataType.Value, false));
+			Assert.AreSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataType.Reference).First());
+			Assert.AreNotSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataType.Value).First());
+			Assert.IsNull(dataIn.GetWrappedData("CorrectFormat", DataType.Value, false));
 
-			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass), DataFormat.Reference, out outParam));
+			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataType.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass), DataFormat.Value, out outParam));
+			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataType.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(TestClass), DataFormat.Value, false, out outParam));
+			Assert.IsFalse(dataOut.TryGetWrappedData("CorrectFormat", DataType.Value, false, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(object), DataFormat.Reference, out outParam));
+			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataType.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(object), DataFormat.Value, out outParam));
+			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataType.Value, out outParam));
 			Assert.IsNull(outParam);
 		}
 
@@ -76,47 +76,47 @@ namespace Duality.Editor.Tests
 			TestClass dataOne = new TestClass();
 			IEnumerable<object> outParam;
 
-			dataIn.SetWrappedData(new[] { dataOne }, typeof(TestClass), DataFormat.Value);
+			dataIn.SetWrappedData(new[] { dataOne }, "CorrectFormat", DataType.Value);
 
-			Assert.IsFalse(dataIn.GetWrappedDataPresent(typeof(TestClass), DataFormat.Reference));
-			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value));
-			Assert.IsTrue(dataIn.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value, false));
-			Assert.IsNull(dataIn.GetWrappedData(typeof(TestClass), DataFormat.Reference));
+			Assert.IsFalse(dataIn.GetWrappedDataPresent("CorrectFormat", DataType.Reference));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataType.Value));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataType.Value, false));
+			Assert.IsNull(dataIn.GetWrappedData("CorrectFormat", DataType.Reference));
 			// Even though we are retrieving a value, serialization has not occured yet
-			Assert.AreSame(dataOne, dataIn.GetWrappedData(typeof(TestClass), DataFormat.Value).First());
-			Assert.AreSame(dataOne, dataIn.GetWrappedData(typeof(TestClass), DataFormat.Value, false).First());
+			Assert.AreSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataType.Value).First());
+			Assert.AreSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataType.Value, false).First());
 
-			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(TestClass), DataFormat.Reference, out outParam));
+			Assert.IsFalse(dataIn.TryGetWrappedData("CorrectFormat", DataType.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass), DataFormat.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataType.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetWrappedData(typeof(TestClass), DataFormat.Value, false, out outParam));
+			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataType.Value, false, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(object), DataFormat.Reference, out outParam));
+			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataType.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(dataIn.TryGetWrappedData(typeof(object), DataFormat.Value, out outParam));
+			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataType.Value, out outParam));
 			Assert.IsNull(outParam);
 
 			Clipboard.SetDataObject(dataIn);
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
 
-			Assert.IsFalse(dataOut.GetWrappedDataPresent(typeof(TestClass), DataFormat.Reference));
-			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value));
-			Assert.IsTrue(dataOut.GetWrappedDataPresent(typeof(TestClass), DataFormat.Value, false));
-			Assert.IsNull(dataOut.GetWrappedData(typeof(TestClass), DataFormat.Reference));
+			Assert.IsFalse(dataOut.GetWrappedDataPresent("CorrectFormat", DataType.Reference));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataType.Value));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataType.Value, false));
+			Assert.IsNull(dataOut.GetWrappedData("CorrectFormat", DataType.Reference));
 			// DeepClone should have been done by now
-			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass), DataFormat.Value).First());
-			Assert.AreNotSame(dataOne, dataOut.GetWrappedData(typeof(TestClass), DataFormat.Value, false).First());
+			Assert.AreNotSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataType.Value).First());
+			Assert.AreNotSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataType.Value, false).First());
 
-			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(TestClass), DataFormat.Reference, out outParam));
+			Assert.IsFalse(dataOut.TryGetWrappedData("CorrectFormat", DataType.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass), DataFormat.Value, out outParam));
+			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataType.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetWrappedData(typeof(TestClass), DataFormat.Value, false, out outParam));
+			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataType.Value, false, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(object), DataFormat.Reference, out outParam));
+			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataType.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(dataOut.TryGetWrappedData(typeof(object), DataFormat.Value, out outParam));
+			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataType.Value, out outParam));
 			Assert.IsNull(outParam);
 		}
 
@@ -129,40 +129,40 @@ namespace Duality.Editor.Tests
 
 			dataIn.SetGameObjects(new [] { gameObject });
 
-			Assert.IsTrue(dataIn.ContainsGameObjects(DataFormat.Reference));
-			Assert.IsTrue(dataIn.ContainsGameObjects(DataFormat.Value));
-			Assert.AreSame(gameObject, dataIn.GetGameObjects(DataFormat.Reference)[0]);
-			Assert.AreNotSame(gameObject, dataIn.GetGameObjects(DataFormat.Value)[0]);
-			Assert.IsFalse(nullData.ContainsGameObjects(DataFormat.Reference));
-			Assert.IsFalse(nullData.ContainsGameObjects(DataFormat.Value));
+			Assert.IsTrue(dataIn.ContainsGameObjects(DataType.Reference));
+			Assert.IsTrue(dataIn.ContainsGameObjects(DataType.Value));
+			Assert.AreSame(gameObject, dataIn.GetGameObjects(DataType.Reference)[0]);
+			Assert.AreNotSame(gameObject, dataIn.GetGameObjects(DataType.Value)[0]);
+			Assert.IsFalse(nullData.ContainsGameObjects(DataType.Reference));
+			Assert.IsFalse(nullData.ContainsGameObjects(DataType.Value));
 
 			Assert.IsTrue(dataIn.TryGetGameObjects(out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetGameObjects(DataFormat.Reference, out outParam));
+			Assert.IsTrue(dataIn.TryGetGameObjects(DataType.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetGameObjects(DataFormat.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetGameObjects(DataType.Value, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsFalse(nullData.TryGetGameObjects(out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(nullData.TryGetGameObjects(DataFormat.Reference, out outParam));
+			Assert.IsFalse(nullData.TryGetGameObjects(DataType.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(nullData.TryGetGameObjects(DataFormat.Value, out outParam));
+			Assert.IsFalse(nullData.TryGetGameObjects(DataType.Value, out outParam));
 			Assert.IsNull(outParam);
 
 			Clipboard.SetDataObject(dataIn);
 
 			DataObject dataOut = (DataObject) Clipboard.GetDataObject();
 
-			Assert.IsTrue(dataOut.ContainsGameObjects(DataFormat.Reference));
-			Assert.IsTrue(dataOut.ContainsGameObjects(DataFormat.Value));
-			Assert.AreSame(gameObject, dataOut.GetGameObjects(DataFormat.Reference)[0]);
-			Assert.AreNotSame(gameObject, dataOut.GetGameObjects(DataFormat.Value)[0]);
+			Assert.IsTrue(dataOut.ContainsGameObjects(DataType.Reference));
+			Assert.IsTrue(dataOut.ContainsGameObjects(DataType.Value));
+			Assert.AreSame(gameObject, dataOut.GetGameObjects(DataType.Reference)[0]);
+			Assert.AreNotSame(gameObject, dataOut.GetGameObjects(DataType.Value)[0]);
 
 			Assert.IsTrue(dataOut.TryGetGameObjects(out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetGameObjects(DataFormat.Reference, out outParam));
+			Assert.IsTrue(dataOut.TryGetGameObjects(DataType.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetGameObjects(DataFormat.Value, out outParam));
+			Assert.IsTrue(dataOut.TryGetGameObjects(DataType.Value, out outParam));
 			Assert.IsNotNull(outParam);
 		}
 
@@ -174,44 +174,44 @@ namespace Duality.Editor.Tests
 
 			dataIn.SetComponents(new[] { comp });
 
-			Assert.IsTrue(dataIn.ContainsComponents(DataFormat.Reference));
-			Assert.IsTrue(dataIn.ContainsComponents(DataFormat.Value));
-			Assert.AreSame(comp, dataIn.GetComponents(DataFormat.Reference)[0]);
-			Assert.AreNotSame(comp, dataIn.GetComponents(DataFormat.Value)[0]);
+			Assert.IsTrue(dataIn.ContainsComponents(DataType.Reference));
+			Assert.IsTrue(dataIn.ContainsComponents(DataType.Value));
+			Assert.AreSame(comp, dataIn.GetComponents(DataType.Reference)[0]);
+			Assert.AreNotSame(comp, dataIn.GetComponents(DataType.Value)[0]);
 
 			Assert.IsTrue(dataIn.TryGetComponents(out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents(DataFormat.Reference, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents(DataType.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents(DataFormat.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents(DataType.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), DataFormat.Reference, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), DataType.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), DataFormat.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), DataType.Value, out outParam));
 			Assert.IsNotNull(outParam);
 
 			Clipboard.SetDataObject(dataIn);
 
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
 
-			Assert.IsTrue(dataOut.ContainsComponents(DataFormat.Reference));
-			Assert.IsTrue(dataOut.ContainsComponents(DataFormat.Value));
-			Assert.AreSame(comp, dataOut.GetComponents(DataFormat.Reference)[0]);
-			Assert.AreNotSame(comp, dataOut.GetComponents(DataFormat.Value)[0]);
+			Assert.IsTrue(dataOut.ContainsComponents(DataType.Reference));
+			Assert.IsTrue(dataOut.ContainsComponents(DataType.Value));
+			Assert.AreSame(comp, dataOut.GetComponents(DataType.Reference)[0]);
+			Assert.AreNotSame(comp, dataOut.GetComponents(DataType.Value)[0]);
 
 			Assert.IsTrue(dataOut.TryGetComponents(out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetComponents(DataFormat.Reference, out outParam));
+			Assert.IsTrue(dataOut.TryGetComponents(DataType.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetComponents(DataFormat.Value, out outParam));
+			Assert.IsTrue(dataOut.TryGetComponents(DataType.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataFormat.Reference, out outParam));
+			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataType.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataFormat.Value, out outParam));
+			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataType.Value, out outParam));
 			Assert.IsNotNull(outParam);
 		}
 
@@ -223,32 +223,32 @@ namespace Duality.Editor.Tests
 
 			dataIn.SetComponents(new[] { comp });
 
-			Assert.IsTrue(dataIn.ContainsComponents<TestComponent>(DataFormat.Reference));
-			Assert.IsTrue(dataIn.ContainsComponents<TestComponent>(DataFormat.Value));
-			Assert.AreSame(comp, dataIn.GetComponents<TestComponent>(DataFormat.Reference)[0]);
-			Assert.AreNotSame(comp, dataIn.GetComponents<TestComponent>(DataFormat.Value)[0]);
+			Assert.IsTrue(dataIn.ContainsComponents<TestComponent>(DataType.Reference));
+			Assert.IsTrue(dataIn.ContainsComponents<TestComponent>(DataType.Value));
+			Assert.AreSame(comp, dataIn.GetComponents<TestComponent>(DataType.Reference)[0]);
+			Assert.AreNotSame(comp, dataIn.GetComponents<TestComponent>(DataType.Value)[0]);
 
 			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataFormat.Reference, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataType.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataFormat.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataType.Value, out outParam));
 			Assert.IsNotNull(outParam);
 
 			Clipboard.SetDataObject(dataIn);
 
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
 
-			Assert.IsTrue(dataOut.ContainsComponents<TestComponent>(DataFormat.Reference));
-			Assert.IsTrue(dataOut.ContainsComponents<TestComponent>(DataFormat.Value));
-			Assert.AreSame(comp, dataOut.GetComponents<TestComponent>(DataFormat.Reference)[0]);
-			Assert.AreNotSame(comp, dataOut.GetComponents<TestComponent>(DataFormat.Value)[0]);
+			Assert.IsTrue(dataOut.ContainsComponents<TestComponent>(DataType.Reference));
+			Assert.IsTrue(dataOut.ContainsComponents<TestComponent>(DataType.Value));
+			Assert.AreSame(comp, dataOut.GetComponents<TestComponent>(DataType.Reference)[0]);
+			Assert.AreNotSame(comp, dataOut.GetComponents<TestComponent>(DataType.Value)[0]);
 
 			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataFormat.Reference, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataType.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataFormat.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataType.Value, out outParam));
 			Assert.IsNotNull(outParam);
 		}
 

--- a/Test/Editor/Utility/DataObjectExtensionsTest.cs
+++ b/Test/Editor/Utility/DataObjectExtensionsTest.cs
@@ -28,45 +28,45 @@ namespace Duality.Editor.Tests
 			TestClass dataOne = new TestClass();
 			IEnumerable<object> outParam;
 
-			dataIn.SetWrappedData(new [] { dataOne }, "CorrectFormat", DataType.Reference);
+			dataIn.SetWrappedData(new [] { dataOne }, "CorrectFormat", DataObjectStorage.Reference);
 
-			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataType.Reference));
-			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataType.Value));
-			Assert.IsFalse(dataIn.GetWrappedDataPresent("CorrectFormat", DataType.Value, false));
-			Assert.AreSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataType.Reference).First());
-			Assert.AreNotSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataType.Value).First());
-			Assert.IsNull(dataIn.GetWrappedData("CorrectFormat", DataType.Value, false));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Reference));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value));
+			Assert.IsFalse(dataIn.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value, false));
+			Assert.AreSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Reference).First());
+			Assert.AreNotSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Value).First());
+			Assert.IsNull(dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Value, false));
 
-			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataType.Reference, out outParam));
+			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataType.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsFalse(dataIn.TryGetWrappedData("CorrectFormat", DataType.Value, false, out outParam));
+			Assert.IsFalse(dataIn.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, false, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataType.Reference, out outParam));
+			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataType.Value, out outParam));
+			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataObjectStorage.Value, out outParam));
 			Assert.IsNull(outParam);
 
 			Clipboard.SetDataObject(dataIn);
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
 
-			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataType.Reference));
-			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataType.Value));
-			Assert.IsFalse(dataOut.GetWrappedDataPresent("CorrectFormat", DataType.Value, false));
-			Assert.AreSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataType.Reference).First());
-			Assert.AreNotSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataType.Value).First());
-			Assert.IsNull(dataIn.GetWrappedData("CorrectFormat", DataType.Value, false));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Reference));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value));
+			Assert.IsFalse(dataOut.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value, false));
+			Assert.AreSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataObjectStorage.Reference).First());
+			Assert.AreNotSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataObjectStorage.Value).First());
+			Assert.IsNull(dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Value, false));
 
-			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataType.Reference, out outParam));
+			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataType.Value, out outParam));
+			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsFalse(dataOut.TryGetWrappedData("CorrectFormat", DataType.Value, false, out outParam));
+			Assert.IsFalse(dataOut.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, false, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataType.Reference, out outParam));
+			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataType.Value, out outParam));
+			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataObjectStorage.Value, out outParam));
 			Assert.IsNull(outParam);
 		}
 
@@ -76,47 +76,47 @@ namespace Duality.Editor.Tests
 			TestClass dataOne = new TestClass();
 			IEnumerable<object> outParam;
 
-			dataIn.SetWrappedData(new[] { dataOne }, "CorrectFormat", DataType.Value);
+			dataIn.SetWrappedData(new[] { dataOne }, "CorrectFormat", DataObjectStorage.Value);
 
-			Assert.IsFalse(dataIn.GetWrappedDataPresent("CorrectFormat", DataType.Reference));
-			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataType.Value));
-			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataType.Value, false));
-			Assert.IsNull(dataIn.GetWrappedData("CorrectFormat", DataType.Reference));
+			Assert.IsFalse(dataIn.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Reference));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value));
+			Assert.IsTrue(dataIn.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value, false));
+			Assert.IsNull(dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Reference));
 			// Even though we are retrieving a value, serialization has not occured yet
-			Assert.AreSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataType.Value).First());
-			Assert.AreSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataType.Value, false).First());
+			Assert.AreSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Value).First());
+			Assert.AreSame(dataOne, dataIn.GetWrappedData("CorrectFormat", DataObjectStorage.Value, false).First());
 
-			Assert.IsFalse(dataIn.TryGetWrappedData("CorrectFormat", DataType.Reference, out outParam));
+			Assert.IsFalse(dataIn.TryGetWrappedData("CorrectFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataType.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataType.Value, false, out outParam));
+			Assert.IsTrue(dataIn.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, false, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataType.Reference, out outParam));
+			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataType.Value, out outParam));
+			Assert.IsFalse(dataIn.TryGetWrappedData("WrongFormat", DataObjectStorage.Value, out outParam));
 			Assert.IsNull(outParam);
 
 			Clipboard.SetDataObject(dataIn);
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
 
-			Assert.IsFalse(dataOut.GetWrappedDataPresent("CorrectFormat", DataType.Reference));
-			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataType.Value));
-			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataType.Value, false));
-			Assert.IsNull(dataOut.GetWrappedData("CorrectFormat", DataType.Reference));
+			Assert.IsFalse(dataOut.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Reference));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value));
+			Assert.IsTrue(dataOut.GetWrappedDataPresent("CorrectFormat", DataObjectStorage.Value, false));
+			Assert.IsNull(dataOut.GetWrappedData("CorrectFormat", DataObjectStorage.Reference));
 			// DeepClone should have been done by now
-			Assert.AreNotSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataType.Value).First());
-			Assert.AreNotSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataType.Value, false).First());
+			Assert.AreNotSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataObjectStorage.Value).First());
+			Assert.AreNotSame(dataOne, dataOut.GetWrappedData("CorrectFormat", DataObjectStorage.Value, false).First());
 
-			Assert.IsFalse(dataOut.TryGetWrappedData("CorrectFormat", DataType.Reference, out outParam));
+			Assert.IsFalse(dataOut.TryGetWrappedData("CorrectFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataType.Value, out outParam));
+			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataType.Value, false, out outParam));
+			Assert.IsTrue(dataOut.TryGetWrappedData("CorrectFormat", DataObjectStorage.Value, false, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataType.Reference, out outParam));
+			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataType.Value, out outParam));
+			Assert.IsFalse(dataOut.TryGetWrappedData("WrongFormat", DataObjectStorage.Value, out outParam));
 			Assert.IsNull(outParam);
 		}
 
@@ -129,40 +129,40 @@ namespace Duality.Editor.Tests
 
 			dataIn.SetGameObjects(new [] { gameObject });
 
-			Assert.IsTrue(dataIn.ContainsGameObjects(DataType.Reference));
-			Assert.IsTrue(dataIn.ContainsGameObjects(DataType.Value));
-			Assert.AreSame(gameObject, dataIn.GetGameObjects(DataType.Reference)[0]);
-			Assert.AreNotSame(gameObject, dataIn.GetGameObjects(DataType.Value)[0]);
-			Assert.IsFalse(nullData.ContainsGameObjects(DataType.Reference));
-			Assert.IsFalse(nullData.ContainsGameObjects(DataType.Value));
+			Assert.IsTrue(dataIn.ContainsGameObjects(DataObjectStorage.Reference));
+			Assert.IsTrue(dataIn.ContainsGameObjects(DataObjectStorage.Value));
+			Assert.AreSame(gameObject, dataIn.GetGameObjects(DataObjectStorage.Reference)[0]);
+			Assert.AreNotSame(gameObject, dataIn.GetGameObjects(DataObjectStorage.Value)[0]);
+			Assert.IsFalse(nullData.ContainsGameObjects(DataObjectStorage.Reference));
+			Assert.IsFalse(nullData.ContainsGameObjects(DataObjectStorage.Value));
 
 			Assert.IsTrue(dataIn.TryGetGameObjects(out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetGameObjects(DataType.Reference, out outParam));
+			Assert.IsTrue(dataIn.TryGetGameObjects(DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetGameObjects(DataType.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetGameObjects(DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsFalse(nullData.TryGetGameObjects(out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(nullData.TryGetGameObjects(DataType.Reference, out outParam));
+			Assert.IsFalse(nullData.TryGetGameObjects(DataObjectStorage.Reference, out outParam));
 			Assert.IsNull(outParam);
-			Assert.IsFalse(nullData.TryGetGameObjects(DataType.Value, out outParam));
+			Assert.IsFalse(nullData.TryGetGameObjects(DataObjectStorage.Value, out outParam));
 			Assert.IsNull(outParam);
 
 			Clipboard.SetDataObject(dataIn);
 
 			DataObject dataOut = (DataObject) Clipboard.GetDataObject();
 
-			Assert.IsTrue(dataOut.ContainsGameObjects(DataType.Reference));
-			Assert.IsTrue(dataOut.ContainsGameObjects(DataType.Value));
-			Assert.AreSame(gameObject, dataOut.GetGameObjects(DataType.Reference)[0]);
-			Assert.AreNotSame(gameObject, dataOut.GetGameObjects(DataType.Value)[0]);
+			Assert.IsTrue(dataOut.ContainsGameObjects(DataObjectStorage.Reference));
+			Assert.IsTrue(dataOut.ContainsGameObjects(DataObjectStorage.Value));
+			Assert.AreSame(gameObject, dataOut.GetGameObjects(DataObjectStorage.Reference)[0]);
+			Assert.AreNotSame(gameObject, dataOut.GetGameObjects(DataObjectStorage.Value)[0]);
 
 			Assert.IsTrue(dataOut.TryGetGameObjects(out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetGameObjects(DataType.Reference, out outParam));
+			Assert.IsTrue(dataOut.TryGetGameObjects(DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetGameObjects(DataType.Value, out outParam));
+			Assert.IsTrue(dataOut.TryGetGameObjects(DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
 		}
 
@@ -174,44 +174,44 @@ namespace Duality.Editor.Tests
 
 			dataIn.SetComponents(new[] { comp });
 
-			Assert.IsTrue(dataIn.ContainsComponents(DataType.Reference));
-			Assert.IsTrue(dataIn.ContainsComponents(DataType.Value));
-			Assert.AreSame(comp, dataIn.GetComponents(DataType.Reference)[0]);
-			Assert.AreNotSame(comp, dataIn.GetComponents(DataType.Value)[0]);
+			Assert.IsTrue(dataIn.ContainsComponents(DataObjectStorage.Reference));
+			Assert.IsTrue(dataIn.ContainsComponents(DataObjectStorage.Value));
+			Assert.AreSame(comp, dataIn.GetComponents(DataObjectStorage.Reference)[0]);
+			Assert.AreNotSame(comp, dataIn.GetComponents(DataObjectStorage.Value)[0]);
 
 			Assert.IsTrue(dataIn.TryGetComponents(out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents(DataType.Reference, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents(DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents(DataType.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents(DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), DataType.Reference, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), DataType.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents(typeof(TestComponent), DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
 
 			Clipboard.SetDataObject(dataIn);
 
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
 
-			Assert.IsTrue(dataOut.ContainsComponents(DataType.Reference));
-			Assert.IsTrue(dataOut.ContainsComponents(DataType.Value));
-			Assert.AreSame(comp, dataOut.GetComponents(DataType.Reference)[0]);
-			Assert.AreNotSame(comp, dataOut.GetComponents(DataType.Value)[0]);
+			Assert.IsTrue(dataOut.ContainsComponents(DataObjectStorage.Reference));
+			Assert.IsTrue(dataOut.ContainsComponents(DataObjectStorage.Value));
+			Assert.AreSame(comp, dataOut.GetComponents(DataObjectStorage.Reference)[0]);
+			Assert.AreNotSame(comp, dataOut.GetComponents(DataObjectStorage.Value)[0]);
 
 			Assert.IsTrue(dataOut.TryGetComponents(out outParam));
 			Assert.IsNotNull(outParam);
 			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetComponents(DataType.Reference, out outParam));
+			Assert.IsTrue(dataOut.TryGetComponents(DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetComponents(DataType.Value, out outParam));
+			Assert.IsTrue(dataOut.TryGetComponents(DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataType.Reference, out outParam));
+			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataType.Value, out outParam));
+			Assert.IsTrue(dataOut.TryGetComponents(typeof(TestComponent), DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
 		}
 
@@ -223,32 +223,32 @@ namespace Duality.Editor.Tests
 
 			dataIn.SetComponents(new[] { comp });
 
-			Assert.IsTrue(dataIn.ContainsComponents<TestComponent>(DataType.Reference));
-			Assert.IsTrue(dataIn.ContainsComponents<TestComponent>(DataType.Value));
-			Assert.AreSame(comp, dataIn.GetComponents<TestComponent>(DataType.Reference)[0]);
-			Assert.AreNotSame(comp, dataIn.GetComponents<TestComponent>(DataType.Value)[0]);
+			Assert.IsTrue(dataIn.ContainsComponents<TestComponent>(DataObjectStorage.Reference));
+			Assert.IsTrue(dataIn.ContainsComponents<TestComponent>(DataObjectStorage.Value));
+			Assert.AreSame(comp, dataIn.GetComponents<TestComponent>(DataObjectStorage.Reference)[0]);
+			Assert.AreNotSame(comp, dataIn.GetComponents<TestComponent>(DataObjectStorage.Value)[0]);
 
 			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataType.Reference, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataType.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
 
 			Clipboard.SetDataObject(dataIn);
 
 			DataObject dataOut = (DataObject)Clipboard.GetDataObject();
 
-			Assert.IsTrue(dataOut.ContainsComponents<TestComponent>(DataType.Reference));
-			Assert.IsTrue(dataOut.ContainsComponents<TestComponent>(DataType.Value));
-			Assert.AreSame(comp, dataOut.GetComponents<TestComponent>(DataType.Reference)[0]);
-			Assert.AreNotSame(comp, dataOut.GetComponents<TestComponent>(DataType.Value)[0]);
+			Assert.IsTrue(dataOut.ContainsComponents<TestComponent>(DataObjectStorage.Reference));
+			Assert.IsTrue(dataOut.ContainsComponents<TestComponent>(DataObjectStorage.Value));
+			Assert.AreSame(comp, dataOut.GetComponents<TestComponent>(DataObjectStorage.Reference)[0]);
+			Assert.AreNotSame(comp, dataOut.GetComponents<TestComponent>(DataObjectStorage.Value)[0]);
 
 			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataType.Reference, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataObjectStorage.Reference, out outParam));
 			Assert.IsNotNull(outParam);
-			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataType.Value, out outParam));
+			Assert.IsTrue(dataIn.TryGetComponents<TestComponent>(DataObjectStorage.Value, out outParam));
 			Assert.IsNotNull(outParam);
 		}
 


### PR DESCRIPTION
### Summary

Added support for Reference and Value data format to DataObject extension methods when using SerializedWrappers. In the process, did general cleanup and bugfixes of the ExtMethodsDataObject file and improved API in various areas. See #655.

### Details
- Added support for reference and value formatted data.
- Added unit tests for most of the code in ExtMethodsDataObject. ~75% coverage.
- Added TryGet methods and changed most code that used Contains/Get to use TryGet instead.
- Added support for automatically converting reference data stored in a DataObject to value data. DeepClones the reference data.
- Changed WrappedData API to take `IEnumerable<object>` rather than `object`
- Fixed bugs in conversion of strings to IColorData


There remain two issue I'd like to get checked.
1. Should BatchInfoPropertyEditor be using the GetBatchInfos method during a paste operation? It uses SetBatchInfos for copy, but uses ConvertOperation for paste. ConvertOperation eventually makes the same calls that GetBatchInfos would but has to go through the conversion call chain first. Is there some non-BatchInfo object that can be converted to BatchInfo?
2. Should the WrappedData methods take `object[]` rather than `IEnumerable<object>`? This keeps people from accidentally passing the wrong collection type into the SetWrappedData call and then asking for something else in GetWrappedData. ie. They pass `IEnumerable<Transform>` such as from a LINQ query and then ask for `Component[]`. If the API used `object[]` it would be more explicit and there be less of a chance that anyone would run into this problem, but it limits the API to only handling arrays rather than arbitrary collection types.