### PR TITLE
HandleAllInput Null Predicate Fix

### DIFF
--- a/Source/Editor/DualityEditor/AssetManagement/Import/ExtMethodsIAssetImportEnvironment.cs
+++ b/Source/Editor/DualityEditor/AssetManagement/Import/ExtMethodsIAssetImportEnvironment.cs
@@ -21,7 +21,7 @@ namespace Duality.Editor.AssetManagement
 			List<AssetImportInput> handledInput = new List<AssetImportInput>();
 			foreach (AssetImportInput input in env.Input)
 			{
-				if (predicate(input) && env.HandleInput(input.Path))
+				if ((predicate == null || predicate(input)) && env.HandleInput(input.Path))
 				{
 					handledInput.Add(input);
 				}


### PR DESCRIPTION
### Summary

The extension method on IAssetImportEnvironment, HandleAllInput, now handles a null predicate. The documentation comment indicates that passing a null predicate should be allowed: "If no predicate is specified, this method will try to handle all available input." but it would instead throw a null reference exception when evaluating a null predicate.
