### PR TITLE
Fix audio source releasing when stream is empty

### DIFF
--- a/Source/Platform/DefaultOpenTK/Backend/Audio/NativeAudioSource.cs
+++ b/Source/Platform/DefaultOpenTK/Backend/Audio/NativeAudioSource.cs
@@ -260,11 +260,13 @@ namespace Duality.Backend.DefaultOpenTK
 				if (this.handle == 0) return false;
 
 				ALSourceState stateTemp = AL.GetSourceState(this.handle);
-				if (stateTemp == ALSourceState.Stopped && this.strStopReq != StopRequest.None)
+				if ((stateTemp == ALSourceState.Stopped || stateTemp == ALSourceState.Initial) && this.strStopReq != StopRequest.None)
 				{
 					// Stopped due to regular EOF. If strStopReq is NOT set,
 					// the source stopped playing because it reached the end of the buffer
 					// but in fact only because we were too slow inserting new data.
+					// When stream is empty, source is still in initial state but strStopReq
+					// is already set to EndOfStream.
 					return false;
 				}
 				else if (this.strStopReq == StopRequest.Immediately)
@@ -281,7 +283,6 @@ namespace Duality.Backend.DefaultOpenTK
 
 					// Initially play source
 					AL.SourcePlay(handle);
-					stateTemp = AL.GetSourceState(handle);
 				}
 				else
 				{
@@ -320,6 +321,7 @@ namespace Duality.Backend.DefaultOpenTK
 				}
 				else
 				{
+					this.strStopReq = StopRequest.EndOfStream;
 					break;
 				}
 			}


### PR DESCRIPTION
In case that audio stream contains no data (even first call to `IAudioStreamProvider.ReadStream(...)` returns false) the `NativeAudioSource` is stuck in `streamWorkerQueue`. Because of this, the source is never freed up and also the `ReadStream` method of `IAudioStreamProvider` is constantly called.

As a fix, I am setting strStopReq to EndOfStream because this is what actually happens. Then I also need to modify condition which is stopping the streaming. I tested this on sample project and also with my custom stream provider. It should handle correctly streams of any lengths (empty, shorter than initial buffers, shorter than one buffer, infinitely long).