### PR TITLE
#244 Expand State saved in UserData

### DIFF
--- a/Source/Plugins/EditorModules/ObjectInspector/Modules/ObjectInspector.cs
+++ b/Source/Plugins/EditorModules/ObjectInspector/Modules/ObjectInspector.cs
@@ -114,7 +114,8 @@ namespace Duality.Editor.Plugins.ObjectInspector
 			node.SetElementValue("TitleText", this.Text);
 			node.SetElementValue("DebugMode", this.buttonDebug.Checked);
 			node.SetElementValue("SortByName", this.buttonSortByName.Checked);
-			// Get the latest expand state
+			// gridExpandState is normally only updated when the current selection changes.
+			// Make sure we have the latest information when saving UserData.
 			this.gridExpandState.UpdateFrom(this.propertyGrid.MainEditor);
 			this.gridExpandState.SaveToXml(node);
 		}

--- a/Source/Plugins/EditorModules/ObjectInspector/Modules/ObjectInspector.cs
+++ b/Source/Plugins/EditorModules/ObjectInspector/Modules/ObjectInspector.cs
@@ -114,10 +114,14 @@ namespace Duality.Editor.Plugins.ObjectInspector
 			node.SetElementValue("TitleText", this.Text);
 			node.SetElementValue("DebugMode", this.buttonDebug.Checked);
 			node.SetElementValue("SortByName", this.buttonSortByName.Checked);
+
 			// gridExpandState is normally only updated when the current selection changes.
 			// Make sure we have the latest information when saving UserData.
 			this.gridExpandState.UpdateFrom(this.propertyGrid.MainEditor);
-			this.gridExpandState.SaveToXml(node);
+
+			XElement expandStateNode = new XElement("ExpandState");
+			this.gridExpandState.SaveToXml(expandStateNode);
+			node.Add(expandStateNode);
 		}
 		internal void LoadUserData(XElement node)
 		{
@@ -128,7 +132,12 @@ namespace Duality.Editor.Plugins.ObjectInspector
 			if (node.GetElementValue("DebugMode", out tryParseBool)) this.buttonDebug.Checked = tryParseBool;
 			if (node.GetElementValue("SortByName", out tryParseBool)) this.buttonSortByName.Checked = tryParseBool;
 			this.Text = node.GetElementValue("TitleText", this.Text);
-			this.gridExpandState.LoadFromXml(node);
+
+			XElement expandStateNode = node.Element("ExpandState", true);
+			if (expandStateNode != null)
+			{
+				this.gridExpandState.LoadFromXml(expandStateNode);
+			}
 		}
 
 		private void UpdateButtons()

--- a/Source/Plugins/EditorModules/ObjectInspector/Modules/ObjectInspector.cs
+++ b/Source/Plugins/EditorModules/ObjectInspector/Modules/ObjectInspector.cs
@@ -183,7 +183,9 @@ namespace Duality.Editor.Plugins.ObjectInspector
 		private void MainEditor_EditorAdded(object sender, PropertyEditorEventArgs e)
 		{
 			// Make sure new editors start in the correct expand state
-			this.gridExpandState.ApplyTo(this.propertyGrid.MainEditor);
+			GroupedPropertyEditor groupedEditor = e.Editor as GroupedPropertyEditor;
+			if (groupedEditor != null)
+				groupedEditor.Expanded = this.gridExpandState.IsEditorExpanded(groupedEditor);
 		}
 
 		private void EditorForm_AfterUpdateDualityApp(object sender, EventArgs e)


### PR DESCRIPTION
### Summary

Addressed #244 by saving `ObjectInspectors` `ExpandState` object to UserData.

### Details

Depends on [this PR from winforms project](https://github.com/AdamsLair/winforms/pull/7).

Nothing much to say here. Along the way I also fixed a bug related to the expand state tracking. New components were not respecting the expand state:
1. Create an object (A). Add a component. 
2. Create a new object (B). Add the same component and expand it.
3. Switch back to object (A). Notice it is expanded (as expected).
4. Create a new object (C). Add the same component. Notice is is not expanded.
5. Switch to object (A). Notice the component is not expanded.

4 and 5 are where you can notice the bug. New components were always collapsed and they would then overwrite the expand state for that component.