### PR TITLE
Tilemap scroll

### DIFF
--- a/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
+++ b/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
@@ -16,10 +16,11 @@ namespace Duality.Editor.Plugins.Tilemaps
 		private Rectangle  selectedArea           = Rectangle.Empty;
 		private Grid<Tile> selectedTiles          = new Grid<Tile>();
 		private Point      actionBeginTilePos     = Point.Empty;
+		private bool       areTilesSelected       = false;
 		private bool       isUserSelecting        = false;
-		private bool isUserScrolling = false;
-		private int lastMouseX = -1;
-		private int lastMouseY = -1;
+		private bool       isUserScrolling        = false;
+		private int        lastMouseX             = -1;
+		private int        lastMouseY             = -1;
 
 		public event EventHandler SelectedAreaChanged = null;
 		public event EventHandler SelectedAreaEditingFinished = null;
@@ -196,7 +197,17 @@ namespace Duality.Editor.Plugins.Tilemaps
 				{
 					this.isUserSelecting = true;
 					this.HoveredTileIndex = -1;
-					if (tileIndex != -1)
+					if (tileIndex != -1 && !this.areTilesSelected)
+					{
+						this.areTilesSelected = true;
+						this.actionBeginTilePos = this.GetTilePos(tileIndex);
+						this.isUserSelecting = true;
+						this.SelectedArea = new Rectangle(
+							this.GetDisplayedTilePos(this.actionBeginTilePos.X, this.actionBeginTilePos.Y),
+							new Size(1, 1));
+						this.HoveredTileIndex = -1;
+					}
+					else if (tileIndex != -1)
 					{
 						Point tilePos = this.GetTilePos(tileIndex);
 						Point displayedBeginPos = this.GetDisplayedTilePos(this.actionBeginTilePos.X, this.actionBeginTilePos.Y);
@@ -222,6 +233,7 @@ namespace Duality.Editor.Plugins.Tilemaps
 				int tileIndex = this.PickTileIndexAt(e.X, e.Y);
 				if (tileIndex != -1)
 				{
+					this.areTilesSelected = true;
 					this.actionBeginTilePos = this.GetTilePos(tileIndex);
 					this.isUserSelecting = true;
 					this.SelectedArea = new Rectangle(
@@ -243,6 +255,7 @@ namespace Duality.Editor.Plugins.Tilemaps
 			if (!this.isUserSelecting && !this.isUserScrolling)
 			{
 				this.SelectedArea = Rectangle.Empty;
+				this.areTilesSelected = false;
 			}
 			if (e.Button == MouseButtons.Middle)
 			{

--- a/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
+++ b/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
@@ -189,7 +189,16 @@ namespace Duality.Editor.Plugins.Tilemaps
 		protected override void OnMouseDown(MouseEventArgs e)
 		{
 			base.OnMouseDown(e);
-			if (e.Button == MouseButtons.Left)
+			if (e.Button == MouseButtons.Left && Control.ModifierKeys == Keys.Shift)
+			{
+				int tileIndex = this.PickTileIndexAt(e.X, e.Y);
+				if (tileIndex != -1)
+				{
+					this.isUserSelecting = true;
+					this.HoveredTileIndex = -1;
+				}
+			}
+			else if (e.Button == MouseButtons.Left)
 			{
 				int tileIndex = this.PickTileIndexAt(e.X, e.Y);
 				if (tileIndex != -1)
@@ -197,7 +206,7 @@ namespace Duality.Editor.Plugins.Tilemaps
 					this.actionBeginTilePos = this.GetTilePos(tileIndex);
 					this.isUserSelecting = true;
 					this.SelectedArea = new Rectangle(
-						this.GetDisplayedTilePos(this.actionBeginTilePos.X, this.actionBeginTilePos.Y), 
+						this.GetDisplayedTilePos(this.actionBeginTilePos.X, this.actionBeginTilePos.Y),
 						new Size(1, 1));
 					this.HoveredTileIndex = -1;
 				}
@@ -224,7 +233,6 @@ namespace Duality.Editor.Plugins.Tilemaps
 				{
 					this.SelectedArea = Rectangle.Empty;
 				}
-				this.actionBeginTilePos = Point.Empty;
 				this.isUserSelecting = false;
 				this.RaiseSelectedAreaEditingFinished();
 			}

--- a/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
+++ b/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
@@ -202,7 +202,7 @@ namespace Duality.Editor.Plugins.Tilemaps
 					this.HoveredTileIndex = -1;
 				}
 			}
-			if (e.Button == MouseButtons.Middle)
+			else if (e.Button == MouseButtons.Middle)
 			{
 				this.isUserScrolling = true;
 				this.lastMouseX = e.X;
@@ -218,13 +218,16 @@ namespace Duality.Editor.Plugins.Tilemaps
 				this.lastMouseX = -1;
 				this.lastMouseY = -1;
 			}
-			if (!this.isUserSelecting)
+			if (e.Button == MouseButtons.Left)
 			{
-				this.SelectedArea = Rectangle.Empty;
+				if (!this.isUserSelecting)
+				{
+					this.SelectedArea = Rectangle.Empty;
+				}
+				this.actionBeginTilePos = Point.Empty;
+				this.isUserSelecting = false;
+				this.RaiseSelectedAreaEditingFinished();
 			}
-			this.actionBeginTilePos = Point.Empty;
-			this.isUserSelecting = false;
-			this.RaiseSelectedAreaEditingFinished();
 		}
 		protected override void OnMouseMove(MouseEventArgs e)
 		{
@@ -257,8 +260,6 @@ namespace Duality.Editor.Plugins.Tilemaps
 				MathF.Clamp(newHoz, this.HorizontalScroll.Minimum, this.HorizontalScroll.Maximum);
 				int newVert = this.VerticalScroll.Value - e.Y + this.lastMouseY;
 				MathF.Clamp(newVert, this.VerticalScroll.Minimum, this.VerticalScroll.Maximum);
-				Log.Editor.Write(e.Y + ", " + this.lastMouseY);
-				Log.Editor.Write(this.VerticalScroll.Minimum + ", " + newVert + ", " + this.VerticalScroll.Maximum);
 				this.AutoScrollPosition = new Point(newHoz, newVert);
 				this.lastMouseX = e.X;
 				this.lastMouseY = e.Y;

--- a/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
+++ b/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
@@ -17,6 +17,9 @@ namespace Duality.Editor.Plugins.Tilemaps
 		private Grid<Tile> selectedTiles          = new Grid<Tile>();
 		private Point      actionBeginTilePos     = Point.Empty;
 		private bool       isUserSelecting        = false;
+		private bool isUserScrolling = false;
+		private int lastMouseX = -1;
+		private int lastMouseY = -1;
 
 		public event EventHandler SelectedAreaChanged = null;
 		public event EventHandler SelectedAreaEditingFinished = null;
@@ -199,10 +202,22 @@ namespace Duality.Editor.Plugins.Tilemaps
 					this.HoveredTileIndex = -1;
 				}
 			}
+			if (e.Button == MouseButtons.Middle)
+			{
+				this.isUserScrolling = true;
+				this.lastMouseX = e.X;
+				this.lastMouseY = e.Y;
+			}
 		}
 		protected override void OnMouseUp(MouseEventArgs e)
 		{
 			base.OnMouseUp(e);
+			if (e.Button == MouseButtons.Middle)
+			{
+				this.isUserScrolling = false;
+				this.lastMouseX = -1;
+				this.lastMouseY = -1;
+			}
 			if (!this.isUserSelecting)
 			{
 				this.SelectedArea = Rectangle.Empty;
@@ -235,6 +250,18 @@ namespace Duality.Editor.Plugins.Tilemaps
 						selectionBottomRight.X - selectionTopLeft.X + 1,
 						selectionBottomRight.Y - selectionTopLeft.Y + 1);
 				}
+			}
+			else if (this.isUserScrolling)
+			{
+				int newHoz = this.HorizontalScroll.Value - e.X + this.lastMouseX;
+				MathF.Clamp(newHoz, this.HorizontalScroll.Minimum, this.HorizontalScroll.Maximum);
+				int newVert = this.VerticalScroll.Value - e.Y + this.lastMouseY;
+				MathF.Clamp(newVert, this.VerticalScroll.Minimum, this.VerticalScroll.Maximum);
+				Log.Editor.Write(e.Y + ", " + this.lastMouseY);
+				Log.Editor.Write(this.VerticalScroll.Minimum + ", " + newVert + ", " + this.VerticalScroll.Maximum);
+				this.AutoScrollPosition = new Point(newHoz, newVert);
+				this.lastMouseX = e.X;
+				this.lastMouseY = e.Y;
 			}
 			else
 			{

--- a/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
+++ b/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
@@ -196,6 +196,25 @@ namespace Duality.Editor.Plugins.Tilemaps
 				{
 					this.isUserSelecting = true;
 					this.HoveredTileIndex = -1;
+					if (tileIndex != -1)
+					{
+						Point tilePos = this.GetTilePos(tileIndex);
+						Point displayedBeginPos = this.GetDisplayedTilePos(this.actionBeginTilePos.X, this.actionBeginTilePos.Y);
+						Point displayedCurrentPos = this.GetDisplayedTilePos(tilePos.X, tilePos.Y);
+
+						Point selectionTopLeft = new Point(
+							Math.Min(displayedBeginPos.X, displayedCurrentPos.X),
+							Math.Min(displayedBeginPos.Y, displayedCurrentPos.Y));
+						Point selectionBottomRight = new Point(
+							Math.Max(displayedBeginPos.X, displayedCurrentPos.X),
+							Math.Max(displayedBeginPos.Y, displayedCurrentPos.Y));
+
+						this.SelectedArea = new Rectangle(
+							selectionTopLeft.X,
+							selectionTopLeft.Y,
+							selectionBottomRight.X - selectionTopLeft.X + 1,
+							selectionBottomRight.Y - selectionTopLeft.Y + 1);
+					}
 				}
 			}
 			else if (e.Button == MouseButtons.Left)
@@ -221,6 +240,10 @@ namespace Duality.Editor.Plugins.Tilemaps
 		protected override void OnMouseUp(MouseEventArgs e)
 		{
 			base.OnMouseUp(e);
+			if (!this.isUserSelecting && !this.isUserScrolling)
+			{
+				this.SelectedArea = Rectangle.Empty;
+			}
 			if (e.Button == MouseButtons.Middle)
 			{
 				this.isUserScrolling = false;
@@ -229,10 +252,6 @@ namespace Duality.Editor.Plugins.Tilemaps
 			}
 			if (e.Button == MouseButtons.Left)
 			{
-				if (!this.isUserSelecting)
-				{
-					this.SelectedArea = Rectangle.Empty;
-				}
 				this.isUserSelecting = false;
 				this.RaiseSelectedAreaEditingFinished();
 			}

--- a/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
+++ b/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
@@ -190,7 +190,7 @@ namespace Duality.Editor.Plugins.Tilemaps
 		protected override void OnMouseDown(MouseEventArgs e)
 		{
 			base.OnMouseDown(e);
-			if (e.Button == MouseButtons.Left && Control.ModifierKeys == Keys.Shift)
+			if (e.Button == MouseButtons.Left && Control.ModifierKeys == Keys.Shift && !this.isUserScrolling)
 			{
 				int tileIndex = this.PickTileIndexAt(e.X, e.Y);
 				if (tileIndex != -1)
@@ -228,7 +228,7 @@ namespace Duality.Editor.Plugins.Tilemaps
 					}
 				}
 			}
-			else if (e.Button == MouseButtons.Left)
+			else if (e.Button == MouseButtons.Left && !this.isUserScrolling)
 			{
 				int tileIndex = this.PickTileIndexAt(e.X, e.Y);
 				if (tileIndex != -1)

--- a/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
+++ b/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
@@ -242,7 +242,7 @@ namespace Duality.Editor.Plugins.Tilemaps
 					this.HoveredTileIndex = -1;
 				}
 			}
-			else if (e.Button == MouseButtons.Middle)
+			else if (e.Button == MouseButtons.Middle && !this.isUserSelecting)
 			{
 				this.isUserScrolling = true;
 				this.lastMouseX = e.X;


### PR DESCRIPTION
Added shift+click functionality:
Allows the user to continue editing the selection rectangle in the tile palette after un-clicking. This lets the user modify the selection rectangle at will, without the need to constantly select an 'anchor point' if they want to add a row or column.

Added middle mouse scrolling:
Pressing the middle mouse button now allows the user to dynamically pan around the tile palette window.


These two additional functionalities are atomic. One cannot occur while the other is occurring and vice versa. (this also applies to just left clicking and attempting to scroll)