### PR TITLE
#711 Updated nuget.core to 2.14

### DIFF
--- a/Source/Editor/DualityEditor/DualityEditor.csproj
+++ b/Source/Editor/DualityEditor/DualityEditor.csproj
@@ -54,9 +54,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build" />
-    <Reference Include="NuGet.Core, Version=2.8.50926.602, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Nuget.Core.2.8.3\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
     <Reference Include="PopupControl, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Editor/DualityEditor/PackageManagement/PackageManager.cs
+++ b/Source/Editor/DualityEditor/PackageManagement/PackageManager.cs
@@ -159,7 +159,7 @@ namespace Duality.Editor.PackageManagement
 			this.manager.PackageUninstalled += this.manager_PackageUninstalled;
 			this.cache = new PackageCache(
 				this.repository,
-				repositories.OfType<LocalPackageRepository>().Any());
+				repositories.OfType<LocalPackageRepository>().Any() || repositories.OfType<LazyLocalPackageRepository>().Any());
 
 			this.logger = new PackageManagerLogger();
 			this.manager.Logger = this.logger;

--- a/Source/Editor/DualityEditor/packages.config
+++ b/Source/Editor/DualityEditor/packages.config
@@ -5,5 +5,5 @@
   <package id="AdamsLair.WinForms" version="1.1.16" targetFramework="net45" />
   <package id="AdamsLair.WinForms.PopupControl" version="1.0.0.0" targetFramework="net40" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net40" />
-  <package id="Nuget.Core" version="2.8.3" targetFramework="net40" />
+  <package id="NuGet.Core" version="2.14.0" targetFramework="net45" />
 </packages>

--- a/Test/Editor/DualityEditorTests.csproj
+++ b/Test/Editor/DualityEditorTests.csproj
@@ -45,9 +45,8 @@
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.50926.602, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Core.2.8.3\lib\net40-Client\NuGet.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>

--- a/Test/Editor/packages.config
+++ b/Test/Editor/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.8.3" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.14.0" targetFramework="net45" />
   <package id="NUnit" version="3.11.0" targetFramework="net45" />
   <package id="NUnit.ConsoleRunner" version="3.10.0" targetFramework="net45" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net45" />


### PR DESCRIPTION
TODO:
- [x] Update `nuget.core` to 2.14 to support netstandard (discovered in #710)
- [x] Find out why IsLatestVersion is wrongly set to true for AdamsLair.Duality.TestPlugin 1.0.0.0 in PackageManagerTests.GetLatestDualityPackages
- [x] Come up with a fix for the above problem
- [x] Verify package installs with the official sample packages work as expected.
- [x] Verify package installs with multi-framework targets work as expected (for example Singularity v0.9)
- [x] Build a binary download .zip with the new NuGet and verify both install and restore work as expected.
- [ ] After the merge, upload a new binary .zip to replace the [current one under releases](https://github.com/AdamsLair/duality/releases/tag/v3.0).