### PR TITLE
[WIP] Migrated projects to packagereference

### DIFF
--- a/Source/Core/Duality/Duality.csproj
+++ b/Source/Core/Duality/Duality.csproj
@@ -468,12 +468,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="NVorbis, Version=0.7.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\AdamsLair.NVorbis.0.7.6\lib\portable45-net45+win8+wpa81\NVorbis.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="AdamsLair.NVorbis">
+      <Version>0.7.6</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="AggregateOutput" BeforeTargets="AfterBuild">

--- a/Source/Core/Duality/packages.config
+++ b/Source/Core/Duality/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AdamsLair.NVorbis" version="0.7.6" targetFramework="portable45-net45+win8+wpa81" />
-</packages>

--- a/Source/Editor/DualityEditor/DualityEditor.csproj
+++ b/Source/Editor/DualityEditor/DualityEditor.csproj
@@ -46,19 +46,7 @@
     <LangVersion>4</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AdamsLair.WinForms, Version=1.1.17.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\AdamsLair.WinForms.1.1.17\lib\net45\AdamsLair.WinForms.dll</HintPath>
-    </Reference>
-    <Reference Include="Aga.Controls, Version=1.7.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\AdamsLair.TreeViewAdv.1.7.7\lib\net20\Aga.Controls.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Build" />
-    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="PopupControl, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\AdamsLair.WinForms.PopupControl.1.0.1\lib\net40\PopupControl.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.IO.Compression" />
@@ -66,9 +54,6 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="WeifenLuo.WinFormsUI.Docking, Version=2.8.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\AdamsLair.DockPanelSuite.2.8.2\lib\net20\WeifenLuo.WinFormsUI.Docking.dll</HintPath>
-    </Reference>
     <Reference Include="Windows7.DesktopIntegration">
       <HintPath>.\Windows7.DesktopIntegration.dll</HintPath>
     </Reference>
@@ -391,7 +376,6 @@
     </Compile>
     <None Include="app.config" />
     <None Include="app.manifest" />
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -459,6 +443,23 @@
     <None Include="EmbeddedResources\CursorArrowAction.png" />
     <None Include="EmbeddedResources\CursorArrow.png" />
     <None Include="EmbeddedResources\cog.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AdamsLair.DockPanelSuite">
+      <Version>2.8.2</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.TreeViewAdv">
+      <Version>1.7.7</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.WinForms">
+      <Version>1.1.17</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Web.Xdt">
+      <Version>2.1.1</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Core">
+      <Version>2.14.0</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AggregateOutput" BeforeTargets="AfterBuild">

--- a/Source/Editor/DualityEditor/packages.config
+++ b/Source/Editor/DualityEditor/packages.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AdamsLair.DockPanelSuite" version="2.8.2" targetFramework="net45" />
-  <package id="AdamsLair.TreeViewAdv" version="1.7.7" targetFramework="net45" />
-  <package id="AdamsLair.WinForms" version="1.1.17" targetFramework="net45" />
-  <package id="AdamsLair.WinForms.PopupControl" version="1.0.1" targetFramework="net45" />
-  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net40" />
-  <package id="NuGet.Core" version="2.14.0" targetFramework="net45" />
-</packages>

--- a/Source/Platform/DefaultOpenTK/DefaultOpenTK.Core.csproj
+++ b/Source/Platform/DefaultOpenTK/DefaultOpenTK.Core.csproj
@@ -88,7 +88,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="AdamsLair.OpenTK">
+      <Version>1.2.2</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AggregateOutput" BeforeTargets="AfterBuild">

--- a/Source/Platform/DefaultOpenTK/packages.config
+++ b/Source/Platform/DefaultOpenTK/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AdamsLair.OpenTK" version="1.2.2" targetFramework="net45" />
-</packages>

--- a/Source/Platform/DefaultOpenTKEditor/DefaultOpenTK.Editor.csproj
+++ b/Source/Platform/DefaultOpenTKEditor/DefaultOpenTK.Editor.csproj
@@ -79,7 +79,12 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="AdamsLair.OpenTK">
+      <Version>1.2.2</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.OpenTK.GLControl">
+      <Version>1.2.2</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AggregateOutput" BeforeTargets="AfterBuild">

--- a/Source/Platform/DefaultOpenTKEditor/packages.config
+++ b/Source/Platform/DefaultOpenTKEditor/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AdamsLair.OpenTK" version="1.2.2" targetFramework="net45" />
-  <package id="AdamsLair.OpenTK.GLControl" version="1.2.2" targetFramework="net45" />
-</packages>

--- a/Source/Plugins/EditorBase/EditorBase.Editor.csproj
+++ b/Source/Plugins/EditorBase/EditorBase.Editor.csproj
@@ -39,20 +39,11 @@
     <LangVersion>4</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AdamsLair.WinForms, Version=1.1.17.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\AdamsLair.WinForms.1.1.17\lib\net45\AdamsLair.WinForms.dll</HintPath>
-    </Reference>
-    <Reference Include="PopupControl, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\AdamsLair.WinForms.PopupControl.1.0.1\lib\net40\PopupControl.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="WeifenLuo.WinFormsUI.Docking, Version=2.8.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\AdamsLair.DockPanelSuite.2.8.2\lib\net20\WeifenLuo.WinFormsUI.Docking.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DataConverters\ComponentFromSound.cs" />
@@ -202,7 +193,14 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Include="AdamsLair.DockPanelSuite">
+      <Version>2.8.2</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.WinForms">
+      <Version>1.1.17</Version>
+    </PackageReference>
+  </ItemGroup>
   <ItemGroup>
     <None Include="EmbeddedResources\IconHideIndices.png" />
     <None Include="EmbeddedResources\IconRevealIndices.png" />
@@ -227,7 +225,6 @@
     <Content Include="EmbeddedResources\eye.ico" />
     <None Include="EmbeddedResources\IconSpeakerBlack.png" />
     <None Include="EmbeddedResources\IconSpeakerWhite.png" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AggregateOutput" BeforeTargets="AfterBuild">

--- a/Source/Plugins/EditorBase/packages.config
+++ b/Source/Plugins/EditorBase/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AdamsLair.DockPanelSuite" version="2.8.2" targetFramework="net45" />
-  <package id="AdamsLair.WinForms" version="1.1.17" targetFramework="net45" />
-  <package id="AdamsLair.WinForms.PopupControl" version="1.0.1" targetFramework="net45" />
-</packages>

--- a/Source/Plugins/EditorModules/CamView/CamView.Editor.csproj
+++ b/Source/Plugins/EditorModules/CamView/CamView.Editor.csproj
@@ -159,7 +159,14 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Include="AdamsLair.DockPanelSuite">
+      <Version>2.8.2</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.WinForms">
+      <Version>1.1.17</Version>
+    </PackageReference>
+  </ItemGroup>
   <ItemGroup>
     <Content Include="EmbeddedResources\iconShapeSelect.png" />
     <Content Include="EmbeddedResources\monitor.png" />
@@ -181,7 +188,6 @@
     <None Include="EmbeddedResources\iconCmpEdgeCollider.png" />
     <None Include="EmbeddedResources\iconCmpLoopCollider.png" />
     <None Include="EmbeddedResources\magnifier_one.png" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AggregateOutput" BeforeTargets="AfterBuild">

--- a/Source/Plugins/EditorModules/CamView/packages.config
+++ b/Source/Plugins/EditorModules/CamView/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AdamsLair.DockPanelSuite" version="2.8.2" targetFramework="net45" />
-  <package id="AdamsLair.WinForms" version="1.1.17" targetFramework="net45" />
-  <package id="AdamsLair.WinForms.PopupControl" version="1.0.1" targetFramework="net45" />
-</packages>

--- a/Source/Plugins/EditorModules/HelpAdvisor/HelpAdvisor.Editor.csproj
+++ b/Source/Plugins/EditorModules/HelpAdvisor/HelpAdvisor.Editor.csproj
@@ -36,20 +36,11 @@
     <LangVersion>4</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AdamsLair.WinForms, Version=1.1.17.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\AdamsLair.WinForms.1.1.17\lib\net45\AdamsLair.WinForms.dll</HintPath>
-    </Reference>
-    <Reference Include="PopupControl, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\AdamsLair.WinForms.PopupControl.1.0.1\lib\net40\PopupControl.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
-    <Reference Include="WeifenLuo.WinFormsUI.Docking, Version=2.8.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\AdamsLair.DockPanelSuite.2.8.2\lib\net20\WeifenLuo.WinFormsUI.Docking.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="HelpAdvisor.cs">
@@ -96,7 +87,14 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="EmbeddedResources\help.png" />
-    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AdamsLair.DockPanelSuite">
+      <Version>2.8.2</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.WinForms">
+      <Version>1.1.17</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AggregateOutput" BeforeTargets="AfterBuild">

--- a/Source/Plugins/EditorModules/HelpAdvisor/packages.config
+++ b/Source/Plugins/EditorModules/HelpAdvisor/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AdamsLair.DockPanelSuite" version="2.8.2" targetFramework="net45" />
-  <package id="AdamsLair.WinForms" version="1.1.17" targetFramework="net45" />
-  <package id="AdamsLair.WinForms.PopupControl" version="1.0.1" targetFramework="net45" />
-</packages>

--- a/Source/Plugins/EditorModules/LogView/LogView.Editor.csproj
+++ b/Source/Plugins/EditorModules/LogView/LogView.Editor.csproj
@@ -107,7 +107,14 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Include="AdamsLair.DockPanelSuite">
+      <Version>2.8.2</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.WinForms">
+      <Version>1.1.17</Version>
+    </PackageReference>
+  </ItemGroup>
   <ItemGroup>
     <None Include="EmbeddedResources\bell.png" />
     <None Include="EmbeddedResources\cross.png" />
@@ -119,7 +126,6 @@
     <None Include="EmbeddedResources\log_warning.png" />
     <None Include="EmbeddedResources\logview.ico" />
     <None Include="EmbeddedResources\logview.png" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AggregateOutput" BeforeTargets="AfterBuild">

--- a/Source/Plugins/EditorModules/LogView/packages.config
+++ b/Source/Plugins/EditorModules/LogView/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AdamsLair.DockPanelSuite" version="2.8.2" targetFramework="net45" />
-  <package id="AdamsLair.WinForms" version="1.1.17" targetFramework="net45" />
-  <package id="AdamsLair.WinForms.PopupControl" version="1.0.1" targetFramework="net45" />
-</packages>

--- a/Source/Plugins/EditorModules/ObjectInspector/ObjectInspector.Editor.csproj
+++ b/Source/Plugins/EditorModules/ObjectInspector/ObjectInspector.Editor.csproj
@@ -113,7 +113,14 @@
     <None Include="EmbeddedResources\bug.png" />
     <None Include="EmbeddedResources\page_copy.png" />
     <None Include="EmbeddedResources\lock.png" />
-    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AdamsLair.DockPanelSuite">
+      <Version>2.8.2</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.WinForms">
+      <Version>1.1.17</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AggregateOutput" BeforeTargets="AfterBuild">

--- a/Source/Plugins/EditorModules/ObjectInspector/packages.config
+++ b/Source/Plugins/EditorModules/ObjectInspector/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AdamsLair.DockPanelSuite" version="2.8.2" targetFramework="net45" />
-  <package id="AdamsLair.WinForms" version="1.1.17" targetFramework="net45" />
-  <package id="AdamsLair.WinForms.PopupControl" version="1.0.1" targetFramework="net45" />
-</packages>

--- a/Source/Plugins/EditorModules/PackageManagerFrontend/PackageManagerFrontend.Editor.csproj
+++ b/Source/Plugins/EditorModules/PackageManagerFrontend/PackageManagerFrontend.Editor.csproj
@@ -112,9 +112,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="EmbeddedResources\core.png" />
     <Content Include="EmbeddedResources\editor.png" />
     <None Include="EmbeddedResources\filter.png" />
@@ -145,6 +142,17 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AdamsLair.DockPanelSuite">
+      <Version>2.8.2</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.TreeViewAdv">
+      <Version>1.7.7</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.WinForms">
+      <Version>1.1.17</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AggregateOutput" BeforeTargets="AfterBuild">

--- a/Source/Plugins/EditorModules/PackageManagerFrontend/packages.config
+++ b/Source/Plugins/EditorModules/PackageManagerFrontend/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AdamsLair.DockPanelSuite" version="2.8.2" targetFramework="net45" />
-  <package id="AdamsLair.TreeViewAdv" version="1.7.7" targetFramework="net45" />
-  <package id="AdamsLair.WinForms" version="1.1.17" targetFramework="net45" />
-  <package id="AdamsLair.WinForms.PopupControl" version="1.0.1" targetFramework="net45" />
-</packages>

--- a/Source/Plugins/EditorModules/ProjectView/ProjectView.Editor.csproj
+++ b/Source/Plugins/EditorModules/ProjectView/ProjectView.Editor.csproj
@@ -108,7 +108,17 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Include="AdamsLair.DockPanelSuite">
+      <Version>2.8.2</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.TreeViewAdv">
+      <Version>1.7.7</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.WinForms">
+      <Version>1.1.17</Version>
+    </PackageReference>
+  </ItemGroup>
   <ItemGroup>
     <None Include="EmbeddedResources\page_white_put.png" />
     <None Include="EmbeddedResources\WorkingFolderIcon16.png" />
@@ -119,7 +129,6 @@
     <None Include="EmbeddedResources\page_paste.png" />
     <None Include="EmbeddedResources\folder.png" />
     <Content Include="EmbeddedResources\projectview.ico" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AggregateOutput" BeforeTargets="AfterBuild">

--- a/Source/Plugins/EditorModules/ProjectView/packages.config
+++ b/Source/Plugins/EditorModules/ProjectView/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AdamsLair.DockPanelSuite" version="2.8.2" targetFramework="net45" />
-  <package id="AdamsLair.TreeViewAdv" version="1.7.7" targetFramework="net45" />
-  <package id="AdamsLair.WinForms" version="1.1.17" targetFramework="net45" />
-  <package id="AdamsLair.WinForms.PopupControl" version="1.0.1" targetFramework="net45" />
-</packages>

--- a/Source/Plugins/EditorModules/SceneView/SceneView.Editor.csproj
+++ b/Source/Plugins/EditorModules/SceneView/SceneView.Editor.csproj
@@ -108,7 +108,17 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Include="AdamsLair.DockPanelSuite">
+      <Version>2.8.2</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.TreeViewAdv">
+      <Version>1.7.7</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.WinForms">
+      <Version>1.1.17</Version>
+    </PackageReference>
+  </ItemGroup>
   <ItemGroup>
     <None Include="EmbeddedResources\iconCmpUnknown.png" />
     <None Include="EmbeddedResources\overlayLinkBroken.png" />
@@ -121,7 +131,6 @@
     <None Include="EmbeddedResources\page_paste.png" />
     <None Include="EmbeddedResources\lock.png" />
     <Content Include="EmbeddedResources\eye_cross.png" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AggregateOutput" BeforeTargets="AfterBuild">

--- a/Source/Plugins/EditorModules/SceneView/packages.config
+++ b/Source/Plugins/EditorModules/SceneView/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AdamsLair.DockPanelSuite" version="2.8.2" targetFramework="net45" />
-  <package id="AdamsLair.TreeViewAdv" version="1.7.7" targetFramework="net45" />
-  <package id="AdamsLair.WinForms" version="1.1.17" targetFramework="net45" />
-  <package id="AdamsLair.WinForms.PopupControl" version="1.0.1" targetFramework="net45" />
-</packages>

--- a/Source/Plugins/Tilemaps/Editor/Tilemaps.Editor.csproj
+++ b/Source/Plugins/Tilemaps/Editor/Tilemaps.Editor.csproj
@@ -182,9 +182,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="Modules\TilemapSetupDialog.resx">
       <DependentUpon>TilemapSetupDialog.cs</DependentUpon>
     </EmbeddedResource>
@@ -250,6 +247,17 @@
     <None Include="EmbeddedResources\CursorPick.png" />
     <None Include="EmbeddedResources\IconPick.png" />
     <Content Include="EmbeddedResources\IconTileOval.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AdamsLair.DockPanelSuite">
+      <Version>2.8.2</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.TreeViewAdv">
+      <Version>1.7.7</Version>
+    </PackageReference>
+    <PackageReference Include="AdamsLair.WinForms">
+      <Version>1.1.17</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AggregateOutput" BeforeTargets="AfterBuild">

--- a/Source/Plugins/Tilemaps/Editor/packages.config
+++ b/Source/Plugins/Tilemaps/Editor/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AdamsLair.DockPanelSuite" version="2.8.2" targetFramework="net45" />
-  <package id="AdamsLair.TreeViewAdv" version="1.7.7" targetFramework="net45" />
-  <package id="AdamsLair.WinForms" version="1.1.17" targetFramework="net45" />
-  <package id="AdamsLair.WinForms.PopupControl" version="1.0.1" targetFramework="net45" />
-</packages>

--- a/Test/Core/DualityTests.csproj
+++ b/Test/Core/DualityTests.csproj
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props')" />
-  <Import Project="..\..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -18,6 +16,8 @@
     <TargetFrameworkProfile />
     <RestorePackages>true</RestorePackages>
     <OutputPath>$(SolutionDir)Build\Output\</OutputPath>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,9 +41,6 @@
     <LangVersion>4</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Xml.Linq" />
@@ -185,9 +182,6 @@
     <None Include="EmbeddedResources\CanvasTestDiagonalLine.png" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="EmbeddedResources\CanvasTestAllShapes.png" />
     <Content Include="EmbeddedResources\CanvasTestAllShapesTransformed.png" />
     <Content Include="EmbeddedResources\TexCoordUV.png" />
@@ -195,12 +189,19 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit">
+      <Version>3.11.0</Version>
+    </PackageReference>
+    <PackageReference Include="NUnit.ConsoleRunner">
+      <Version>3.10.0</Version>
+    </PackageReference>
+    <PackageReference Include="NUnit.Extension.NUnitProjectLoader">
+      <Version>3.6.0</Version>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter">
+      <Version>3.13.0</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.11.0\build\NUnit.props'))" />
-    <Error Condition="!Exists('..\..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props'))" />
-  </Target>
 </Project>

--- a/Test/Core/packages.config
+++ b/Test/Core/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="3.11.0" targetFramework="net45" />
-  <package id="NUnit.ConsoleRunner" version="3.10.0" targetFramework="net45" />
-  <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net45" />
-  <package id="NUnit3TestAdapter" version="3.13.0" targetFramework="net45" />
-</packages>

--- a/Test/Editor/DualityEditorTests.csproj
+++ b/Test/Editor/DualityEditorTests.csproj
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props')" />
-  <Import Project="..\..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -18,6 +16,8 @@
     <TargetFrameworkProfile />
     <RestorePackages>true</RestorePackages>
     <OutputPath>$(SolutionDir)Build\Output\</OutputPath>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,16 +41,6 @@
     <LangVersion>4</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Drawing" />
@@ -90,17 +80,27 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Web.Xdt">
+      <Version>2.1.1</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Core">
+      <Version>2.14.0</Version>
+    </PackageReference>
+    <PackageReference Include="NUnit">
+      <Version>3.11.0</Version>
+    </PackageReference>
+    <PackageReference Include="NUnit.ConsoleRunner">
+      <Version>3.10.0</Version>
+    </PackageReference>
+    <PackageReference Include="NUnit.Extension.NUnitProjectLoader">
+      <Version>3.6.0</Version>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter">
+      <Version>3.13.0</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.11.0\build\NUnit.props'))" />
-    <Error Condition="!Exists('..\..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props'))" />
-  </Target>
 </Project>

--- a/Test/Editor/packages.config
+++ b/Test/Editor/packages.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.14.0" targetFramework="net45" />
-  <package id="NUnit" version="3.11.0" targetFramework="net45" />
-  <package id="NUnit.ConsoleRunner" version="3.10.0" targetFramework="net45" />
-  <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net45" />
-  <package id="NUnit3TestAdapter" version="3.13.0" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
Migration went pretty smooth but noticed some build errors:
![image](https://user-images.githubusercontent.com/19387223/57397004-f25d2080-71cb-11e9-8c64-40cc6d2c59b7.png)

Seems it does not copy some references to the build output folder for some reason. Not sure why. I tested it with a .NET framework console app and it works correctly in that case so it might be that the portable target is causing issues here.