### PR TITLE
690 - Fixed incorrect tileset selection on resizing palette

### DIFF
--- a/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
+++ b/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
@@ -86,6 +86,19 @@ namespace Duality.Editor.Plugins.Tilemaps
 		protected override void OnTileDisplayModeChanged()
 		{
 			base.OnTileDisplayModeChanged();
+
+			// Remove selection if it extends beyound selectable boundaries now that the layout 
+			// may have changed. 
+			// Note that this only handles cases where the updated selection would tap outside 
+			// the valid region. If it's still within after the layout change, this code won't
+			// trigger and UpdateSelectedTiles will properly redo the mapping, which is probably
+			// just fine for now.
+			if (this.DisplayedTileCount.X < this.SelectedArea.X + this.SelectedArea.Width ||
+				this.DisplayedTileCount.Y < this.SelectedArea.Y + this.SelectedArea.Height)
+			{
+				this.SelectedArea = Rectangle.Empty;
+			}
+
 			this.UpdateSelectedTiles();
 			this.RaiseSelectedAreaChanged();
 			this.RaiseSelectedAreaEditingFinished();
@@ -323,13 +336,6 @@ namespace Duality.Editor.Plugins.Tilemaps
 
 		private void UpdateSelectedTiles()
 		{
-			if (this.DisplayedTileCount.X < this.SelectedArea.X + this.SelectedArea.Width ||
-				this.DisplayedTileCount.Y < this.SelectedArea.Y + this.SelectedArea.Height)
-			{
-				this.SelectedArea = Rectangle.Empty;
-				this.areTilesSelected = false;
-			}
-
 			// Allocate and clear a tile rect space of the appropriate size.
 			this.selectedTiles.ResizeClear(this.selectedArea.Width, this.selectedArea.Height);
 

--- a/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
+++ b/Source/Plugins/Tilemaps/Editor/Modules/SourcePaletteTilesetView.cs
@@ -323,6 +323,13 @@ namespace Duality.Editor.Plugins.Tilemaps
 
 		private void UpdateSelectedTiles()
 		{
+			if (this.DisplayedTileCount.X < this.SelectedArea.X + this.SelectedArea.Width ||
+				this.DisplayedTileCount.Y < this.SelectedArea.Y + this.SelectedArea.Height)
+			{
+				this.SelectedArea = Rectangle.Empty;
+				this.areTilesSelected = false;
+			}
+
 			// Allocate and clear a tile rect space of the appropriate size.
 			this.selectedTiles.ResizeClear(this.selectedArea.Width, this.selectedArea.Height);
 


### PR DESCRIPTION
Very simple fix to #690. Essentially just a check whenever selected tiles are updated that they are within the bounds of the selectable tiles. If this isn't the case, the selection is deselected entirely. 
