### PR TITLE
WIP: Add camera tilt support

### DIFF
--- a/Source/Core/Duality/Components/Camera.cs
+++ b/Source/Core/Duality/Components/Camera.cs
@@ -30,6 +30,7 @@ namespace Duality.Components
 		private ContentRef<RenderSetup>   renderSetup      = null;
 		private int                       priority         = 0;
 		private ShaderParameterCollection shaderParameters = new ShaderParameterCollection();
+		private Vector2                   tilt             = Vector2.Zero;
 
 		[DontSerialize] private DrawDevice         drawDevice      = null;
 		[DontSerialize] private DrawDevice         transformDevice = null;
@@ -177,6 +178,23 @@ namespace Duality.Components
 		public ShaderParameterCollection ShaderParameters
 		{
 			get { return this.shaderParameters; }
+		}
+		/// <summary>
+		/// [GET / SET] The camera orientation angles along the x and y axis in radians, used when
+		/// calculting the view matrix.
+		/// </summary>
+		public Vector2 Tilt
+		{
+			get { return this.tilt; }
+			set { this.tilt = value; }
+		}
+
+		/// <summary>
+		/// [GET] The camera's tilt angles along the x, y, and z axis in radians.
+		/// </summary>
+		public Vector3 Orientation
+		{
+			get { return new Vector3(this.tilt, this.gameobj.Transform.Angle); }
 		}
 		/// <summary>
 		/// [GET] Rendered image / screen space offset between the rendered <see cref="TargetRect"/> center
@@ -441,7 +459,7 @@ namespace Duality.Components
 			if (this.drawDevice == null) this.SetupDrawDevice();
 
 			this.drawDevice.ViewerPos = this.gameobj.Transform.Pos;
-			this.drawDevice.ViewerAngle = this.gameobj.Transform.Angle;
+			this.drawDevice.ViewerOrientation = this.Orientation;
 			this.drawDevice.NearZ = this.nearZ;
 			this.drawDevice.FarZ = this.farZ;
 			this.drawDevice.FocusDist = this.focusDist;
@@ -474,7 +492,7 @@ namespace Duality.Components
 			if (this.transformDevice == null) this.SetupTransformDevice();
 
 			this.transformDevice.ViewerPos = this.gameobj.Transform.Pos;
-			this.transformDevice.ViewerAngle = this.gameobj.Transform.Angle;
+			this.transformDevice.ViewerOrientation = this.Orientation;
 			this.transformDevice.NearZ = this.nearZ;
 			this.transformDevice.FarZ = this.farZ;
 			this.transformDevice.FocusDist = this.focusDist;

--- a/Source/Core/Duality/Components/Camera.cs
+++ b/Source/Core/Duality/Components/Camera.cs
@@ -192,21 +192,13 @@ namespace Duality.Components
 		/// [GET / SET] The camera orientation angles along the x and y axis in radians, used when
 		/// calculting the view matrix.
 		/// </summary>
-		[EditorHintFlags(MemberFlags.Invisible)]
-		public Vector2 TiltInRadians
+		private Vector2 TiltInRadians
 		{
 			get { return this.tilt; }
 			set {
 				this.tilt.X = MathF.NormalizeAngle(value.X);
 				this.tilt.Y = MathF.NormalizeAngle(value.Y);
 			}
-		}
-		/// <summary>
-		/// [GET] The camera's tilt angles along the x, y, and z axis in radians.
-		/// </summary>
-		public Vector3 Orientation
-		{
-			get { return new Vector3(this.tilt, this.gameobj.Transform.Angle); }
 		}
 		/// <summary>
 		/// [GET] Rendered image / screen space offset between the rendered <see cref="TargetRect"/> center
@@ -471,7 +463,8 @@ namespace Duality.Components
 			if (this.drawDevice == null) this.SetupDrawDevice();
 
 			this.drawDevice.ViewerPos = this.gameobj.Transform.Pos;
-			this.drawDevice.ViewerOrientation = this.Orientation;
+			this.drawDevice.ViewerAngle = this.gameobj.Transform.Angle;
+			this.drawDevice.ViewerTilt = this.TiltInRadians;
 			this.drawDevice.NearZ = this.nearZ;
 			this.drawDevice.FarZ = this.farZ;
 			this.drawDevice.FocusDist = this.focusDist;
@@ -504,7 +497,8 @@ namespace Duality.Components
 			if (this.transformDevice == null) this.SetupTransformDevice();
 
 			this.transformDevice.ViewerPos = this.gameobj.Transform.Pos;
-			this.transformDevice.ViewerOrientation = this.Orientation;
+			this.transformDevice.ViewerAngle= this.gameobj.Transform.Angle;
+			this.transformDevice.ViewerTilt = this.TiltInRadians;
 			this.transformDevice.NearZ = this.nearZ;
 			this.transformDevice.FarZ = this.farZ;
 			this.transformDevice.FocusDist = this.focusDist;

--- a/Source/Core/Duality/Components/Camera.cs
+++ b/Source/Core/Duality/Components/Camera.cs
@@ -180,15 +180,27 @@ namespace Duality.Components
 			get { return this.shaderParameters; }
 		}
 		/// <summary>
-		/// [GET / SET] The camera orientation angles along the x and y axis in radians, used when
+		/// [GET / SET] The camera orientation angles along the x and y axis in degrees, used when
 		/// calculting the view matrix.
 		/// </summary>
 		public Vector2 Tilt
 		{
-			get { return this.tilt; }
-			set { this.tilt = value; }
+			get { return new Vector2(MathF.RadToDeg(this.tilt.X), MathF.RadToDeg(this.tilt.Y)); }
+			set { this.TiltInRadians = new Vector2(MathF.DegToRad(value.X), MathF.DegToRad(value.Y)); }
 		}
-
+		/// <summary>
+		/// [GET / SET] The camera orientation angles along the x and y axis in radians, used when
+		/// calculting the view matrix.
+		/// </summary>
+		[EditorHintFlags(MemberFlags.Invisible)]
+		public Vector2 TiltInRadians
+		{
+			get { return this.tilt; }
+			set {
+				this.tilt.X = MathF.NormalizeAngle(value.X);
+				this.tilt.Y = MathF.NormalizeAngle(value.Y);
+			}
+		}
 		/// <summary>
 		/// [GET] The camera's tilt angles along the x, y, and z axis in radians.
 		/// </summary>

--- a/Source/Core/Duality/Drawing/DrawDevice.cs
+++ b/Source/Core/Duality/Drawing/DrawDevice.cs
@@ -708,6 +708,8 @@ namespace Duality.Drawing
 				this.matView *= Matrix4.CreateTranslation(-this.viewerPos);
 				// Rotate opposite to camera angle
 				this.matView *= Matrix4.CreateRotationZ(-this.viewerOrientation.Z);
+				this.matView *= Matrix4.CreateRotationY(-this.viewerOrientation.Y);
+				this.matView *= Matrix4.CreateRotationX(-this.viewerOrientation.X);
 			}
 		}
 		private void UpdateProjectionMatrix()

--- a/Source/Core/Duality/Drawing/DrawDevice.cs
+++ b/Source/Core/Duality/Drawing/DrawDevice.cs
@@ -197,13 +197,23 @@ namespace Duality.Drawing
 				this.UpdateMatrices();
 			}
 		}
-		public Vector3 ViewerOrientation
+		public float ViewerAngle
 		{
-			get { return this.viewerOrientation; }
+			get { return this.viewerOrientation.Z; }
 			set
 			{
-				if (this.viewerOrientation == value) return;
-				this.viewerOrientation = value;
+				if (this.viewerOrientation.Z == value) return;
+				this.viewerOrientation.Z = value;
+				this.UpdateMatrices();
+			}
+		}
+		public Vector2 ViewerTilt
+		{
+			get { return this.viewerOrientation.Xy; }
+			set
+			{
+				if (this.viewerOrientation.Xy == value) return;
+				this.viewerOrientation.Xy = value;
 				this.UpdateMatrices();
 			}
 		}

--- a/Source/Core/Duality/Drawing/DrawDevice.cs
+++ b/Source/Core/Duality/Drawing/DrawDevice.cs
@@ -156,7 +156,7 @@ namespace Duality.Drawing
 		private Vector2                   targetSize       = Vector2.Zero;
 		private Rect                      viewportRect     = Rect.Empty;
 		private Vector3                   viewerPos        = Vector3.Zero;
-		private float                     viewerAngle      = 0.0f;
+		private Vector3                   viewerOrientation= Vector3.Zero;
 		private ContentRef<RenderTarget>  renderTarget     = null;
 		private ProjectionMode            projection       = ProjectionMode.Perspective;
 		private Matrix4                   matView          = Matrix4.Identity;
@@ -197,13 +197,13 @@ namespace Duality.Drawing
 				this.UpdateMatrices();
 			}
 		}
-		public float ViewerAngle
+		public Vector3 ViewerOrientation
 		{
-			get { return this.viewerAngle; }
+			get { return this.viewerOrientation; }
 			set
 			{
-				if (this.viewerAngle == value) return;
-				this.viewerAngle = value;
+				if (this.viewerOrientation == value) return;
+				this.viewerOrientation = value;
 				this.UpdateMatrices();
 			}
 		}
@@ -707,7 +707,7 @@ namespace Duality.Drawing
 				// Translate opposite to camera position
 				this.matView *= Matrix4.CreateTranslation(-this.viewerPos);
 				// Rotate opposite to camera angle
-				this.matView *= Matrix4.CreateRotationZ(-this.viewerAngle);
+				this.matView *= Matrix4.CreateRotationZ(-this.viewerOrientation.Z);
 			}
 		}
 		private void UpdateProjectionMatrix()

--- a/Source/Core/Duality/Drawing/DrawDevice.cs
+++ b/Source/Core/Duality/Drawing/DrawDevice.cs
@@ -432,14 +432,15 @@ namespace Duality.Drawing
 			clipPos.X *= invClipW;
 			clipPos.Y *= invClipW;
 			clipPos.Z *= invClipW;
-			Vector2 clipRadius;
+			Vector3 clipRadius;
 			clipRadius.X = radius * Math.Abs(this.matProjection.Row0.X) * invClipW;
 			clipRadius.Y = radius * Math.Abs(this.matProjection.Row1.Y) * invClipW;
+			clipRadius.Z = radius * Math.Abs(this.matProjection.Row2.Z) * invClipW;
 
 			// Check if the result would still be within valid device coordinates
 			return 
-				clipPos.Z >= -1.0f &&
-				clipPos.Z <= 1.0f &&
+				clipPos.Z >= -1.0f - clipRadius.Z && 
+				clipPos.Z <= 1.0f + clipRadius.Z &&
 				clipPos.X >= -1.0f - clipRadius.X &&
 				clipPos.X <= 1.0f + clipRadius.X &&
 				clipPos.Y >= -1.0f - clipRadius.Y &&

--- a/Source/Core/Duality/Drawing/IDrawDevice.cs
+++ b/Source/Core/Duality/Drawing/IDrawDevice.cs
@@ -22,9 +22,10 @@ namespace Duality.Drawing
 		/// </summary>
 		Vector3 ViewerPos { get; }
 		/// <summary>
-		/// [GET] Reference angle for rendering i.e. the angle of the drawing device's virtual camera.
+		/// [GET] Reference angles for rendering i.e. the tilt angles of the drawing device's virtual camera
+		/// in radians.
 		/// </summary>
-		float ViewerAngle { get; }
+		Vector3 ViewerOrientation { get; }
 		/// <summary>
 		/// [GET] Reference distance for calculating the perspective effect. An object this far away from
 		/// the camera will appear in its original size.

--- a/Source/Core/Duality/Drawing/IDrawDevice.cs
+++ b/Source/Core/Duality/Drawing/IDrawDevice.cs
@@ -21,11 +21,14 @@ namespace Duality.Drawing
 		/// [GET] Reference coordinate for rendering i.e. the position of the drawing device's virtual camera.
 		/// </summary>
 		Vector3 ViewerPos { get; }
+		/// [GET] Reference angle for rendering i.e. the angle (in radians) of the drawing device's virtual
+		/// camera around the z axis.
+		float ViewerAngle { get; }
 		/// <summary>
 		/// [GET] Reference angles for rendering i.e. the tilt angles of the drawing device's virtual camera
-		/// in radians.
+		/// in radians around the x and y axis.
 		/// </summary>
-		Vector3 ViewerOrientation { get; }
+		Vector2 ViewerTilt { get; }
 		/// <summary>
 		/// [GET] Reference distance for calculating the perspective effect. An object this far away from
 		/// the camera will appear in its original size.

--- a/Source/Core/Duality/Utility/Log/VisualLogEntries/VisualLogTextEntry.cs
+++ b/Source/Core/Duality/Utility/Log/VisualLogEntries/VisualLogTextEntry.cs
@@ -79,7 +79,7 @@ namespace Duality
 			// Draw text and background
 			target.State.ColorTint = target.State.ColorTint.WithAlpha(target.State.ColorTint.A * 2.0f / 255.0f);
 			target.State.ColorTint *= this.Color;
-			if (worldSpace) target.State.TransformAngle = target.DrawDevice.ViewerAngle;
+			if (worldSpace) target.State.TransformAngle = target.DrawDevice.ViewerOrientation.Z; // TODO: figure out what this should be
 			target.State.TransformScale = new Vector2(textScale, textScale);
 			target.DrawText(
 				this.lines,

--- a/Source/Core/Duality/Utility/Log/VisualLogEntries/VisualLogTextEntry.cs
+++ b/Source/Core/Duality/Utility/Log/VisualLogEntries/VisualLogTextEntry.cs
@@ -79,7 +79,7 @@ namespace Duality
 			// Draw text and background
 			target.State.ColorTint = target.State.ColorTint.WithAlpha(target.State.ColorTint.A * 2.0f / 255.0f);
 			target.State.ColorTint *= this.Color;
-			if (worldSpace) target.State.TransformAngle = target.DrawDevice.ViewerOrientation.Z; // TODO: figure out what this should be
+			if (worldSpace) target.State.TransformAngle = target.DrawDevice.ViewerAngle; // TODO: figure out what this should be
 			target.State.TransformScale = new Vector2(textScale, textScale);
 			target.DrawText(
 				this.lines,

--- a/Source/Plugins/Tilemaps/Core/Tilemaps/TilemapCulling.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilemaps/TilemapCulling.cs
@@ -113,7 +113,7 @@ namespace Duality.Plugins.Tilemaps
 			}
 
 			// Determine the edge length of a square that is big enough to enclose the world space rect of the Camera view
-			float visualAngle = input.TilemapAngle - device.ViewerAngle;
+			float visualAngle = input.TilemapAngle - device.ViewerOrientation.Z; // TODO: Tilemaps are broken with this change, need to fix
 			Vector2 visualBounds = new Vector2(
 				device.TargetSize.Y * MathF.Abs(MathF.Sin(visualAngle)) + device.TargetSize.X * MathF.Abs(MathF.Cos(visualAngle)),
 				device.TargetSize.X * MathF.Abs(MathF.Sin(visualAngle)) + device.TargetSize.Y * MathF.Abs(MathF.Cos(visualAngle)));

--- a/Source/Plugins/Tilemaps/Core/Tilemaps/TilemapCulling.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilemaps/TilemapCulling.cs
@@ -113,7 +113,7 @@ namespace Duality.Plugins.Tilemaps
 			}
 
 			// Determine the edge length of a square that is big enough to enclose the world space rect of the Camera view
-			float visualAngle = input.TilemapAngle - device.ViewerOrientation.Z; // TODO: Tilemaps are broken with this change, need to fix
+			float visualAngle = input.TilemapAngle - device.ViewerAngle; // TODO: Tilemaps are broken with this change, need to fix
 			Vector2 visualBounds = new Vector2(
 				device.TargetSize.Y * MathF.Abs(MathF.Sin(visualAngle)) + device.TargetSize.X * MathF.Abs(MathF.Cos(visualAngle)),
 				device.TargetSize.X * MathF.Abs(MathF.Sin(visualAngle)) + device.TargetSize.Y * MathF.Abs(MathF.Cos(visualAngle)));

--- a/Test/Core/Drawing/DrawDeviceTest.cs
+++ b/Test/Core/Drawing/DrawDeviceTest.cs
@@ -22,7 +22,7 @@ namespace Duality.Tests.Drawing
 				device.Projection = ProjectionMode.Screen;
 
 				// Screen space mode is supposed to ignore view dependent settings
-				device.ViewerOrientation = new Vector3(0, 0, MathF.DegToRad(90.0f));
+				device.ViewerAngle = MathF.DegToRad(90.0f);
 				device.ViewerPos = new Vector3(7000, 8000, -500);
 				device.FocusDist = 500;
 				device.NearZ = 100;

--- a/Test/Core/Drawing/DrawDeviceTest.cs
+++ b/Test/Core/Drawing/DrawDeviceTest.cs
@@ -22,7 +22,7 @@ namespace Duality.Tests.Drawing
 				device.Projection = ProjectionMode.Screen;
 
 				// Screen space mode is supposed to ignore view dependent settings
-				device.ViewerAngle = MathF.DegToRad(90.0f);
+				device.ViewerOrientation = new Vector3(0, 0, MathF.DegToRad(90.0f));
 				device.ViewerPos = new Vector3(7000, 8000, -500);
 				device.FocusDist = 500;
 				device.NearZ = 100;

--- a/Test/Core/Drawing/DrawDeviceTest.cs
+++ b/Test/Core/Drawing/DrawDeviceTest.cs
@@ -45,7 +45,7 @@ namespace Duality.Tests.Drawing
 				Assert.IsFalse(device.IsSphereInView(new Vector3(viewportSize.X + 200, 0, 0), 150));
 				Assert.IsFalse(device.IsSphereInView(new Vector3(0, viewportSize.Y + 200, 0), 150));
 				Assert.IsFalse(device.IsSphereInView(new Vector3(0, 0, 1000000000), 150));
-				Assert.IsFalse(device.IsSphereInView(new Vector3(0, 0, -50), 150));
+				Assert.IsFalse(device.IsSphereInView(new Vector3(0, 0, -200), 150));
 			}
 		}
 		[Test] public void IsSphereInViewOrthographic()
@@ -69,16 +69,16 @@ namespace Duality.Tests.Drawing
 				Assert.IsTrue(device.IsSphereInView(new Vector3(0, -viewportSize.Y * 0.5f - 100, device.FocusDist), 150));
 				Assert.IsTrue(device.IsSphereInView(new Vector3(viewportSize.X * 0.5f + 100, 0, device.FocusDist), 150));
 				Assert.IsTrue(device.IsSphereInView(new Vector3(0, viewportSize.Y * 0.5f + 100, device.FocusDist), 150));
-				Assert.IsTrue(device.IsSphereInView(new Vector3(0, 0, device.FarZ - 50), 150));
-				Assert.IsTrue(device.IsSphereInView(new Vector3(0, 0, device.NearZ + 50), 150));
+				Assert.IsTrue(device.IsSphereInView(new Vector3(0, 0, device.FarZ + 100), 150));
+				Assert.IsTrue(device.IsSphereInView(new Vector3(0, 0, device.NearZ - 100), 150));
 				
 				// Just outside each of the viewports sides
 				Assert.IsFalse(device.IsSphereInView(new Vector3(-viewportSize.X * 0.5f - 200, 0, device.FocusDist), 150));
 				Assert.IsFalse(device.IsSphereInView(new Vector3(0, -viewportSize.Y * 0.5f - 200, device.FocusDist), 150));
 				Assert.IsFalse(device.IsSphereInView(new Vector3(viewportSize.X * 0.5f + 200, 0, device.FocusDist), 150));
 				Assert.IsFalse(device.IsSphereInView(new Vector3(0, viewportSize.Y * 0.5f + 200, device.FocusDist), 150));
-				Assert.IsFalse(device.IsSphereInView(new Vector3(0, 0, device.FarZ + 50), 150));
-				Assert.IsFalse(device.IsSphereInView(new Vector3(0, 0, device.NearZ - 50), 150));
+				Assert.IsFalse(device.IsSphereInView(new Vector3(0, 0, device.FarZ + 200), 150));
+				Assert.IsFalse(device.IsSphereInView(new Vector3(0, 0, device.NearZ - 200), 150));
 			}
 		}
 		[Test] public void IsSphereInViewPerspective()
@@ -102,16 +102,16 @@ namespace Duality.Tests.Drawing
 				Assert.IsTrue(device.IsSphereInView(new Vector3(0, -viewportSize.Y * 0.5f - 100, device.FocusDist), 150));
 				Assert.IsTrue(device.IsSphereInView(new Vector3(viewportSize.X * 0.5f + 100, 0, device.FocusDist), 150));
 				Assert.IsTrue(device.IsSphereInView(new Vector3(0, viewportSize.Y * 0.5f + 100, device.FocusDist), 150));
-				Assert.IsTrue(device.IsSphereInView(new Vector3(0, 0, device.FarZ - 50), 150));
-				Assert.IsTrue(device.IsSphereInView(new Vector3(0, 0, device.NearZ + 50), 150));
-				
+				Assert.IsTrue(device.IsSphereInView(new Vector3(0, 0, device.FarZ + 50), 150));
+				Assert.IsTrue(device.IsSphereInView(new Vector3(0, 0, device.NearZ - 50), 150));
+
 				// Just outside each of the viewports sides
 				Assert.IsFalse(device.IsSphereInView(new Vector3(-viewportSize.X * 0.5f - 200, 0, device.FocusDist), 150));
 				Assert.IsFalse(device.IsSphereInView(new Vector3(0, -viewportSize.Y * 0.5f - 200, device.FocusDist), 150));
 				Assert.IsFalse(device.IsSphereInView(new Vector3(viewportSize.X * 0.5f + 200, 0, device.FocusDist), 150));
 				Assert.IsFalse(device.IsSphereInView(new Vector3(0, viewportSize.Y * 0.5f + 200, device.FocusDist), 150));
-				Assert.IsFalse(device.IsSphereInView(new Vector3(0, 0, device.FarZ + 50), 150));
-				Assert.IsFalse(device.IsSphereInView(new Vector3(0, 0, device.NearZ - 50), 150));
+				Assert.IsFalse(device.IsSphereInView(new Vector3(0, 0, device.FarZ + 500), 1));
+				Assert.IsFalse(device.IsSphereInView(new Vector3(0, 0, device.NearZ - 200), 150));
 
 				// Things that are in/visible because of perspective projection
 				Assert.IsFalse(device.IsSphereInView(new Vector3(-viewportSize.X * 0.5f - 100, 0, device.FocusDist * 0.5f), 150));


### PR DESCRIPTION
**This is a work in progress**

This is an initial PR for https://github.com/AdamsLair/duality/issues/747

The core of the functionality works for anyone that wants to play around with it. Add some things to the scene and change the camera transform angle and camera tilt values to see the world rotate around you.

# TODOs:
1. Source/Core/Duality/Utility/Log/VisualLogEntries/VisualLogTextEntry.cs does something with the transform Angle when drawing. Not familiar with this feature so will have to investigate if this is now broken and how to fix it if it is.
2. Source/Plugins/Tilemaps/Core/Tilemaps/TilemapCulling.cs `GetVisibleTileRect` is probably broken with this change, need to investigate a fix.
3. Write some samples that show a couple ways of doing orthographic/isometric rendering that take advantage of being able to set the camera tilt.
  a) A basic sample that renders the terrain as is and then uses "billboard rendering" to draw things that stand vertically in the scene.
  b) A sample using sprite stacking (stacking the sprites over the z axis).
  b) A sample using basic 3d models (a collection of rotated sprites) to create terrain.
  c) A Camera shake demo?

# Things to discuss:
1. I changed `DrawDevice.ViewerAngle` into `DrawDevice.ViewerOrientation`, should I leave `ViewerAngle` alone to make sure this is not a breaking change?
2. Setting the Camera.Tilt in the editor over or under 360 does not wrap in the same way that the Transform.Angle does. Seems like there is some special editor logic in https://github.com/AdamsLair/duality/blob/master/Source/Plugins/EditorBase/PropertyEditors/Components/TransformPropertyEditor.cs#L220 that does that. Do we want that for this Tilt value as well?
3. Currently storing the three camera tilt/orientation values as Euler angles and then applying them to the view matrix in a very specific order, rotation around Z axis first, then around Y, then X. Probably would be better to store the rotation as quaternions as that should reduce the cost of producing the rotation matrix. Not really sure if this is necessary at the moment since we do not expect a lot of camera rotations occurring during runtime, and if I remember my math correctly, the main advantage of quaternions is the speed/stability of combining rotations together. Is that something we want extended support for? What do people think? Should we convert to using quaternions internally?
4. Related to the item above (as in we will probably want to do that if we want to do this item), there is a bunch of helper methods in the Transform object for performing angle changes, do we want to offer some similar methods for Camera tilt? If Camera shake is something we want first class support for, then this is probably a good idea.
5. Additional test ideas?
