### PR TITLE
enable sourcelink

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <!-- these settings will be applied to all projects -->
+  <PropertyGroup>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This enables [Source Link](https://github.com/dotnet/sourcelink) information on all compatible projects in the repository. Should it only happen for projects under Source instead?

The Source Link documentation [recommends separating the PDBs into symbol packages](https://github.com/dotnet/sourcelink#alternative-pdb-distribution) instead of packaging them in the main nupkg files. That can probably be done in NightlyBuilder by passing an additional parameter to `nuget pack` and changing the PDB type if you want it.

Related to #746 