### PR TITLE
#731 - Use a default empty tile for all empty tiles

### DIFF
--- a/Source/Plugins/Tilemaps/Core/Tilesets/Tileset.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilesets/Tileset.cs
@@ -167,7 +167,7 @@ namespace Duality.Plugins.Tilemaps
 					this.GetCompileHashCode() != this.compileHash;
 			}
 		}
-        /// <summary>
+		/// <summary>
 		/// [GET] Returns the tile index that should be used for painting an empty tile.
 		/// </summary>
 		[EditorHintFlags(MemberFlags.Invisible)]

--- a/Source/Plugins/Tilemaps/Core/Tilesets/Tileset.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilesets/Tileset.cs
@@ -35,6 +35,7 @@ namespace Duality.Plugins.Tilemaps
 		[DontSerialize] private bool                      compiled       = false;
 		[DontSerialize] private int                       compileHash    = 0;
 		[DontSerialize] private int                       tileCount      = 0;
+		[DontSerialize] private int                       emptyTileIndex = -1;
 
 		
 		/// <summary>
@@ -166,7 +167,15 @@ namespace Duality.Plugins.Tilemaps
 					this.GetCompileHashCode() != this.compileHash;
 			}
 		}
-		
+        /// <summary>
+		/// [GET] Returns the tile index that should be used for painting an empty tile.
+		/// </summary>
+		[EditorHintFlags(MemberFlags.Invisible)]
+		public int EmptyTileIndex
+		{
+			get { return this.emptyTileIndex; }
+		}
+
 
 		/// <summary>
 		/// Looks up the vertex UV rect for the specified rendering input / data and tile.
@@ -235,6 +244,7 @@ namespace Duality.Plugins.Tilemaps
 			this.tileData = data.TileData;
 			this.autoTileData = data.AutoTileData;
 			this.tileCount = data.TileCount;
+			this.emptyTileIndex = data.EmptyTileIndex;
 			this.GenerateRenderMaterial();
 
 			this.compiled = true;

--- a/Source/Plugins/Tilemaps/Core/Tilesets/TilesetCompiler.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilesets/TilesetCompiler.cs
@@ -103,7 +103,7 @@ namespace Duality.Plugins.Tilemaps
 				TilesetRenderInput renderInput = input.RenderConfig[renderInputIndex] ?? DefaultRenderInput;
 				PixelData sourceLayerData = (renderInput.SourceData.Res ?? Pixmap.Checkerboard.Res).MainLayer;
 
-				// Determine overal geometry values for this layer, such as tile bounds and texture sizes
+				// Determine overall geometry values for this layer, such as tile bounds and texture sizes
 				LayerGeometry layerGeometry = this.CalculateLayerGeometry(renderInput, sourceLayerData);
 
 				// Generate pixel data and atlas values for this layer's texture
@@ -150,6 +150,8 @@ namespace Duality.Plugins.Tilemaps
 			output.AutoTileData = output.AutoTileData ?? new List<TilesetAutoTileInfo>();
 			output.AutoTileData.Clear();
 			this.TransformAutoTileData(output.AutoTileData);
+
+			output.EmptyTileIndex = this.GetEmptyTileIndex();
 
 			this.ClearWorkingData();
 			return output;
@@ -573,6 +575,11 @@ namespace Duality.Plugins.Tilemaps
 			}
 
 			return target;
+		}
+
+		private int GetEmptyTileIndex()
+		{
+			return this.tiles.Data.IndexOfFirst(tileInfo => tileInfo.IsVisuallyEmpty);
 		}
 
 		/// <summary>

--- a/Source/Plugins/Tilemaps/Core/Tilesets/TilesetCompilerOutput.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilesets/TilesetCompilerOutput.cs
@@ -34,5 +34,10 @@ namespace Duality.Plugins.Tilemaps
 		/// AutoTile input that was specified in the <see cref="TilesetCompilerInput"/>.
 		/// </summary>
 		public List<TilesetAutoTileInfo> AutoTileData;
+		/// <summary>
+		/// The tile index that should be used for painting empty tiles.
+		/// -1 indicates that there are no empty tiles.
+		/// </summary>
+		public int EmptyTileIndex;
 	}
 }

--- a/Source/Plugins/Tilemaps/Editor/Modules/TilemapToolSourcePalette.cs
+++ b/Source/Plugins/Tilemaps/Editor/Modules/TilemapToolSourcePalette.cs
@@ -243,6 +243,8 @@ namespace Duality.Editor.Plugins.Tilemaps
 				{
 					Tile tile = selectedTiles[x, y];
 
+					TileInfo baseTile = tileset.TileData[tile.BaseIndex];
+
 					// For standard autotile parts, only paint the autotiles base index
 					// and ignore which specific part was selected. 
 					//
@@ -251,7 +253,7 @@ namespace Duality.Editor.Plugins.Tilemaps
 					// normalization guarantee would be possible by changing Tile.ResolveIndex, 
 					// but since it isn't actually necessary and potentially destructive, we'll
 					// just make sure "most indices are generally" normalized.
-					int autoTileIndex = tileset.TileData[tile.BaseIndex].AutoTileLayer - 1;
+					int autoTileIndex = baseTile.AutoTileLayer - 1;
 					if (autoTileIndex >= 0)
 					{
 						TilesetAutoTileInfo autoTile = tileset.AutoTileData[autoTileIndex];
@@ -260,6 +262,9 @@ namespace Duality.Editor.Plugins.Tilemaps
 						if (isDefaultTile)
 							tile.BaseIndex = autoTile.BaseTileIndex;
 					}
+
+					if (tileset.EmptyTileIndex >= 0 && baseTile.IsVisuallyEmpty)
+						tile.BaseIndex = tileset.EmptyTileIndex;
 
 					shape[x, y] = true;
 					pattern[x, y] = tile;


### PR DESCRIPTION
Fairly simple change that adds an `int EmptyTileIndex` to the `Tileset` which will be used by the `TileMapToolSourcePalette` when making a new selection of tiles. This value is computed at `Tileset` compile time. It is set to -1 if there are no empty tiles. 