### PR TITLE
#719 Fixed vertex locking test failing in debug mode

### DIFF
--- a/Test/Core/Drawing/VertexBatchTest.cs
+++ b/Test/Core/Drawing/VertexBatchTest.cs
@@ -87,7 +87,7 @@ namespace Duality.Tests.Drawing
 				WeakReference weakRefToLockedData = new WeakReference(typedBatch.Vertices.Data);
 				Assert.IsTrue(weakRefToLockedData.IsAlive);
 
-				return new CleanupTestSet(weakRefToLockedData);
+				return new GarbageCollectionTestSet(weakRefToLockedData);
 			});
 		}
 

--- a/Test/Core/DualityTests.csproj
+++ b/Test/Core/DualityTests.csproj
@@ -128,6 +128,7 @@
     <Compile Include="GlobalSetup.cs" />
     <Compile Include="Drawing\CanvasTest.cs" />
     <Compile Include="Testing\IdentityComparer.cs" />
+    <Compile Include="Utility\GarbageCollectionUtils.cs" />
     <Compile Include="Utility\RawListPoolTest.cs" />
     <Compile Include="Utility\SortingIntContainer.cs" />
     <Compile Include="Utility\ExtMethodsRandomTest.cs" />

--- a/Test/Core/DualityTests.csproj
+++ b/Test/Core/DualityTests.csproj
@@ -128,6 +128,7 @@
     <Compile Include="GlobalSetup.cs" />
     <Compile Include="Drawing\CanvasTest.cs" />
     <Compile Include="Testing\IdentityComparer.cs" />
+    <Compile Include="Utility\GarbageCollectionTestSet.cs" />
     <Compile Include="Utility\GarbageCollectionUtils.cs" />
     <Compile Include="Utility\RawListPoolTest.cs" />
     <Compile Include="Utility\SortingIntContainer.cs" />
@@ -205,7 +206,6 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-
   <!-- Copy all required NUnit command line runner files to a local folder -->
   <Import Project="..\AcquireNUnitRunner.targets" />
 </Project>

--- a/Test/Core/Utility/GarbageCollectionTestSet.cs
+++ b/Test/Core/Utility/GarbageCollectionTestSet.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace Duality.Tests.Utility
+{
+	/// <summary>
+	/// Represents the data used to test if instances are properly collected afer a garbage collection.
+	/// </summary>
+	public class GarbageCollectionTestSet
+	{
+		/// <summary>
+		/// Creates a new <see cref="GarbageCollectionTestSet"/> without instances to keep alive.
+		/// </summary>
+		/// <param name="weakReference"></param>
+		/// <param name="keepAliveInstances"></param>
+		public GarbageCollectionTestSet(WeakReference weakReference, object[] keepAliveInstances = null) : this(new[] { weakReference }, keepAliveInstances) { }
+
+		/// <summary>
+		/// Creates a new <see cref="GarbageCollectionTestSet"/> with instances to keep alive.
+		/// </summary>
+		/// <param name="weakReference"></param>
+		/// <param name="keepAliveInstances"></param>
+		public GarbageCollectionTestSet(WeakReference[] weakReferences, object[] keepAliveInstances = null)
+		{
+			this.WeakReferences = weakReferences;
+			this.KeepAliveInstances = keepAliveInstances;
+		}
+
+		/// <summary>
+		/// These references will be checked after a collection to verify they are properly collected
+		/// </summary>
+		public WeakReference[] WeakReferences { get; }
+
+		/// <summary>
+		/// Instances that will be kept alive during the test.
+		/// </summary>
+		public object[] KeepAliveInstances { get; }
+	}
+}

--- a/Test/Core/Utility/GarbageCollectionUtils.cs
+++ b/Test/Core/Utility/GarbageCollectionUtils.cs
@@ -11,14 +11,14 @@ namespace Duality.Tests.Utility
 	public class GarbageCollectionUtils
 	{
 		/// <summary>
-		/// Asserts if the <see cref="WeakReference"/> in <see cref="CleanupTestSet"/> are collected after a garbage collection.
+		/// Asserts if the <see cref="WeakReference"/> in <see cref="GarbageCollectionTestSet"/> are collected after a garbage collection.
 		/// </summary>
 		/// <param name="func"></param>
 		// No inlining is important here to defeat any optimizations the compiler can make that could cause instances to live longer.
 		[MethodImpl(MethodImplOptions.NoInlining)]
-		public static void CheckIfCleanedUp(Func<CleanupTestSet> func)
+		public static void CheckIfCleanedUp(Func<GarbageCollectionTestSet> func)
 		{
-			CleanupTestSet cleanupTestSet = func();
+			GarbageCollectionTestSet cleanupTestSet = func();
 
 			// In some cases unloading something happens async and can take some time such as with AssemblyLoadContext. Workaround this by retrying a couple of times..
 			for (int i = 0; cleanupTestSet.WeakReferences.Any(x => x.IsAlive) && i < 10; i++)
@@ -31,39 +31,5 @@ namespace Duality.Tests.Utility
 				Assert.False(item.IsAlive);
 			}
 		}
-	}
-
-	/// <summary>
-	/// Represents the data used to test if instances are properly collected afer a garbage collection.
-	/// </summary>
-	public class CleanupTestSet
-	{
-		/// <summary>
-		/// Creates a new <see cref="CleanupTestSet"/> without instances to keep alive.
-		/// </summary>
-		/// <param name="weakReference"></param>
-		/// <param name="keepAliveInstances"></param>
-		public CleanupTestSet(WeakReference weakReference, object[] keepAliveInstances = null) : this(new[] { weakReference }, keepAliveInstances) { }
-
-		/// <summary>
-		/// Creates a new <see cref="CleanupTestSet"/> with instances to keep alive.
-		/// </summary>
-		/// <param name="weakReference"></param>
-		/// <param name="keepAliveInstances"></param>
-		public CleanupTestSet(WeakReference[] weakReferences, object[] keepAliveInstances = null)
-		{
-			this.WeakReferences = weakReferences;
-			this.KeepAliveInstances = keepAliveInstances;
-		}
-
-		/// <summary>
-		/// These references will be checked after a collection to verify they are properly collected
-		/// </summary>
-		public WeakReference[] WeakReferences { get; }
-
-		/// <summary>
-		/// Instances that will be kept alive during the test.
-		/// </summary>
-		public object[] KeepAliveInstances { get; }
 	}
 }

--- a/Test/Core/Utility/GarbageCollectionUtils.cs
+++ b/Test/Core/Utility/GarbageCollectionUtils.cs
@@ -5,8 +5,15 @@ using NUnit.Framework;
 
 namespace Duality.Tests.Utility
 {
+	/// <summary>
+	/// Contains utilities to help test garbage collection related code.
+	/// </summary>
 	public class GarbageCollectionUtils
 	{
+		/// <summary>
+		/// Asserts if the <see cref="WeakReference"/> in <see cref="CleanupTestSet"/> are collected after a garbage collection.
+		/// </summary>
+		/// <param name="func"></param>
 		// No inlining is important here to defeat any optimizations the compiler can make that could cause instances to live longer.
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static void CheckIfCleanedUp(Func<CleanupTestSet> func)
@@ -26,17 +33,37 @@ namespace Duality.Tests.Utility
 		}
 	}
 
+	/// <summary>
+	/// Represents the data used to test if instances are properly collected afer a garbage collection.
+	/// </summary>
 	public class CleanupTestSet
 	{
+		/// <summary>
+		/// Creates a new <see cref="CleanupTestSet"/> without instances to keep alive.
+		/// </summary>
+		/// <param name="weakReference"></param>
+		/// <param name="keepAliveInstances"></param>
 		public CleanupTestSet(WeakReference weakReference, object[] keepAliveInstances = null) : this(new[] { weakReference }, keepAliveInstances) { }
 
+		/// <summary>
+		/// Creates a new <see cref="CleanupTestSet"/> with instances to keep alive.
+		/// </summary>
+		/// <param name="weakReference"></param>
+		/// <param name="keepAliveInstances"></param>
 		public CleanupTestSet(WeakReference[] weakReferences, object[] keepAliveInstances = null)
 		{
 			this.WeakReferences = weakReferences;
 			this.KeepAliveInstances = keepAliveInstances;
 		}
 
+		/// <summary>
+		/// These references will be checked after a collection to verify they are properly collected
+		/// </summary>
 		public WeakReference[] WeakReferences { get; }
+
+		/// <summary>
+		/// Instances that will be kept alive during the test.
+		/// </summary>
 		public object[] KeepAliveInstances { get; }
 	}
 }

--- a/Test/Core/Utility/GarbageCollectionUtils.cs
+++ b/Test/Core/Utility/GarbageCollectionUtils.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using NUnit.Framework;
+
+namespace Duality.Tests.Utility
+{
+	public class GarbageCollectionUtils
+	{
+		// No inlining is important here to defeat any optimizations the compiler can make that could cause instances to live longer.
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public static void CheckIfCleanedUp(Func<CleanupTestSet> func)
+		{
+			CleanupTestSet cleanupTestSet = func();
+
+			// In some cases unloading something happens async and can take some time such as with AssemblyLoadContext. Workaround this by retrying a couple of times..
+			for (int i = 0; cleanupTestSet.WeakReferences.Any(x => x.IsAlive) && i < 10; i++)
+			{
+				GC.Collect(2, GCCollectionMode.Forced, true);
+				GC.WaitForPendingFinalizers();
+			}
+			foreach (var item in cleanupTestSet.WeakReferences)
+			{
+				Assert.False(item.IsAlive);
+			}
+		}
+	}
+
+	public class CleanupTestSet
+	{
+		public CleanupTestSet(WeakReference weakReference, object[] keepAliveInstances = null) : this(new[] { weakReference }, keepAliveInstances) { }
+
+		public CleanupTestSet(WeakReference[] weakReferences, object[] keepAliveInstances = null)
+		{
+			this.WeakReferences = weakReferences;
+			this.KeepAliveInstances = keepAliveInstances;
+		}
+
+		public WeakReference[] WeakReferences { get; }
+		public object[] KeepAliveInstances { get; }
+	}
+}


### PR DESCRIPTION
Moved assert code to check if the resource that a weakreference points to is alive or not after garbage collecting to a separate method. This defeats the fact that in debug mode instances might be kept alive for longer than strictly needed. Disabling inlining defeats any optimizations that might happen in release mode.

The end result is a garbage collection test that works both in debug and release.