### PR TITLE
Block the renaming of a resource to a null or empty string.

### DIFF
--- a/Source/Plugins/EditorModules/ProjectView/Modules/ProjectFolderView.cs
+++ b/Source/Plugins/EditorModules/ProjectView/Modules/ProjectFolderView.cs
@@ -1284,7 +1284,10 @@ namespace Duality.Editor.Plugins.ProjectView
 			NodeBase node = this.lastEditedNode;
 			string oldName = node.GetNameFromPath(node.NodePath);
 
-			// https://github.com/AdamsLair/duality/issues/773
+			// This piece of code blocks the user from setting an empty string as a Resource's name,
+			// avoiding the appearence of the behavior described in https://github.com/AdamsLair/duality/issues/773
+			// If an invalid name is set, it is reverted back to the previous one, and the Resource 
+			// flashes to warn the user
 			if (string.IsNullOrWhiteSpace(node.Text))
 			{
 				node.Text = oldName;

--- a/Source/Plugins/EditorModules/ProjectView/Modules/ProjectFolderView.cs
+++ b/Source/Plugins/EditorModules/ProjectView/Modules/ProjectFolderView.cs
@@ -1283,6 +1283,16 @@ namespace Duality.Editor.Plugins.ProjectView
 		{
 			NodeBase node = this.lastEditedNode;
 			string oldName = node.GetNameFromPath(node.NodePath);
+
+			// https://github.com/AdamsLair/duality/issues/773
+			if (string.IsNullOrWhiteSpace(node.Text))
+			{
+				node.Text = oldName;
+				this.FlashNode(node);
+				this.RevokeGlobalRenameEventFor(node.NodePath);
+				return;
+			}
+
 			if (oldName == node.Text)
 			{
 				this.RevokeGlobalRenameEventFor(node.NodePath);


### PR DESCRIPTION
As described in the discussion of issues #773, this PR inhibits the possibility to rename a Resource as nothing, removing the issue itself.
The affected node will be flashed as well, to focus the attention on the fact that it wasn't renamed.