### PR TITLE
Changed and updated nvorbis to use the official version instead of ou…

### DIFF
--- a/Source/Core/Duality/Duality.csproj
+++ b/Source/Core/Duality/Duality.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AdamsLair.NVorbis" Version="0.7.6" GeneratePathProperty="true" />
+		<PackageReference Include="NVorbis" Version="0.10.1" GeneratePathProperty="true"/>
 		<PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
 	</ItemGroup>
 
@@ -86,7 +86,7 @@
 		<Copy SourceFiles="$(OutputPath)$(AssemblyName).dll" DestinationFolder="$(SolutionDir)Build\Output\" />
 		<Copy SourceFiles="$(OutputPath)$(AssemblyName).pdb" DestinationFolder="$(SolutionDir)Build\Output\" />
 		<Copy SourceFiles="$(OutputPath)$(AssemblyName).xml" DestinationFolder="$(SolutionDir)Build\Output\" />
-		<copy SourceFiles="$(PkgAdamsLair_NVorbis)\lib\portable45-net45+win8+wpa81\NVorbis.dll" DestinationFolder="$(SolutionDir)Build\Output\" />
-		<copy SourceFiles="$(PkgAdamsLair_NVorbis)\lib\portable45-net45+win8+wpa81\NVorbis.xml" DestinationFolder="$(SolutionDir)Build\Output\" />
+		<Copy SourceFiles="$(PkgNVorbis)\lib\netstandard2.0\NVorbis.dll" DestinationFolder="$(SolutionDir)Build\Output\" />
+		<Copy SourceFiles="$(PkgNVorbis)\lib\netstandard2.0\NVorbis.xml" DestinationFolder="$(SolutionDir)Build\Output\" />
 	</Target>
 </Project>


### PR DESCRIPTION
Fixes the warnings you get when referencing nvorbis in a netstandard project. This needs to be fixed because these warnings are transitive and also end up in endusers projects because they indirectly reference nvorbis.

So far the code compiles and unit tests are green but need to do more testing