### PR TITLE
Remove unneeded xml version from csprojs

### DIFF
--- a/Samples/AudioHandling/AudioHandling.Sample.Core.csproj
+++ b/Samples/AudioHandling/AudioHandling.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>

--- a/Samples/BasicMenu/BasicMenu.Sample.Core.csproj
+++ b/Samples/BasicMenu/BasicMenu.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>

--- a/Samples/BasicShaders/BasicShaders.Sample.Core.csproj
+++ b/Samples/BasicShaders/BasicShaders.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>

--- a/Samples/Benchmarks/Benchmarks.Sample.Core.csproj
+++ b/Samples/Benchmarks/Benchmarks.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Samples/CameraController/CameraController.Sample.Core.csproj
+++ b/Samples/CameraController/CameraController.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>

--- a/Samples/CustomRenderingSetup/CustomRenderingSetup.Sample.Core.csproj
+++ b/Samples/CustomRenderingSetup/CustomRenderingSetup.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Samples/DualStickSpaceShooter/DualStickSpaceShooter.Sample.Core.csproj
+++ b/Samples/DualStickSpaceShooter/DualStickSpaceShooter.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>

--- a/Samples/DynamicLighting/Core/DynamicLighting.Sample.Core.csproj
+++ b/Samples/DynamicLighting/Core/DynamicLighting.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>

--- a/Samples/FlapOrDie/FlapOrDie.Sample.Core.csproj
+++ b/Samples/FlapOrDie/FlapOrDie.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>

--- a/Samples/InputHandling/InputHandling.Sample.Core.csproj
+++ b/Samples/InputHandling/InputHandling.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>

--- a/Samples/ParticleSystem/ParticleSystem.Sample.Core.csproj
+++ b/Samples/ParticleSystem/ParticleSystem.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>

--- a/Samples/Physics/Physics.Sample.Core.csproj
+++ b/Samples/Physics/Physics.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>

--- a/Samples/SmoothAnimation/SmoothAnimation.Sample.Core.csproj
+++ b/Samples/SmoothAnimation/SmoothAnimation.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Samples/Steering/Steering.Sample.Core.csproj
+++ b/Samples/Steering/Steering.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>

--- a/Samples/Tilemaps/Tilemaps.Sample.Core.csproj
+++ b/Samples/Tilemaps/Tilemaps.Sample.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>

--- a/Source/Core/Duality/Duality.csproj
+++ b/Source/Core/Duality/Duality.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Source/Core/Physics/DualityPhysics.csproj
+++ b/Source/Core/Physics/DualityPhysics.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Source/Core/Primitives/DualityPrimitives.csproj
+++ b/Source/Core/Primitives/DualityPrimitives.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Source/Plugins/Compatibility/Compatibility.Core.csproj
+++ b/Source/Plugins/Compatibility/Compatibility.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Source/Plugins/Tilemaps/Core/Tilemaps.Core.csproj
+++ b/Source/Plugins/Tilemaps/Core/Tilemaps.Core.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Just a small cleanup, the `<?xml version="1.0" encoding="utf-8"?>` is not needed with sdk style projects