### PR TITLE
Fixing xml documentation warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- these settings will be applied to all projects -->
   <PropertyGroup>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <NoWarn>1701;1702;CS1591</NoWarn>
+    <NoWarn>1701;1702;CS1591;CS0419</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
   <!-- these settings will be applied to all projects -->
   <PropertyGroup>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <NoWarn>1701;1702;CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>

--- a/Samples/BasicMenu/MenuComponent.cs
+++ b/Samples/BasicMenu/MenuComponent.cs
@@ -55,7 +55,7 @@ namespace BasicMenu
 		/// 
 		/// A full 2.5D implementation (no ScreenOverlay) would require more complex calculations.
 		/// </summary>
-		/// <returns></returns>
+
 		public Rect GetAreaOnScreen()
 		{
 			if (this.sprite == null)

--- a/Samples/Tilemaps/RpgLike/ActorAnimator.cs
+++ b/Samples/Tilemaps/RpgLike/ActorAnimator.cs
@@ -121,7 +121,6 @@ namespace Duality.Samples.Tilemaps.RpgLike
 		/// Retrieves one of the available animations that matches the specified name.
 		/// </summary>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		public ActorAnimation GetAnimation(string name)
 		{
 			foreach (ActorAnimation anim in this.animations)

--- a/Samples/Tilemaps/RpgLike/ActorRenderer.cs
+++ b/Samples/Tilemaps/RpgLike/ActorRenderer.cs
@@ -144,7 +144,6 @@ namespace Duality.Samples.Tilemaps.RpgLike
 		/// This also inclues the renderers overall offset as specified in <see cref="DepthOffset"/>.
 		/// </summary>
 		/// <param name="worldPos"></param>
-		/// <returns></returns>
 		public float GetDepthOffsetAt(Vector2 worldPos)
 		{
 			Transform transform = this.GameObj.Transform;

--- a/Source/Core/Duality/Backend/Graphics/IGraphicsBackend.cs
+++ b/Source/Core/Duality/Backend/Graphics/IGraphicsBackend.cs
@@ -54,6 +54,7 @@ namespace Duality.Backend
 		/// Retrieves the main rendering buffer's pixel data from video memory in the Rgba8 format.
 		/// As a storage array type, either byte or <see cref="ColorRgba"/> is recommended.
 		/// </summary>
+		/// <param name="backend"></param>
 		/// <param name="target">The target buffer to store transferred pixel data in.</param>
 		/// <param name="dataLayout">The desired color layout of the specified buffer.</param>
 		/// <param name="dataElementType">The desired color element type of the specified buffer.</param>

--- a/Source/Core/Duality/Backend/Graphics/INativeGraphicsBuffer.cs
+++ b/Source/Core/Duality/Backend/Graphics/INativeGraphicsBuffer.cs
@@ -48,7 +48,6 @@ namespace Duality.Backend
 		/// Sets up an empty storage with the specified size, in number of array elements of the
 		/// generic type of this method.
 		/// </summary>
-		/// <param name="count"></param>
 		public static void SetupEmpty<T>(this INativeGraphicsBuffer buffer, int count) where T : struct
 		{
 			int itemSize = Marshal.SizeOf(typeof(T));
@@ -80,6 +79,7 @@ namespace Duality.Backend
 		/// <summary>
 		/// Uploads the specified data block into a subsection of this buffer, keeping all other content.
 		/// </summary>
+		/// <param name="buffer"></param>
 		/// <param name="bufferIndex">The offset from the beginning of the existing buffer, as number of elements.</param>
 		/// <param name="data">An array containing the data that will be uploaded.</param>
 		/// <param name="index">The array starting index from which to start uploading data.</param>

--- a/Source/Core/Duality/Backend/Graphics/INativeRenderTarget.cs
+++ b/Source/Core/Duality/Backend/Graphics/INativeRenderTarget.cs
@@ -23,7 +23,7 @@ namespace Duality.Backend
 		/// Note that generic, array-based variants of this method are available via extension method
 		/// when using the Duality.Backend namespace.
 		/// </summary>
-		/// <param name="target">The target buffer to store transferred pixel data in.</param>
+		/// <param name="buffer">The target buffer to store transferred pixel data in.</param>
 		/// <param name="dataLayout">The desired color layout of the specified buffer.</param>
 		/// <param name="dataElementType">The desired color element type of the specified buffer.</param>
 		/// <param name="targetIndex">The target texture lists index to read from.</param>
@@ -46,7 +46,8 @@ namespace Duality.Backend
 		/// Retrieves the rendering targets pixel data from video memory in the Rgba8 format.
 		/// As a storage array type, either byte or <see cref="ColorRgba"/> is recommended.
 		/// </summary>
-		/// <param name="target">The target buffer to store transferred pixel data in.</param>
+		/// <param name="renderTarget"></param>
+		/// <param name="buffer">The target buffer to store transferred pixel data in.</param>
 		/// <param name="dataLayout">The desired color layout of the specified buffer.</param>
 		/// <param name="dataElementType">The desired color element type of the specified buffer.</param>
 		/// <param name="targetIndex">The target texture lists index to read from.</param>

--- a/Source/Core/Duality/Backend/Graphics/INativeTexture.cs
+++ b/Source/Core/Duality/Backend/Graphics/INativeTexture.cs
@@ -100,6 +100,7 @@ namespace Duality.Backend
 		/// As a storage array type, either byte or <see cref="ColorRgba"/> is recommended.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
+		/// <param name="texture"></param>
 		/// <param name="target">The buffer to store pixel values into.</param>
 		/// <param name="dataLayout">The desired color layout of the specified buffer.</param>
 		/// <param name="dataElementType">The desired color element type of the specified buffer.</param>

--- a/Source/Core/Duality/Backend/ISystemBackend.cs
+++ b/Source/Core/Duality/Backend/ISystemBackend.cs
@@ -18,7 +18,6 @@ namespace Duality.Backend
 		/// Retrieves the path of a named / special directory.
 		/// </summary>
 		/// <param name="dir"></param>
-		/// <returns></returns>
 		string GetNamedPath(NamedDirectory dir);
 	}
 }

--- a/Source/Core/Duality/Backend/PluginLoader/IAssemblyLoader.cs
+++ b/Source/Core/Duality/Backend/PluginLoader/IAssemblyLoader.cs
@@ -33,7 +33,6 @@ namespace Duality.Backend
 		/// <summary>
 		/// [GET] Enumerates all Assemblies that are currently loaded in the context of this application.
 		/// </summary>
-		/// <returns></returns>
 		IEnumerable<Assembly> LoadedAssemblies { get; }
 
 		/// <summary>
@@ -41,7 +40,6 @@ namespace Duality.Backend
 		/// usage, that path should be one of the <see cref="AvailableAssemblyPaths"/>.
 		/// </summary>
 		/// <param name="assemblyPath">The path from which the Assembly will be loaded.</param>
-		/// <returns></returns>
 		Assembly LoadAssembly(string assemblyPath);
 		/// <summary>
 		/// Determines the hash code of the specified Assembly. This may be used for
@@ -49,7 +47,6 @@ namespace Duality.Backend
 		/// are equal.
 		/// </summary>
 		/// <param name="assemblyPath"></param>
-		/// <returns></returns>
 		int GetAssemblyHash(string assemblyPath);
 
 		/// <summary>

--- a/Source/Core/Duality/Cloning/CloneProvider.cs
+++ b/Source/Core/Duality/Cloning/CloneProvider.cs
@@ -119,7 +119,6 @@ namespace Duality.Cloning
 		/// already present, performance of subsequent clone operations within the same object
 		/// graph can benefit by this.
 		/// </param>
-		/// <returns></returns>
 		public T CloneObject<T>(T source, bool preserveCache = false)
 		{
 			object target; // Don't use T, we'll need to make sure "target" is a reference Type
@@ -246,8 +245,6 @@ namespace Duality.Cloning
 		/// reference assignment instead.
 		/// </summary>
 		/// <param name="source"></param>
-		/// <param name="target"></param>
-		/// <returns></returns>
 		private object GetTargetOf(object source)
 		{
 			if (object.ReferenceEquals(source, null))
@@ -266,7 +263,6 @@ namespace Duality.Cloning
 		/// </summary>
 		/// <param name="source"></param>
 		/// <param name="typeData"></param>
-		/// <returns></returns>
 		private bool PushCurrentObject(object source, CloneType typeData)
 		{
 			return typeData.Type.IsValueType || object.ReferenceEquals(source, null) || this.handledObjects.Add(source);
@@ -277,7 +273,6 @@ namespace Duality.Cloning
 		/// </summary>
 		/// <param name="source"></param>
 		/// <param name="typeData"></param>
-		/// <returns></returns>
 		private bool PopCurrentObject(object source, CloneType typeData)
 		{
 			return typeData.Type.IsValueType || object.ReferenceEquals(source, null) || this.handledObjects.Remove(source);
@@ -815,7 +810,6 @@ namespace Duality.Cloning
 		/// Returns the <see cref="CloneType"/> of a Type.
 		/// </summary>
 		/// <param name="type"></param>
-		/// <returns></returns>
 		protected internal static CloneType GetCloneType(Type type)
 		{
 			if (type == null) return null;

--- a/Source/Core/Duality/Cloning/ICloneOperation.cs
+++ b/Source/Core/Duality/Cloning/ICloneOperation.cs
@@ -18,17 +18,12 @@ namespace Duality.Cloning
 		/// <summary>
 		/// Retrieves the target object that is mapped to the specified source object.
 		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
-		/// <returns></returns>
 		T GetTarget<T>(T source) where T : class;
 		/// <summary>
 		/// Returns true if the specified object is part of the target object graph.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="target"></param>
-		/// <returns></returns>
 		bool IsTarget<T>(T target) where T : class;
 		
 		/// <summary>
@@ -60,7 +55,6 @@ namespace Duality.Cloning
 		/// <param name="operation"></param>
 		/// <param name="source"></param>
 		/// <param name="target"></param>
-		/// <returns></returns>
 		public static void HandleObject<T>(this ICloneOperation operation, T source, T target = null) where T : class
 		{
 			T targetObj = target;
@@ -75,7 +69,6 @@ namespace Duality.Cloning
 		/// <param name="source"></param>
 		/// <param name="target"></param>
 		/// <param name="dontNullifyExternal"></param>
-		/// <returns></returns>
 		public static void HandleObject<T>(this ICloneOperation operation, T source, ref T target, bool dontNullifyExternal) where T : class
 		{
 			if (object.ReferenceEquals(source, null) && dontNullifyExternal && !operation.IsTarget(target))
@@ -90,7 +83,6 @@ namespace Duality.Cloning
 		/// <typeparam name="T"></typeparam>
 		/// <param name="operation"></param>
 		/// <param name="source"></param>
-		/// <returns></returns>
 		public static T GetWeakTarget<T>(this ICloneOperation operation, T source) where T : class
 		{
 			T target = operation.GetTarget(source);

--- a/Source/Core/Duality/Component.cs
+++ b/Source/Core/Duality/Component.cs
@@ -159,7 +159,6 @@ namespace Duality
 		/// this method in order to handle certain fields and cases manually. See <see cref="ICloneExplicit.SetupCloneTargets"/>
 		/// for a more thorough explanation.
 		/// </summary>
-		/// <param name="setup"></param>
 		protected virtual void OnSetupCloneTargets(object target, ICloneTargetSetup setup)
 		{
 			setup.HandleObject(this, target);

--- a/Source/Core/Duality/Components/Camera.cs
+++ b/Source/Core/Duality/Components/Camera.cs
@@ -285,7 +285,6 @@ namespace Duality.Components
 		/// Returns the scale factor of objects that are located at the specified world space Z position.
 		/// </summary>
 		/// <param name="z"></param>
-		/// <returns></returns>
 		public float GetScaleAtZ(float z)
 		{
 			this.UpdateTransformDevice();
@@ -296,7 +295,6 @@ namespace Duality.Components
 		/// interpreted as the target world Z coordinate.
 		/// </summary>
 		/// <param name="screenPos"></param>
-		/// <returns></returns>
 		public Vector3 GetWorldPos(Vector3 screenPos)
 		{
 			this.UpdateTransformDevice();
@@ -309,7 +307,6 @@ namespace Duality.Components
 		/// Transforms screen space to world space.
 		/// </summary>
 		/// <param name="screenPos"></param>
-		/// <returns></returns>
 		public Vector3 GetWorldPos(Vector2 screenPos)
 		{
 			this.UpdateTransformDevice();
@@ -319,8 +316,6 @@ namespace Duality.Components
 		/// <summary>
 		/// Transforms world space to screen space positions.
 		/// </summary>
-		/// <param name="spacePos"></param>
-		/// <returns></returns>
 		public Vector2 GetScreenPos(Vector3 worldPos)
 		{
 			this.UpdateTransformDevice();
@@ -329,8 +324,6 @@ namespace Duality.Components
 		/// <summary>
 		/// Transforms world space to screen space positions.
 		/// </summary>
-		/// <param name="spacePos"></param>
-		/// <returns></returns>
 		public Vector2 GetScreenPos(Vector2 worldPos)
 		{
 			this.UpdateTransformDevice();
@@ -341,7 +334,6 @@ namespace Duality.Components
 		/// </summary>
 		/// <param name="worldPos">The spheres world space center position.</param>
 		/// <param name="radius">The spheres world space radius.</param>
-		/// <returns></returns>
 		public bool IsSphereInView(Vector3 worldPos, float radius = 1.0f)
 		{
 			this.UpdateTransformDevice();

--- a/Source/Core/Duality/Components/Other/ComponentExecutionOrder.cs
+++ b/Source/Core/Duality/Components/Other/ComponentExecutionOrder.cs
@@ -168,7 +168,6 @@ namespace Duality
 		/// Retrieves the sorting index of the specified <see cref="Component"/> type.
 		/// </summary>
 		/// <param name="componentType"></param>
-		/// <returns></returns>
 		public int GetSortIndex(Type componentType)
 		{
 			int index;
@@ -248,7 +247,6 @@ namespace Duality
 		/// types.
 		/// </summary>
 		/// <param name="typeSet"></param>
-		/// <returns></returns>
 		private static List<OrderConstraint> GatherConstraints(HashSet<Type> typeSet)
 		{
 			// This hashset will store a distinct set of constraints, but allow constraining
@@ -351,8 +349,6 @@ namespace Duality
 		/// since the number of <see cref="Component"/> types will likely stay below a few thousands
 		/// this is probably not necessary and can be skipped for convenience and maintenance reasons.
 		/// </summary>
-		/// <param name="constraints"></param>
-		/// <returns></returns>
 		private static Dictionary<Type,List<OrderConstraint>> CreateConstraintGraph(IEnumerable<Type> types, List<OrderConstraint> constraints)
 		{
 			Dictionary<Type,List<OrderConstraint>> graph = new Dictionary<Type,List<OrderConstraint>>();
@@ -373,7 +369,6 @@ namespace Duality
 		/// <summary>
 		/// Clears the specified constraint graph of all loops.
 		/// </summary>
-		/// <param name="graph"></param>
 		private static void ResolveConstraintLoops(Dictionary<Type,List<OrderConstraint>> graph)
 		{
 			while (true)
@@ -413,7 +408,6 @@ namespace Duality
 		/// The result is not necessarily the smallest loop. Returns null if no loop was found.
 		/// </summary>
 		/// <param name="graph"></param>
-		/// <returns></returns>
 		private static List<OrderConstraint> FindConstraintLoop(Dictionary<Type,List<OrderConstraint>> graph)
 		{
 			if (graph.Count == 0) return null;
@@ -479,8 +473,6 @@ namespace Duality
 		/// Assigns every node in the constraint graph a score that corresponds to its absolute position
 		/// in the desired execution order. Score collisions are possible but unlikely.
 		/// </summary>
-		/// <param name="graph"></param>
-		/// <returns></returns>
 		private static Dictionary<Type,int> ScoreGraphNodes(Dictionary<Type,List<OrderConstraint>> graph, IEnumerable<Type> types)
 		{
 			Dictionary<Type,int> graphScores = new Dictionary<Type,int>(graph.Count);
@@ -540,7 +532,6 @@ namespace Duality
 		/// Extracts a unique sorting index for each type in a previously scored constraint graph.
 		/// </summary>
 		/// <param name="graphScores"></param>
-		/// <returns></returns>
 		private static Dictionary<Type,int> ExtractSortIndices(Dictionary<Type,int> graphScores)
 		{
 			List<KeyValuePair<Type,int>> scoreItems = graphScores.ToList();

--- a/Source/Core/Duality/Components/Other/ComponentRequirementMap.cs
+++ b/Source/Core/Duality/Components/Other/ComponentRequirementMap.cs
@@ -247,7 +247,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="componentType"></param>
 		/// <param name="requiredType"></param>
-		/// <returns></returns>
 		public bool IsRequired(Type componentType, Type requiredType)
 		{
 			if (componentType == requiredType) return false;
@@ -269,7 +268,6 @@ namespace Duality
 		/// <param name="targetObj"></param>
 		/// <param name="targetComponentType"></param>
 		/// <param name="whenAddingThose"></param>
-		/// <returns></returns>
 		public bool IsRequirementMet(GameObject targetObj, Type targetComponentType, IEnumerable<Type> whenAddingThose = null)
 		{
 			IEnumerable<Type> reqTypes = this.GetRequirements(targetComponentType);
@@ -292,7 +290,6 @@ namespace Duality
 		/// These may include abstract classes or interface definitions.
 		/// </summary>
 		/// <param name="componentType"></param>
-		/// <returns></returns>
 		public IEnumerable<Type> GetRequirements(Type componentType)
 		{
 			TypeData data;
@@ -313,7 +310,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="targetObj"></param>
 		/// <param name="targetComponentType"></param>
-		/// <returns></returns>
 		public IEnumerable<Type> GetRequirementsToCreate(GameObject targetObj, Type targetComponentType)
 		{
 			// Retrieve the component's requirements

--- a/Source/Core/Duality/Components/Other/IRendererVisibilityStrategy.cs
+++ b/Source/Core/Duality/Components/Other/IRendererVisibilityStrategy.cs
@@ -25,7 +25,6 @@ namespace Duality.Components
 		/// </summary>
 		/// <param name="device"></param>
 		/// <param name="visibleRenderers"></param>
-		/// <returns></returns>
 		void QueryVisibleRenderers(DrawDevice device, RawList<ICmpRenderer> visibleRenderers);
 		/// <summary>
 		/// Updates the strategy to account for changes in the <see cref="Duality.Resources.Scene"/>

--- a/Source/Core/Duality/Components/Physics/PhysicsWorld.cs
+++ b/Source/Core/Duality/Components/Physics/PhysicsWorld.cs
@@ -279,7 +279,6 @@ namespace Duality.Components.Physics
 		/// the specified world coordinate is located in.
 		/// </summary>
 		/// <param name="worldCoord"></param>
-		/// <returns></returns>
 		public ShapeInfo PickShape(Vector2 worldCoord)
 		{
 			Vector2 fsWorldCoord = PhysicsUnit.LengthToPhysical * worldCoord;

--- a/Source/Core/Duality/Components/Physics/RigidBody.cs
+++ b/Source/Core/Duality/Components/Physics/RigidBody.cs
@@ -458,7 +458,6 @@ namespace Duality.Components.Physics
 		/// <summary>
 		/// Removes an existing joint from the body.
 		/// </summary>
-		/// <param name="joint"></param>
 		public void RemoveJoint(JointInfo joint)
 		{
 			if (joint == null) throw new ArgumentNullException("joint");
@@ -477,7 +476,6 @@ namespace Duality.Components.Physics
 		/// <summary>
 		/// Adds a new joint to the body.
 		/// </summary>
-		/// <param name="joint"></param>
 		public void AddJoint(JointInfo joint, RigidBody other = null)
 		{
 			if (joint == null) throw new ArgumentNullException("joint");
@@ -707,7 +705,6 @@ namespace Duality.Components.Physics
 		/// the specified world coordinate is located in.
 		/// </summary>
 		/// <param name="worldCoord"></param>
-		/// <returns></returns>
 		public ShapeInfo PickShape(Vector2 worldCoord)
 		{
 			if (this.body == null) return null;

--- a/Source/Core/Duality/Components/Transform.cs
+++ b/Source/Core/Duality/Components/Transform.cs
@@ -228,7 +228,6 @@ namespace Duality.Components
 		/// Transforms a position from local space of this object to world space.
 		/// </summary>
 		/// <param name="local"></param>
-		/// <returns></returns>
 		public Vector3 GetWorldPoint(Vector3 local)
 		{
 			return new Vector3(
@@ -240,7 +239,6 @@ namespace Duality.Components
 		/// Transforms a position from local space of this object to world space.
 		/// </summary>
 		/// <param name="local"></param>
-		/// <returns></returns>
 		public Vector2 GetWorldPoint(Vector2 local)
 		{
 			return new Vector2(
@@ -251,7 +249,6 @@ namespace Duality.Components
 		/// Transforms a position from world space to local space of this object.
 		/// </summary>
 		/// <param name="world"></param>
-		/// <returns></returns>
 		public Vector3 GetLocalPoint(Vector3 world)
 		{
 			float inverseScale = 1f / this.scaleAbs;
@@ -264,7 +261,6 @@ namespace Duality.Components
 		/// Transforms a position from world space to local space of this object.
 		/// </summary>
 		/// <param name="world"></param>
-		/// <returns></returns>
 		public Vector2 GetLocalPoint(Vector2 world)
 		{
 			float inverseScale = 1f / this.scaleAbs;
@@ -278,7 +274,6 @@ namespace Duality.Components
 		/// Does only take scale and rotation into account, but not position.
 		/// </summary>
 		/// <param name="local"></param>
-		/// <returns></returns>
 		public Vector3 GetWorldVector(Vector3 local)
 		{
 			return new Vector3(
@@ -291,7 +286,6 @@ namespace Duality.Components
 		/// Does only take scale and rotation into account, but not position.
 		/// </summary>
 		/// <param name="local"></param>
-		/// <returns></returns>
 		public Vector2 GetWorldVector(Vector2 local)
 		{
 			return new Vector2(
@@ -303,7 +297,6 @@ namespace Duality.Components
 		/// Does only take scale and rotation into account, but not position.
 		/// </summary>
 		/// <param name="world"></param>
-		/// <returns></returns>
 		public Vector3 GetLocalVector(Vector3 world)
 		{
 			float inverseScale = 1f / this.scaleAbs;
@@ -317,7 +310,6 @@ namespace Duality.Components
 		/// Does only take scale and rotation into account, but not position.
 		/// </summary>
 		/// <param name="world"></param>
-		/// <returns></returns>
 		public Vector2 GetLocalVector(Vector2 world)
 		{
 			float inverseScale = 1f / this.scaleAbs;
@@ -438,11 +430,6 @@ namespace Duality.Components
 		/// Updates the Transforms world space data all at once. This change is
 		/// not regarded as a continuous movement, but as a hard teleport.
 		/// </summary>
-		/// <param name="pos"></param>
-		/// <param name="vel"></param>
-		/// <param name="angle"></param>
-		/// <param name="scale"></param>
-		/// <param name="angleVel"></param>
 		public void SetTransform(Vector3 pos, float angle, float scale)
 		{
 			this.posAbs = pos;
@@ -469,11 +456,6 @@ namespace Duality.Components
 		/// Updates the Transforms local space data all at once. This change is
 		/// not regarded as a continuous movement, but as a hard teleport.
 		/// </summary>
-		/// <param name="pos"></param>
-		/// <param name="vel"></param>
-		/// <param name="angle"></param>
-		/// <param name="scale"></param>
-		/// <param name="angleVel"></param>
 		public void SetLocalTransform(Vector3 pos, float angle, float scale)
 		{
 			this.pos = pos;

--- a/Source/Core/Duality/ContentProvider.cs
+++ b/Source/Core/Duality/ContentProvider.cs
@@ -37,7 +37,6 @@ namespace Duality
 		/// <summary>
 		/// Returns a list of embedded default content that matches the specified type.
 		/// </summary>
-		/// <returns></returns>
 		public static List<ContentRef<T>> GetDefaultContent<T>() where T : Resource
 		{
 			return defaultContent.OfType<T>().Select(r => new ContentRef<T>(r)).ToList();
@@ -45,7 +44,6 @@ namespace Duality
 		/// <summary>
 		/// Returns a list of embedded default content that matches the specified type.
 		/// </summary>
-		/// <returns></returns>
 		public static List<IContentRef> GetDefaultContent(Type t)
 		{
 			TypeInfo typeInfo = t.GetTypeInfo();
@@ -55,7 +53,6 @@ namespace Duality
 		/// Returns a list of all currently loaded content matching the specified Type
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
-		/// <returns></returns>
 		public static List<ContentRef<T>> GetLoadedContent<T>() where T : Resource
 		{
 			return resLibrary.Values
@@ -68,7 +65,6 @@ namespace Duality
 		/// Returns a list of all currently loaded content matching the specified Type
 		/// </summary>
 		/// <param name="t"></param>
-		/// <returns></returns>
 		public static List<IContentRef> GetLoadedContent(Type t)
 		{
 			TypeInfo typeInfo = t.GetTypeInfo();
@@ -82,7 +78,6 @@ namespace Duality
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="baseDirectory">The base directory to search in. Defaults to <see cref="DualityApp.DataDirectory"/> if not specified otherwise.</param>
-		/// <returns></returns>
 		public static List<ContentRef<T>> GetAvailableContent<T>(string baseDirectory = null) where T : Resource
 		{
 			IEnumerable<string> resFiles = Resource.GetResourceFiles(baseDirectory);
@@ -98,7 +93,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="t"></param>
 		/// <param name="baseDirectory">The base directory to search in. Defaults to <see cref="DualityApp.DataDirectory"/> if not specified otherwise.</param>
-		/// <returns></returns>
 		public static List<IContentRef> GetAvailableContent(Type t, string baseDirectory = null)
 		{
 			TypeInfo typeInfo = t.GetTypeInfo();
@@ -182,7 +176,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="content"></param>
 		/// <param name="dispose"></param>
-		/// <returns></returns>
 		public static bool RemoveContent(Resource content, bool dispose = true)
 		{
 			if (content == null) return false;

--- a/Source/Core/Duality/ContentRef.cs
+++ b/Source/Core/Duality/ContentRef.cs
@@ -336,7 +336,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		/// <remarks>
 		/// This is a two-step comparison. First, their actual Resources references are compared.
 		/// If they're both not null and equal, true is returned. Otherwise, their Resource paths
@@ -372,7 +371,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static bool operator !=(ContentRef<T> first, ContentRef<T> second)
 		{
 			return !(first == second);

--- a/Source/Core/Duality/CorePluginManager.cs
+++ b/Source/Core/Duality/CorePluginManager.cs
@@ -35,7 +35,6 @@ namespace Duality
 		/// <summary>
 		/// Enumerates all currently loaded assemblies that are part of Duality, i.e. Duality itsself and all loaded plugins.
 		/// </summary>
-		/// <returns></returns>
 		public override IEnumerable<Assembly> GetAssemblies()
 		{
 			return this.coreAssemblies.Concat(base.GetAssemblies());
@@ -170,7 +169,6 @@ namespace Duality
 		/// (such as <see cref="BadImageFormatException"/>) are catched and ignored
 		/// without reporting an error.
 		/// </param>
-		/// <returns></returns>
 		private Assembly LoadAuxilliaryLibrary(string dllPath, bool tryAndFailSilently)
 		{
 			// Check for already loaded assemblies first

--- a/Source/Core/Duality/DefaultContent.cs
+++ b/Source/Core/Duality/DefaultContent.cs
@@ -46,7 +46,6 @@ namespace Duality
 		/// Opens a <see cref="Stream"/> to an embedded Duality core resource with the specified name.
 		/// </summary>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		public static Stream GetEmbeddedResourceStream(string name)
 		{
 			string embeddedNameBase = "Duality.EmbeddedResources.";

--- a/Source/Core/Duality/Drawing/BatchInfo.cs
+++ b/Source/Core/Duality/Drawing/BatchInfo.cs
@@ -79,7 +79,6 @@ namespace Duality.Drawing
 		/// Creates a new color-only BatchInfo.
 		/// </summary>
 		/// <param name="technique">The <see cref="Duality.Resources.DrawTechnique"/> to use.</param>
-		/// <param name="mainColor">The <see cref="MainColor"/> to use.</param>
 		public BatchInfo(ContentRef<DrawTechnique> technique) : this()
 		{
 			this.technique = technique;
@@ -120,7 +119,6 @@ namespace Duality.Drawing
 		/// target instance exactly, e.g. use the same <see cref="Technique"/> and
 		/// specify the same shader parameter values.
 		/// </summary>
-		/// <param name="target"></param>
 		public void InitFrom(BatchInfo source)
 		{
 			this.Reset();
@@ -192,7 +190,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		/// <seealso cref="ShaderParameterCollection.TryGet"/>
 		public T[] GetArray<T>(string name) where T : struct
 		{
@@ -214,7 +211,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		/// <seealso cref="ShaderParameterCollection.TryGet"/>
 		public T GetValue<T>(string name) where T : struct
 		{
@@ -234,7 +230,6 @@ namespace Duality.Drawing
 		/// Retrieves a texture from the specified variable.
 		/// </summary>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		/// <seealso cref="ShaderParameterCollection.TryGet"/>
 		public ContentRef<Texture> GetTexture(string name)
 		{
@@ -256,7 +251,6 @@ namespace Duality.Drawing
 		/// The returned array should be treated as read-only.
 		/// </summary>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		public float[] GetInternalData(string name)
 		{
 			// Retrieve the material parameter if available
@@ -276,7 +270,6 @@ namespace Duality.Drawing
 		/// The returned value should be treated as read-only.
 		/// </summary>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		public ContentRef<Texture> GetInternalTexture(string name)
 		{
 			// Retrieve the material parameter if available

--- a/Source/Core/Duality/Drawing/Canvas.cs
+++ b/Source/Core/Duality/Drawing/Canvas.cs
@@ -298,6 +298,8 @@ namespace Duality.Drawing
 		/// <param name="x2"></param>
 		/// <param name="y2"></param>
 		/// <param name="z2"></param>
+		/// <param name="pattern"></param>
+		/// <param name="patternLen"></param>
 		public void DrawDashLine(float x, float y, float z, float x2, float y2, float z2, DashPattern pattern = DashPattern.Dash, float patternLen = 1.0f)
 		{
 			uint patternBits = (uint)pattern;
@@ -337,10 +339,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Draws a flat line.
 		/// </summary>
-		/// <param name="x"></param>
-		/// <param name="y"></param>
-		/// <param name="x2"></param>
-		/// <param name="y2"></param>
 		public void DrawDashLine(float x, float y, float x2, float y2, DashPattern pattern = DashPattern.Dash, float patternLen = 1.0f)
 		{
 			this.DrawDashLine(x, y, 0, x2, y2, 0, pattern, patternLen);
@@ -348,12 +346,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Draws a thick, three-dimensional line.
 		/// </summary>
-		/// <param name="x"></param>
-		/// <param name="y"></param>
-		/// <param name="z"></param>
-		/// <param name="x2"></param>
-		/// <param name="y2"></param>
-		/// <param name="z2"></param>
 		public void DrawThickLine(float x, float y, float z, float x2, float y2, float z2, float width)
 		{
 			Vector3 pos = new Vector3(x, y, z);
@@ -397,10 +389,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Draws a thick, flat line.
 		/// </summary>
-		/// <param name="x"></param>
-		/// <param name="y"></param>
-		/// <param name="x2"></param>
-		/// <param name="y2"></param>
 		public void DrawThickLine(float x, float y, float x2, float y2, float width)
 		{
 			this.DrawThickLine(x, y, 0, x2, y2, 0, width);
@@ -409,11 +397,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Draws a rectangle.
 		/// </summary>
-		/// <param name="x"></param>
-		/// <param name="y"></param>
-		/// <param name="z"></param>
-		/// <param name="w"></param>
-		/// <param name="h"></param>
 		public void DrawRect(float x, float y, float z, float w, float h)
 		{
 			if (w < 0.0f) { x += w; w = -w; }
@@ -581,13 +564,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Draws the section of an oval.
 		/// </summary>
-		/// <param name="x"></param>
-		/// <param name="y"></param>
-		/// <param name="z"></param>
-		/// <param name="width"></param>
-		/// <param name="height"></param>
-		/// <param name="minAngle"></param>
-		/// <param name="maxAngle"></param>
 		public void DrawOval(float x, float y, float z, float width, float height)
 		{
 			this.DrawOvalSegment(x, y, z, width, height, 0.0f, MathF.RadAngle360);
@@ -595,12 +571,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Draws the section of an oval.
 		/// </summary>
-		/// <param name="x"></param>
-		/// <param name="y"></param>
-		/// <param name="width"></param>
-		/// <param name="height"></param>
-		/// <param name="minAngle"></param>
-		/// <param name="maxAngle"></param>
 		public void DrawOval(float x, float y, float width, float height)
 		{
 			this.DrawOvalSegment(x, y, 0, width, height, 0.0f, MathF.RadAngle360);
@@ -608,12 +578,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Draws the section of a circle.
 		/// </summary>
-		/// <param name="x"></param>
-		/// <param name="y"></param>
-		/// <param name="z"></param>
-		/// <param name="radius"></param>
-		/// <param name="minAngle"></param>
-		/// <param name="maxAngle"></param>
 		public void DrawCircle(float x, float y, float z, float radius)
 		{
 			this.State.TransformHandle += new Vector2(radius, radius);
@@ -623,11 +587,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Draws the section of a circle
 		/// </summary>
-		/// <param name="x"></param>
-		/// <param name="y"></param>
-		/// <param name="radius"></param>
-		/// <param name="minAngle"></param>
-		/// <param name="maxAngle"></param>
 		public void DrawCircle(float x, float y, float radius)
 		{
 			this.State.TransformHandle += new Vector2(radius, radius);
@@ -638,10 +597,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Fills a polygon. All vertices share the same Z value, and the polygon needs to be convex.
 		/// </summary>
-		/// <param name="points"></param>
-		/// <param name="x"></param>
-		/// <param name="y"></param>
-		/// <param name="z"></param>
 		public void FillPolygon(Vector2[] points, float x, float y, float z = 0.0f)
 		{
 			Vector3 pos = new Vector3(x, y, z);
@@ -701,12 +656,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Fills a three-dimensional line.
 		/// </summary>
-		/// <param name="x"></param>
-		/// <param name="y"></param>
-		/// <param name="z"></param>
-		/// <param name="x2"></param>
-		/// <param name="y2"></param>
-		/// <param name="z2"></param>
 		public void FillThickLine(float x, float y, float z, float x2, float y2, float z2, float width)
 		{
 			Vector3 pos = new Vector3(x, y, z);
@@ -750,10 +699,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Fills a thick, flat line.
 		/// </summary>
-		/// <param name="x"></param>
-		/// <param name="y"></param>
-		/// <param name="x2"></param>
-		/// <param name="y2"></param>
 		public void FillThickLine(float x, float y, float x2, float y2, float width)
 		{
 			this.FillThickLine(x, y, 0, x2, y2, 0, width);
@@ -1040,6 +985,7 @@ namespace Duality.Drawing
 		/// <param name="y"></param>
 		/// <param name="z"></param>
 		/// <param name="blockAlign">Specifies the alignment of the text block.</param>
+		/// <param name="drawBackground"></param>
 		public void DrawText(string text, float x, float y, float z = 0.0f, Alignment blockAlign = Alignment.TopLeft, bool drawBackground = false)
 		{
 			if(!string.IsNullOrEmpty(text))
@@ -1054,6 +1000,7 @@ namespace Duality.Drawing
 		/// <param name="y"></param>
 		/// <param name="z"></param>
 		/// <param name="blockAlign">Specifies the alignment of the text block. To make use of individual line alignment, use the <see cref="FormattedText"/> overload.</param>
+		/// <param name="drawBackground"></param>
 		public void DrawText(string[] text, ref VertexC1P3T2[][] vertices, float x, float y, float z = 0.0f, Alignment blockAlign = Alignment.TopLeft, bool drawBackground = false)
 		{
 			if (text == null || text.Length == 0) return;
@@ -1160,6 +1107,7 @@ namespace Duality.Drawing
 		/// <param name="y"></param>
 		/// <param name="z"></param>
 		/// <param name="blockAlign">Specifies the alignment of the text block. To make use of individual line alignment, use the <see cref="FormattedText"/> overload.</param>
+		/// <param name="drawBackground"></param>
 		public void DrawText(string[] text, float x, float y, float z = 0.0f, Alignment blockAlign = Alignment.TopLeft, bool drawBackground = false)
 		{
 			VertexC1P3T2[][] vertices = null;
@@ -1176,6 +1124,7 @@ namespace Duality.Drawing
 		/// <param name="z"></param>
 		/// <param name="iconMat"></param>
 		/// <param name="blockAlign">Specifies the alignment of the text block. To make use of individual line alignment, make use of <see cref="FormattedText"/> format tags.</param>
+		/// <param name="drawBackground"></param>
 		public void DrawText(FormattedText text, ref VertexC1P3T2[][] vertText, ref VertexC1P3T2[] vertIcon, float x, float y, float z = 0.0f, BatchInfo iconMat = null, Alignment blockAlign = Alignment.TopLeft, bool drawBackground = false)
 		{
 			if (text == null || text.IsEmpty) return;
@@ -1286,6 +1235,7 @@ namespace Duality.Drawing
 		/// <param name="z"></param>
 		/// <param name="iconMat"></param>
 		/// <param name="blockAlign">Specifies the alignment of the text block. To make use of individual line alignment, make use of <see cref="FormattedText"/> format tags.</param>
+		/// <param name="drawBackground"></param>
 		public void DrawText(FormattedText text, float x, float y, float z = 0.0f, BatchInfo iconMat = null, Alignment blockAlign = Alignment.TopLeft, bool drawBackground = false)
 		{
 			VertexC1P3T2[][] vertText = null;
@@ -1297,7 +1247,6 @@ namespace Duality.Drawing
 		/// Measures the specified text using the currently used <see cref="Duality.Resources.Font"/>.
 		/// </summary>
 		/// <param name="text"></param>
-		/// <returns></returns>
 		public Vector2 MeasureText(string text)
 		{
 			Font font = this.State.TextFont.Res;
@@ -1307,7 +1256,6 @@ namespace Duality.Drawing
 		/// Measures the specified text using the currently used <see cref="Duality.Resources.Font"/>.
 		/// </summary>
 		/// <param name="text"></param>
-		/// <returns></returns>
 		public Vector2 MeasureText(string[] text)
 		{
 			Font font = this.State.TextFont.Res;
@@ -1487,7 +1435,6 @@ namespace Duality.Drawing
 		/// at a time, to be re-used after submitting it to the device.
 		/// </summary>
 		/// <param name="minLength"></param>
-		/// <returns></returns>
 		private VertexC1P3T2[] RentVertices(int minLength)
 		{
 			this.buffer.Count = minLength;

--- a/Source/Core/Duality/Drawing/CanvasState.cs
+++ b/Source/Core/Duality/Drawing/CanvasState.cs
@@ -157,7 +157,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Creates a clone of this State.
 		/// </summary>
-		/// <returns></returns>
 		public CanvasState Clone()
 		{
 			return new CanvasState(this);

--- a/Source/Core/Duality/Drawing/DrawDevice.cs
+++ b/Source/Core/Duality/Drawing/DrawDevice.cs
@@ -345,7 +345,6 @@ namespace Duality.Drawing
 		/// Returns the scale factor of objects that are located at the specified world space Z position.
 		/// </summary>
 		/// <param name="z"></param>
-		/// <returns></returns>
 		public float GetScaleAtZ(float z)
 		{
 			if (this.projection == ProjectionMode.Screen)
@@ -360,7 +359,6 @@ namespace Duality.Drawing
 		/// interpreted as the target world Z coordinate.
 		/// </summary>
 		/// <param name="screenPos"></param>
-		/// <returns></returns>
 		public Vector3 GetWorldPos(Vector3 screenPos)
 		{
 			// Determine which clip space depth and divide the target Z corresponds to
@@ -389,7 +387,6 @@ namespace Duality.Drawing
 		/// Transforms world space to screen space positions.
 		/// </summary>
 		/// <param name="worldPos"></param>
-		/// <returns></returns>
 		public Vector2 GetScreenPos(Vector3 worldPos)
 		{
 			// Transform coordinate into clip space
@@ -416,7 +413,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="worldPos">The points world space position.</param>
 		/// <param name="radius">A world space radius around the point.</param>
-		/// <returns></returns>
 		public bool IsSphereInView(Vector3 worldPos, float radius)
 		{
 			// Transform coordinate into clip space
@@ -450,7 +446,6 @@ namespace Duality.Drawing
 		/// Rents a temporary material instance which can be used for rendering. The instance
 		/// is returned implicitly when the device is done with the current rendering operation.
 		/// </summary>
-		/// <returns></returns>
 		public BatchInfo RentMaterial()
 		{
 			int index = this.tempMaterialIndex++;

--- a/Source/Core/Duality/Drawing/FormattedText.cs
+++ b/Source/Core/Duality/Drawing/FormattedText.cs
@@ -55,7 +55,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Returns a format string for changing the current text color to the specified one.
 		/// </summary>
-		/// <returns></returns>
 		public static string FormatColor(ColorRgba color)
 		{
 			int intClr = color.ToIntRgba();
@@ -800,7 +799,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Creates a deep copy of the FormattedText and returns it.
 		/// </summary>
-		/// <returns></returns>
 		public FormattedText Clone()
 		{
 			return this.DeepClone();
@@ -1339,8 +1337,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Renders a text to the specified target Image.
 		/// </summary>
-		/// <param name="text"></param>
-		/// <param name="target"></param>
 		public void RenderToBitmap(string text, PixelData target, float x = 0.0f, float y = 0.0f, PixelData icons = null)
 		{
 			// Rendering

--- a/Source/Core/Duality/Drawing/IDrawDevice.cs
+++ b/Source/Core/Duality/Drawing/IDrawDevice.cs
@@ -62,20 +62,17 @@ namespace Duality.Drawing
 		/// Returns the scale factor of objects that are located at the specified (world space) z-Coordinate.
 		/// </summary>
 		/// <param name="z"></param>
-		/// <returns></returns>
 		float GetScaleAtZ(float z);
 		/// <summary>
 		/// Transforms screen space to world space. The screen positions Z coordinate is
 		/// interpreted as the target world Z coordinate.
 		/// </summary>
 		/// <param name="screenPos"></param>
-		/// <returns></returns>
 		Vector3 GetWorldPos(Vector3 screenPos);
 		/// <summary>
 		/// Transforms world space to screen space.
 		/// </summary>
 		/// <param name="spacePos"></param>
-		/// <returns></returns>
 		Vector2 GetScreenPos(Vector3 spacePos);
 
 		/// <summary>
@@ -84,7 +81,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="worldPos">The points world space position.</param>
 		/// <param name="radius">A world space radius around the point.</param>
-		/// <returns></returns>
 		bool IsSphereInView(Vector3 worldPos, float radius = 1.0f);
 
 		/// <summary>
@@ -92,7 +88,6 @@ namespace Duality.Drawing
 		/// The instance is returned implicitly when the device is done with the 
 		/// current rendering operation.
 		/// </summary>
-		/// <returns></returns>
 		BatchInfo RentMaterial();
 
 		/// <summary>
@@ -125,7 +120,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="screenPos"></param>
 		/// <param name="device"></param>
-		/// <returns></returns>
 		public static Vector3 GetWorldPos(this IDrawDevice device, Vector2 screenPos)
 		{
 			return device.GetWorldPos(new Vector3(screenPos));
@@ -135,7 +129,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="worldPos"></param>
 		/// <param name="device"></param>
-		/// <returns></returns>
 		public static Vector2 GetScreenPos(this IDrawDevice device, Vector2 worldPos)
 		{
 			return device.GetScreenPos(new Vector3(worldPos));
@@ -147,7 +140,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="device"></param>
 		/// <param name="baseMaterial"></param>
-		/// <returns></returns>
 		public static BatchInfo RentMaterial(this IDrawDevice device, BatchInfo baseMaterial)
 		{
 			BatchInfo material = device.RentMaterial();
@@ -160,7 +152,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="device"></param>
 		/// <param name="baseMaterial"></param>
-		/// <returns></returns>
 		public static BatchInfo RentMaterial(this IDrawDevice device, ContentRef<Material> baseMaterial)
 		{
 			return device.RentMaterial(

--- a/Source/Core/Duality/Drawing/PixelData.cs
+++ b/Source/Core/Duality/Drawing/PixelData.cs
@@ -66,7 +66,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="x"></param>
 		/// <param name="y"></param>
-		/// <returns></returns>
 		public ColorRgba this[int x, int y]
 		{
 			get
@@ -115,7 +114,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Clones the pixel data layer and returns the new instance.
 		/// </summary>
-		/// <returns></returns>
 		public PixelData Clone()
 		{
 			return new PixelData(
@@ -266,7 +264,6 @@ namespace Duality.Drawing
 		/// Determines the average color of a Layer.
 		/// </summary>
 		/// <param name="weightTransparent">If true, the alpha value weights a pixels color value. </param>
-		/// <returns></returns>
 		public ColorRgba GetAverageColor(bool weightTransparent = true)
 		{
 			float[] sum = new float[4];

--- a/Source/Core/Duality/Drawing/ShaderParameterCollection.cs
+++ b/Source/Core/Duality/Drawing/ShaderParameterCollection.cs
@@ -151,7 +151,6 @@ namespace Duality.Drawing
 		/// Returns whether a variable with the specified name is defined in this parameter set.
 		/// </summary>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		public bool HasValue(string name)
 		{
 			int index = this.FindIndex(name);
@@ -480,9 +479,6 @@ namespace Duality.Drawing
 		/// <see cref="Vector4"/>, <see cref="Matrix3"/>, <see cref="Matrix4"/>, <see cref="int"/>,
 		/// <see cref="Point2"/> and <see cref="bool"/>.
 		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="name"></param>
-		/// <returns></returns>
 		public bool TryGet<T>(string name, out T[] value) where T : struct
 		{
 			value = null;
@@ -664,9 +660,6 @@ namespace Duality.Drawing
 		/// <see cref="Vector4"/>, <see cref="Matrix3"/>, <see cref="Matrix4"/>, <see cref="int"/>,
 		/// <see cref="Point2"/> and <see cref="bool"/>.
 		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="name"></param>
-		/// <returns></returns>
 		public bool TryGet<T>(string name, out T value) where T : struct
 		{
 			value = default(T);
@@ -759,8 +752,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Retrieves a texture from the specified variable.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <returns></returns>
 		public bool TryGet(string name, out ContentRef<Texture> value)
 		{
 			return this.TryGetInternal(name, out value);
@@ -770,8 +761,6 @@ namespace Duality.Drawing
 		/// Retrieves the internal representation of the specified variables numeric value.
 		/// The returned array should be treated as read-only.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <returns></returns>
 		public bool TryGetInternal(string name, out float[] value)
 		{
 			int index = this.FindIndex(name);
@@ -790,8 +779,6 @@ namespace Duality.Drawing
 		/// Retrieves the internal representation of the specified variables texture value.
 		/// The returned value should be treated as read-only.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <returns></returns>
 		public bool TryGetInternal(string name, out ContentRef<Texture> value)
 		{
 			int index = this.FindIndex(name);

--- a/Source/Core/Duality/Drawing/VertexData/IVertexBatch.cs
+++ b/Source/Core/Duality/Drawing/VertexData/IVertexBatch.cs
@@ -25,7 +25,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Locks the batch in order to access its vertex data directly using an <see cref="IntPtr"/>.
 		/// </summary>
-		/// <returns></returns>
 		PinnedArrayHandle Lock();
 	}
 }

--- a/Source/Core/Duality/Drawing/VertexData/VertexBatch.cs
+++ b/Source/Core/Duality/Drawing/VertexData/VertexBatch.cs
@@ -44,7 +44,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Locks the batch in order to access its vertex data directly using an <see cref="IntPtr"/>.
 		/// </summary>
-		/// <returns></returns>
 		public PinnedArrayHandle Lock()
 		{
 			return new PinnedArrayHandle(this.vertices.Data);

--- a/Source/Core/Duality/Drawing/VertexData/VertexBatchStore.cs
+++ b/Source/Core/Duality/Drawing/VertexData/VertexBatchStore.cs
@@ -54,7 +54,6 @@ namespace Duality.Drawing
 		/// vertex type.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
-		/// <returns></returns>
 		public int GetBatchCount<T>() where T : struct, IVertexData
 		{
 			int typeIndex = VertexDeclaration.Get<T>().TypeIndex;
@@ -66,7 +65,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="batchIndex"></param>
-		/// <returns></returns>
 		public VertexBatch<T> GetBatch<T>(int batchIndex) where T : struct, IVertexData
 		{
 			int typeIndex = VertexDeclaration.Get<T>().TypeIndex;
@@ -79,7 +77,6 @@ namespace Duality.Drawing
 		/// not represented in this <see cref="VertexBatchStore"/>.
 		/// </summary>
 		/// <param name="typeIndex"></param>
-		/// <returns></returns>
 		public IReadOnlyList<IVertexBatch> GetBatches(int typeIndex)
 		{
 			if (typeIndex < 0) return null;
@@ -97,7 +94,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="length"></param>
-		/// <returns></returns>
 		public VertexSlice<T> Rent<T>(int length) where T : struct, IVertexData
 		{
 			RawList<T> vertexList = this.GetVertexList<T>();

--- a/Source/Core/Duality/Drawing/VertexData/VertexBuffer.cs
+++ b/Source/Core/Duality/Drawing/VertexData/VertexBuffer.cs
@@ -163,6 +163,7 @@ namespace Duality.Drawing
 		/// This method changes neither size nor vertex type associated with this buffer.
 		/// This method is unsafe. Where possible, prefer the overload that accepts a managed array.
 		/// </summary>
+		/// <param name="vertexType"></param>
 		/// <param name="bufferIndex">Offset in this buffer to which the new data will be copied, as number of elements.</param>
 		/// <param name="vertexData"></param>
 		/// <param name="vertexCount"></param>

--- a/Source/Core/Duality/Drawing/VertexData/VertexSlice.cs
+++ b/Source/Core/Duality/Drawing/VertexData/VertexSlice.cs
@@ -33,7 +33,6 @@ namespace Duality.Drawing
 		/// Addresses the underlying <see cref="Data"/> starting at the <see cref="Offset"/> of this slice.
 		/// </summary>
 		/// <param name="index"></param>
-		/// <returns></returns>
 		public T this[int index]
 		{
 			// No range checking for performance reasons.

--- a/Source/Core/Duality/Drawing/VertexFormatDefinition/VertexDeclaration.cs
+++ b/Source/Core/Duality/Drawing/VertexFormatDefinition/VertexDeclaration.cs
@@ -32,7 +32,6 @@ namespace Duality.Drawing
 		/// via generic parameter. This is a very efficient compile-time lookup.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
-		/// <returns></returns>
 		public static VertexDeclaration Get<T>() where T : struct, IVertexData
 		{
 			return Cache<T>.Instance;
@@ -41,7 +40,6 @@ namespace Duality.Drawing
 		/// Retrieves the <see cref="VertexDeclaration"/> for the specified type index.
 		/// Returns null if the type index is not valid.
 		/// </summary>
-		/// <returns></returns>
 		public static VertexDeclaration Get(int typeIndex)
 		{
 			if (typeIndex < 0 || typeIndex >= delcarationByIndex.Count)
@@ -55,7 +53,6 @@ namespace Duality.Drawing
 		/// possible, use the generic <see cref="Get{T}()"/> method instead.
 		/// </summary>
 		/// <param name="vertexType"></param>
-		/// <returns></returns>
 		public static VertexDeclaration Get(Type vertexType)
 		{
 			if (vertexType == null) return null;

--- a/Source/Core/Duality/Duality.csproj
+++ b/Source/Core/Duality/Duality.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NVorbis" Version="0.10.1" GeneratePathProperty="true"/>
+		<PackageReference Include="NVorbis" Version="0.10.1" GeneratePathProperty="true" />
 		<PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
 	</ItemGroup>
 

--- a/Source/Core/Duality/DualityApp.cs
+++ b/Source/Core/Duality/DualityApp.cs
@@ -293,7 +293,9 @@ namespace Duality
 		/// <summary>
 		/// Initializes this DualityApp. Should be called before performing any operations within Duality.
 		/// </summary>
+		/// <param name="env"></param>
 		/// <param name="context">The <see cref="ExecutionContext"/> in which Duality runs.</param>
+		/// <param name="plugins"></param>
 		/// <param name="commandLineArgs">
 		/// Command line arguments to run this DualityApp with. 
 		/// Usually these are just the ones from the host application, passed on.
@@ -747,7 +749,6 @@ namespace Duality
 		/// <summary>
 		/// Enumerates all currently loaded assemblies that are part of Duality, i.e. Duality itsself and all loaded plugins.
 		/// </summary>
-		/// <returns></returns>
 		public static IEnumerable<Assembly> GetDualityAssemblies()
 		{
 			return pluginManager.GetAssemblies();

--- a/Source/Core/Duality/GameObject.cs
+++ b/Source/Core/Duality/GameObject.cs
@@ -377,7 +377,6 @@ namespace Duality
 		/// Returns the first child GameObject with the specified name. You may also specify a full name to access children's children.
 		/// </summary>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		public GameObject GetChildByName(string name)
 		{
 			if (this.children == null || string.IsNullOrEmpty(name)) return null;

--- a/Source/Core/Duality/IO/DirectoryOp.cs
+++ b/Source/Core/Duality/IO/DirectoryOp.cs
@@ -13,7 +13,6 @@ namespace Duality.IO
 		/// Returns whether the specified path refers to an existing directory.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		public static bool Exists(string path)
 		{
 			if (string.IsNullOrWhiteSpace(path)) return false;
@@ -45,7 +44,6 @@ namespace Duality.IO
 		/// </summary>
 		/// <param name="path"></param>
 		/// <param name="recursive">If true, the specified path will be searched recursively and yield all descendant file paths.</param>
-		/// <returns></returns>
 		public static IEnumerable<string> GetFiles(string path, bool recursive = false)
 		{
 			if (string.IsNullOrWhiteSpace(path)) return Enumerable.Empty<string>();
@@ -57,7 +55,6 @@ namespace Duality.IO
 		/// </summary>
 		/// <param name="path"></param>
 		/// <param name="recursive">If true, the specified path will be searched recursively and yield all descendant directory paths.</param>
-		/// <returns></returns>
 		public static IEnumerable<string> GetDirectories(string path, bool recursive = false)
 		{
 			if (string.IsNullOrWhiteSpace(path)) return Enumerable.Empty<string>();

--- a/Source/Core/Duality/IO/FileOp.cs
+++ b/Source/Core/Duality/IO/FileOp.cs
@@ -14,7 +14,6 @@ namespace Duality.IO
 		/// Returns whether the specified path refers to an existing file.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		public static bool Exists(string path)
 		{
 			if (string.IsNullOrWhiteSpace(path)) return false;

--- a/Source/Core/Duality/IO/IFileSystem.cs
+++ b/Source/Core/Duality/IO/IFileSystem.cs
@@ -15,7 +15,6 @@ namespace Duality.IO
 		/// Returns a rooted version of the specified path, which uniquely identifies the referenced file system entity.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		string GetFullPath(string path);
 
 		/// <summary>
@@ -23,27 +22,23 @@ namespace Duality.IO
 		/// </summary>
 		/// <param name="path"></param>
 		/// <param name="recursive">If true, the specified path will be searched recursively and yield all descendant file paths.</param>
-		/// <returns></returns>
 		IEnumerable<string> GetFiles(string path, bool recursive = false);
 		/// <summary>
 		/// Enumerates all directories that are located within the specified path.
 		/// </summary>
 		/// <param name="path"></param>
 		/// <param name="recursive">If true, the specified path will be searched recursively and yield all descendant directory paths.</param>
-		/// <returns></returns>
 		IEnumerable<string> GetDirectories(string path, bool recursive = false);
 
 		/// <summary>
 		/// Returns whether the specified path refers to an existing file.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		bool FileExists(string path);
 		/// <summary>
 		/// Returns whether the specified path refers to an existing directory.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		bool DirectoryExists(string path);
 
 		/// <summary>
@@ -51,14 +46,12 @@ namespace Duality.IO
 		/// The returned stream has implicit read / write access.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		Stream CreateFile(string path);
 		/// <summary>
 		/// Opens an existing file at the specified path and returns a <see cref="System.IO.Stream"/> to it.
 		/// </summary>
 		/// <param name="path"></param>
 		/// <param name="mode"></param>
-		/// <returns></returns>
 		Stream OpenFile(string path, FileAccessMode mode);
 		/// <summary>
 		/// Deletes the file that is referred to by the specified path.

--- a/Source/Core/Duality/IO/PathOp.cs
+++ b/Source/Core/Duality/IO/PathOp.cs
@@ -61,7 +61,6 @@ namespace Duality.IO
 		/// Determines whether the specified path begins with a file system root.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		public static bool IsPathRooted(string path)
 		{
 			if (string.IsNullOrWhiteSpace(path)) return false;
@@ -78,7 +77,6 @@ namespace Duality.IO
 		/// Unlike most methods of <see cref="PathOp"/>, this method accesses the file system.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		public static string GetFullPath(string path)
 		{
 			if (string.IsNullOrWhiteSpace(path)) return string.Empty;
@@ -93,7 +91,6 @@ namespace Duality.IO
 		/// </summary>
 		/// <param name="firstPath"></param>
 		/// <param name="secondPath"></param>
-		/// <returns></returns>
 		public static bool ArePathsEqual(string firstPath, string secondPath)
 		{
 			// Early-out for null or empty cases
@@ -146,7 +143,6 @@ namespace Duality.IO
 		/// Determines the directory name component of a path, i.e. everything except the rightmost path element name.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		public static string GetDirectoryName(string path)
 		{
 			if (string.IsNullOrEmpty(path)) return string.Empty;
@@ -163,7 +159,6 @@ namespace Duality.IO
 		/// Determines the file name component of a path, i.e. the rightmost path element name.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		public static string GetFileName(string path)
 		{
 			if (string.IsNullOrEmpty(path)) return string.Empty;
@@ -180,7 +175,6 @@ namespace Duality.IO
 		/// Similar to <see cref="GetFileName"/>, but also strips away the files extension.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		public static string GetFileNameWithoutExtension(string path)
 		{
 			if (string.IsNullOrEmpty(path)) return string.Empty;
@@ -202,10 +196,6 @@ namespace Duality.IO
 		/// Determines the extension of a file path.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <param name="multiExt">
-		/// If true, multi-extensions such as ".Texture.res" will be considered a 
-		/// single extension, not two consecutive ones.
-		/// </param>
 		/// <returns>
 		/// The paths file extension, including the leading separator char. 
 		/// Returns an empty string, if no extension was found.
@@ -228,7 +218,6 @@ namespace Duality.IO
 		/// </summary>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static string Combine(string first, string second)
 		{
 			bool firstEmpty = string.IsNullOrWhiteSpace(first);
@@ -257,7 +246,6 @@ namespace Duality.IO
 		/// Concatenates any number of path strings.
 		/// </summary>
 		/// <param name="paths"></param>
-		/// <returns></returns>
 		public static string Combine(params string[] paths)
 		{
 			if (paths == null) throw new ArgumentNullException ("paths");
@@ -296,7 +284,6 @@ namespace Duality.IO
 		/// <summary>
 		/// Returns an array of characters which are invalid in path strings.
 		/// </summary>
-		/// <returns></returns>
 		public static char[] GetInvalidPathChars()
 		{
 			return InvalidPathChars.Clone() as char[];
@@ -304,7 +291,6 @@ namespace Duality.IO
 		/// <summary>
 		/// Returns an array of characters which are invalid in file name strings.
 		/// </summary>
-		/// <returns></returns>
 		public static char[] GetInvalidFileNameChars()
 		{
 			return InvalidFileNameChars.Clone() as char[];
@@ -315,7 +301,6 @@ namespace Duality.IO
 		/// cleared of all invalid path characters.
 		/// </summary>
 		/// <param name="fileName"></param>
-		/// <returns></returns>
 		public static string GetValidFileName(string fileName)
 		{
 			string invalidChars = new string(InvalidFileNameChars);

--- a/Source/Core/Duality/IO/Streams/ExtMethodsStream.cs
+++ b/Source/Core/Duality/IO/Streams/ExtMethodsStream.cs
@@ -13,7 +13,6 @@ namespace Duality.IO
 		/// Wraps the Stream inside a <see cref="NonClosingStreamWrapper">proxy</see> that won't close the underlying stream when being closed.
 		/// </summary>
 		/// <param name="stream"></param>
-		/// <returns></returns>
 		public static Stream NonClosing(this Stream stream)
 		{
 			return new NonClosingStreamWrapper(stream);
@@ -26,7 +25,6 @@ namespace Duality.IO
 		/// </summary>
 		/// <param name="stream"></param>
 		/// <param name="maxLength">The maximum length in bytes that is accessible using the sub-Stream. Specify -1 for not limiting it.</param>
-		/// <returns></returns>
 		public static Stream SubStream(this Stream stream, long maxLength = -1)
 		{
 			return new SubStreamWrapper(stream, maxLength);

--- a/Source/Core/Duality/Input/Collections/UserInputCollection.cs
+++ b/Source/Core/Duality/Input/Collections/UserInputCollection.cs
@@ -30,7 +30,6 @@ namespace Duality.Input
 		/// [GET] Returns a specific input by index.
 		/// </summary>
 		/// <param name="index"></param>
-		/// <returns></returns>
 		public TInput this[int index]
 		{
 			get { return (index >= 0 && index < this.input.Count) ? this.input[index] : this.dummyInput; }
@@ -39,7 +38,6 @@ namespace Duality.Input
 		/// [GET] Returns a specific input by its <see cref="IUserInput.Id"/>.
 		/// </summary>
 		/// <param name="id"></param>
-		/// <returns></returns>
 		public TInput this[string id]
 		{
 			get { return this.input.FirstOrDefault(j => j.Id == id) as TInput ?? this.dummyInput as TInput; }
@@ -132,7 +130,6 @@ namespace Duality.Input
 		/// Returns the index of a specific user input.
 		/// </summary>
 		/// <param name="item"></param>
-		/// <returns></returns>
 		public int IndexOf(TInput item)
 		{
 			return this.input.IndexOf(item);
@@ -141,7 +138,6 @@ namespace Duality.Input
 		/// Returns whether a certain user input is known.
 		/// </summary>
 		/// <param name="item"></param>
-		/// <returns></returns>
 		public bool Contains(TInput item)
 		{
 			return this.input.Contains(item);
@@ -158,7 +154,6 @@ namespace Duality.Input
 		/// <summary>
 		/// Returns an enumerator to iterate over all known user inputs.
 		/// </summary>
-		/// <returns></returns>
 		public IEnumerator<TInput> GetEnumerator()
 		{
 			return this.input.GetEnumerator();

--- a/Source/Core/Duality/Input/Sources/IGamepadInputSource.cs
+++ b/Source/Core/Duality/Input/Sources/IGamepadInputSource.cs
@@ -11,13 +11,11 @@ namespace Duality.Input
 		/// [GET] Returns whether the specified gamepad button is currently pressed.
 		/// </summary>
 		/// <param name="button"></param>
-		/// <returns></returns>
 		bool this[GamepadButton button] { get; }
 		/// <summary>
 		/// [GET] Returns the specified gamepad axis value.
 		/// </summary>
 		/// <param name="axis"></param>
-		/// <returns></returns>
 		float this[GamepadAxis axis] { get; }
 
 		/// <summary>

--- a/Source/Core/Duality/Input/Sources/IJoystickInputSource.cs
+++ b/Source/Core/Duality/Input/Sources/IJoystickInputSource.cs
@@ -24,19 +24,16 @@ namespace Duality.Input
 		/// Returns whether the specified device button is currently pressed.
 		/// </summary>
 		/// <param name="buttonIndex"></param>
-		/// <returns></returns>
 		bool ButtonPressed(int buttonIndex);
 		/// <summary>
 		/// Returns the specified device axis current value.
 		/// </summary>
 		/// <param name="axisIndex"></param>
-		/// <returns></returns>
 		float AxisValue(int axisIndex);
 		/// <summary>
 		/// [GET] Returns the current position of the specified joystick hat.
 		/// </summary>
 		/// <param name="hatIndex"></param>
-		/// <returns></returns>
 		JoystickHatPosition HatPosition(int hatIndex);
 	}
 }

--- a/Source/Core/Duality/Input/Sources/IKeyboardInputSource.cs
+++ b/Source/Core/Duality/Input/Sources/IKeyboardInputSource.cs
@@ -16,7 +16,6 @@ namespace Duality.Input
 		/// [GET] Returns whether a specific key is currently pressed.
 		/// </summary>
 		/// <param name="key"></param>
-		/// <returns></returns>
 		bool this[Key key] { get; }
 	}
 }

--- a/Source/Core/Duality/Input/StateManagers/GamepadInput.cs
+++ b/Source/Core/Duality/Input/StateManagers/GamepadInput.cs
@@ -205,7 +205,6 @@ namespace Duality.Input
 		/// [GET] Returns whether the specified gamepad button is currently pressed.
 		/// </summary>
 		/// <param name="button"></param>
-		/// <returns></returns>
 		public bool this[GamepadButton button]
 		{
 			get { return this.currentState.ButtonPressed[(int)button]; }
@@ -214,7 +213,6 @@ namespace Duality.Input
 		/// [GET] Returns the specified gamepad axis current value.
 		/// </summary>
 		/// <param name="axis"></param>
-		/// <returns></returns>
 		public float this[GamepadAxis axis]
 		{
 			get { return this.currentState.AxisValue[(int)axis]; }
@@ -316,7 +314,6 @@ namespace Duality.Input
 		/// Returns whether the specified button is currently pressed.
 		/// </summary>
 		/// <param name="button"></param>
-		/// <returns></returns>
 		public bool ButtonPressed(GamepadButton button)
 		{
 			return this.currentState.ButtonPressed[(int)button];
@@ -325,7 +322,6 @@ namespace Duality.Input
 		/// Returns whether the specified button was hit this frame.
 		/// </summary>
 		/// <param name="button"></param>
-		/// <returns></returns>
 		public bool ButtonHit(GamepadButton button)
 		{
 			return this.currentState.ButtonPressed[(int)button] && !this.lastState.ButtonPressed[(int)button];
@@ -334,7 +330,6 @@ namespace Duality.Input
 		/// Returns whether the specified button was released this frame.
 		/// </summary>
 		/// <param name="button"></param>
-		/// <returns></returns>
 		public bool ButtonReleased(GamepadButton button)
 		{
 			return !this.currentState.ButtonPressed[(int)button] && this.lastState.ButtonPressed[(int)button];
@@ -344,7 +339,6 @@ namespace Duality.Input
 		/// Returns the specified axis value.
 		/// </summary>
 		/// <param name="axis"></param>
-		/// <returns></returns>
 		public float AxisValue(GamepadAxis axis)
 		{
 			return this.currentState.AxisValue[(int)axis];
@@ -353,7 +347,6 @@ namespace Duality.Input
 		/// Returns the specified axis value change since last frame.
 		/// </summary>
 		/// <param name="axis"></param>
-		/// <returns></returns>
 		public float AxisSpeed(GamepadAxis axis)
 		{
 			return this.currentState.AxisValue[(int)axis] - this.lastState.AxisValue[(int)axis];

--- a/Source/Core/Duality/Input/StateManagers/JoystickInput.cs
+++ b/Source/Core/Duality/Input/StateManagers/JoystickInput.cs
@@ -258,7 +258,6 @@ namespace Duality.Input
 		/// Returns whether the specified button is currently pressed.
 		/// </summary>
 		/// <param name="buttonIndex"></param>
-		/// <returns></returns>
 		public bool ButtonPressed(int buttonIndex)
 		{
 			return this.currentState.ButtonPressed[buttonIndex];
@@ -267,7 +266,6 @@ namespace Duality.Input
 		/// Returns whether the specified button was hit this frame.
 		/// </summary>
 		/// <param name="buttonIndex"></param>
-		/// <returns></returns>
 		public bool ButtonHit(int buttonIndex)
 		{
 			return this.currentState.ButtonPressed[buttonIndex] && !this.lastState.ButtonPressed[buttonIndex];
@@ -276,7 +274,6 @@ namespace Duality.Input
 		/// Returns whether the specified button was released this frame.
 		/// </summary>
 		/// <param name="buttonIndex"></param>
-		/// <returns></returns>
 		public bool ButtonReleased(int buttonIndex)
 		{
 			return !this.currentState.ButtonPressed[buttonIndex] && this.lastState.ButtonPressed[buttonIndex];
@@ -286,7 +283,6 @@ namespace Duality.Input
 		/// Returns the specified axis value.
 		/// </summary>
 		/// <param name="axisIndex"></param>
-		/// <returns></returns>
 		public float AxisValue(int axisIndex)
 		{
 			return this.currentState.AxisValue[axisIndex];
@@ -295,7 +291,6 @@ namespace Duality.Input
 		/// Returns the specified axis value change since last frame.
 		/// </summary>
 		/// <param name="axisIndex"></param>
-		/// <returns></returns>
 		public float AxisSpeed(int axisIndex)
 		{
 			return this.currentState.AxisValue[axisIndex] - this.lastState.AxisValue[axisIndex];
@@ -305,7 +300,6 @@ namespace Duality.Input
 		/// Returns the current position of the specified joystick hat.
 		/// </summary>
 		/// <param name="hatIndex"></param>
-		/// <returns></returns>
 		public JoystickHatPosition HatPosition(int hatIndex)
 		{
 			return this.currentState.HatPosition[hatIndex];
@@ -314,7 +308,6 @@ namespace Duality.Input
 		/// Returns all new hat displacement that occurred since last frame.
 		/// </summary>
 		/// <param name="hatIndex"></param>
-		/// <returns></returns>
 		public JoystickHatPosition HatHit(int hatIndex)
 		{
 			return this.currentState.HatPosition[hatIndex] & (~this.lastState.HatPosition[hatIndex]);
@@ -323,7 +316,6 @@ namespace Duality.Input
 		/// Returns all old hat displacement that stopped since last frame.
 		/// </summary>
 		/// <param name="hatIndex"></param>
-		/// <returns></returns>
 		public JoystickHatPosition HatReleased(int hatIndex)
 		{
 			return this.lastState.HatPosition[hatIndex] & (~this.currentState.HatPosition[hatIndex]);

--- a/Source/Core/Duality/Input/StateManagers/KeyboardInput.cs
+++ b/Source/Core/Duality/Input/StateManagers/KeyboardInput.cs
@@ -100,7 +100,6 @@ namespace Duality.Input
 		/// [GET] Returns whether a specific key is currently pressed.
 		/// </summary>
 		/// <param name="key"></param>
-		/// <returns></returns>
 		public bool this[Key key]
 		{
 			get { return this.currentState.KeyPressed[(int)key]; }
@@ -172,7 +171,6 @@ namespace Duality.Input
 		/// Returns whether the specified key is currently pressed.
 		/// </summary>
 		/// <param name="key"></param>
-		/// <returns></returns>
 		public bool KeyPressed(Key key)
 		{
 			return this.currentState.KeyPressed[(int)key];
@@ -181,7 +179,6 @@ namespace Duality.Input
 		/// Returns whether the specified key was hit this frame.
 		/// </summary>
 		/// <param name="key"></param>
-		/// <returns></returns>
 		public bool KeyHit(Key key)
 		{
 			return this.currentState.KeyPressed[(int)key] && !this.lastState.KeyPressed[(int)key];
@@ -190,7 +187,6 @@ namespace Duality.Input
 		/// Returns whether the specified key was released this frame.
 		/// </summary>
 		/// <param name="key"></param>
-		/// <returns></returns>
 		public bool KeyReleased(Key key)
 		{
 			return !this.currentState.KeyPressed[(int)key] && this.lastState.KeyPressed[(int)key];

--- a/Source/Core/Duality/Input/StateManagers/MouseInput.cs
+++ b/Source/Core/Duality/Input/StateManagers/MouseInput.cs
@@ -148,7 +148,6 @@ namespace Duality.Input
 		/// [GET] Returns whether a specific <see cref="MouseButton"/> is currently pressed.
 		/// </summary>
 		/// <param name="btn"></param>
-		/// <returns></returns>
 		public bool this[MouseButton btn]
 		{
 			get { return this.currentState.ButtonPressed[(int)btn]; }
@@ -254,7 +253,6 @@ namespace Duality.Input
 		/// Returns whether the specified button is currently pressed.
 		/// </summary>
 		/// <param name="button"></param>
-		/// <returns></returns>
 		public bool ButtonPressed(MouseButton button)
 		{
 			return this.currentState.ButtonPressed[(int)button];
@@ -263,7 +261,6 @@ namespace Duality.Input
 		/// Returns whether the specified button was hit this frame.
 		/// </summary>
 		/// <param name="button"></param>
-		/// <returns></returns>
 		public bool ButtonHit(MouseButton button)
 		{
 			return this.currentState.ButtonPressed[(int)button] && !this.lastState.ButtonPressed[(int)button];
@@ -272,7 +269,6 @@ namespace Duality.Input
 		/// Returns whether the specified button was released this frame.
 		/// </summary>
 		/// <param name="button"></param>
-		/// <returns></returns>
 		public bool ButtonReleased(MouseButton button)
 		{
 			return !this.currentState.ButtonPressed[(int)button] && this.lastState.ButtonPressed[(int)button];

--- a/Source/Core/Duality/PluginManager.cs
+++ b/Source/Core/Duality/PluginManager.cs
@@ -120,7 +120,6 @@ namespace Duality
 		/// Enumerates all currently loaded assemblies that are considered part of the 
 		/// managed subset of this <see cref="PluginManager{T}"/>.
 		/// </summary>
-		/// <returns></returns>
 		public virtual IEnumerable<Assembly> GetAssemblies()
 		{
 			return this.LoadedPlugins.Select(plugin => plugin.PluginAssembly);
@@ -207,7 +206,6 @@ namespace Duality
 		/// </remarks>
 		/// <param name="pluginAssembly"></param>
 		/// <param name="pluginFilePath"></param>
-		/// <returns></returns>
 		public T LoadPlugin(Assembly pluginAssembly, string pluginFilePath)
 		{
 			this.disposedPlugins.Remove(pluginAssembly);

--- a/Source/Core/Duality/Resource.cs
+++ b/Source/Core/Duality/Resource.cs
@@ -243,7 +243,6 @@ namespace Duality
 		/// <summary>
 		/// Creates a deep copy of this Resource.
 		/// </summary>
-		/// <returns></returns>
 		public Resource Clone()
 		{
 			return this.DeepClone();
@@ -274,7 +273,6 @@ namespace Duality
 		/// this method in order to handle certain fields and cases manually. See <see cref="ICloneExplicit.SetupCloneTargets"/>
 		/// for a more thorough explanation.
 		/// </summary>
-		/// <param name="setup"></param>
 		protected virtual void OnSetupCloneTargets(object target, ICloneTargetSetup setup) {}
 		/// <summary>
 		/// This method performs the <see cref="CopyTo"/> operation for custom Resource Types.
@@ -408,7 +406,7 @@ namespace Duality
 		/// Desired Type of the returned reference. Does not affect the loaded Resource in any way - it is simply returned as T.
 		/// Results in returning null if the loaded Resource's Type isn't assignable to T.
 		/// </typeparam>
-		/// <param name="str">The stream to load the Resource from.</param>
+		/// <param name="formatter"></param>
 		/// <param name="resPath">The path that is assumed as the loaded Resource's origin.</param>
 		/// <param name="loadCallback">An optional callback that is invoked right after loading the Resource, but before initializing it.</param>
 		/// <param name="initResource">
@@ -463,7 +461,6 @@ namespace Duality
 		/// Determines the name of a Resource based on its path.
 		/// </summary>
 		/// <param name="resPath"></param>
-		/// <returns></returns>
 		public static string GetNameFromPath(string resPath)
 		{
 			if (string.IsNullOrEmpty(resPath)) return "null";
@@ -474,7 +471,6 @@ namespace Duality
 		/// Determines the full (hierarchical) name of a Resource based on its path.
 		/// </summary>
 		/// <param name="resPath"></param>
-		/// <returns></returns>
 		public static string GetFullNameFromPath(string resPath)
 		{
 			if (string.IsNullOrEmpty(resPath)) return "null";
@@ -486,7 +482,6 @@ namespace Duality
 		/// Returns whether or not the specified path points to Duality default content.
 		/// </summary>
 		/// <param name="resPath"></param>
-		/// <returns></returns>
 		public static bool IsDefaultContentPath(string resPath)
 		{
 			return
@@ -498,7 +493,6 @@ namespace Duality
 		/// Determines whether or not the specified path points to a Duality Resource file.
 		/// </summary>
 		/// <param name="filePath"></param>
-		/// <returns></returns>
 		public static bool IsResourceFile(string filePath)
 		{
 			return string.Equals(PathOp.GetExtension(filePath), FileExt, StringComparison.OrdinalIgnoreCase);
@@ -508,7 +502,6 @@ namespace Duality
 		/// any actual content- or load states.
 		/// </summary>
 		/// <param name="folderPath"></param>
-		/// <returns></returns>
 		public static IEnumerable<string> GetResourceFiles(string folderPath = null)
 		{
 			if (string.IsNullOrEmpty(folderPath)) folderPath = DualityApp.DataDirectory;
@@ -530,7 +523,7 @@ namespace Duality
 		/// <summary>
 		/// Returns the Resource file extension for a specific Resource Type.
 		/// </summary>
-		/// <param name="resType">The Resource Type to return the file extension from.</param>
+		/// <typeparam name="T">The Resource Type to return the file extension from.</typeparam>
 		/// <returns>The specified Resource Type's file extension.</returns>
 		public static string GetFileExtByType<T>() where T : Resource
 		{
@@ -574,7 +567,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="field"></param>
 		/// <param name="obj"></param>
-		/// <returns></returns>
 		public static bool DontSerializeResourceBlocker(FieldInfo field, object obj)
 		{
 			return field.HasAttributeCached<DontSerializeResourceAttribute>();
@@ -585,7 +577,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="field"></param>
 		/// <param name="obj"></param>
-		/// <returns></returns>
 		public static bool PrefabLinkedFieldBlocker(FieldInfo field, object obj)
 		{
 			Component cmp = obj as Component;

--- a/Source/Core/Duality/Resources/DrawTechnique.cs
+++ b/Source/Core/Duality/Resources/DrawTechnique.cs
@@ -225,9 +225,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Creates a new DrawTechnique using the specified <see cref="BlendMode"/> and shaders.
 		/// </summary>
-		/// <param name="blendType"></param>
-		/// <param name="shader"></param>
-		/// <param name="formatPref"></param>
 		public DrawTechnique(BlendMode blendType, ContentRef<VertexShader> vertexShader, ContentRef<FragmentShader> fragmentShader) 
 		{
 			this.blendType = blendType;

--- a/Source/Core/Duality/Resources/Font/Font.cs
+++ b/Source/Core/Duality/Resources/Font/Font.cs
@@ -168,10 +168,6 @@ namespace Duality.Resources
 		/// Applies a new set of rendered glyphs to the <see cref="Font"/>, adjusts its typeface metadata 
 		/// re-generates texture and material.
 		/// </summary>
-		/// <param name="bitmap"></param>
-		/// <param name="atlas"></param>
-		/// <param name="glyphs"></param>
-		/// <param name="metrics"></param>
 		public void SetGlyphData(FontData fontData)
 		{
 			this.ReleaseResources();
@@ -538,7 +534,6 @@ namespace Duality.Resources
 		/// <param name="text">The original text.</param>
 		/// <param name="maxWidth">The maximum width it may occupy.</param>
 		/// <param name="fitMode">The mode by which the text fitting algorithm operates.</param>
-		/// <returns></returns>
 		public string FitText(string text, float maxWidth, FitTextMode fitMode = FitTextMode.ByChar)
 		{
 			if (this.texture == null) return text;

--- a/Source/Core/Duality/Resources/Font/FontCharSet.cs
+++ b/Source/Core/Duality/Resources/Font/FontCharSet.cs
@@ -66,7 +66,6 @@ namespace Duality.Resources
 		/// Merges two character sets to form a new one that contains both of their characters without duplicates.
 		/// </summary>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public FontCharSet MergedWith(FontCharSet second)
 		{
 			return new FontCharSet(

--- a/Source/Core/Duality/Resources/Font/FontKerningLookup.cs
+++ b/Source/Core/Duality/Resources/Font/FontKerningLookup.cs
@@ -39,7 +39,6 @@ namespace Duality.Resources
 		/// </summary>
 		/// <param name="firstChar"></param>
 		/// <param name="secondChar"></param>
-		/// <returns></returns>
 		public float GetAdvanceOffset(char firstChar, char secondChar)
 		{
 			// Find a matching range of entries for the first char

--- a/Source/Core/Duality/Resources/Material.cs
+++ b/Source/Core/Duality/Resources/Material.cs
@@ -206,7 +206,6 @@ namespace Duality.Resources
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		/// <seealso cref="BatchInfo.GetArray"/>
 		public T[] GetArray<T>(string name) where T : struct
 		{
@@ -218,7 +217,6 @@ namespace Duality.Resources
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		/// <seealso cref="BatchInfo.GetValue"/>
 		public T GetValue<T>(string name) where T : struct
 		{
@@ -228,7 +226,6 @@ namespace Duality.Resources
 		/// Retrieves a texture from the specified variable.
 		/// </summary>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		/// <seealso cref="BatchInfo.GetTexture"/>
 		public ContentRef<Texture> GetTexture(string name)
 		{

--- a/Source/Core/Duality/Resources/Prefab.cs
+++ b/Source/Core/Duality/Resources/Prefab.cs
@@ -104,7 +104,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Creates a new instance of the Prefab. You will need to add it to a Scene in most cases.
 		/// </summary>
-		/// <returns></returns>
 		public GameObject Instantiate()
 		{
 			if (this.objTree == null)
@@ -120,7 +119,6 @@ namespace Duality.Resources
 		/// <param name="position"></param>
 		/// <param name="angle"></param>
 		/// <param name="scale"></param>
-		/// <returns></returns>
 		public GameObject Instantiate(Vector3 position, float angle = 0.0f, float scale = 1.0f)
 		{
 			GameObject obj = this.Instantiate();
@@ -176,7 +174,6 @@ namespace Duality.Resources
 		/// </summary>
 		/// <param name="gameObjIndexPath">The <see cref="GameObject.GetIndexPathOfChild">index path</see> at which to search for a GameObject.</param>
 		/// <param name="cmpType">The Component type to search for inside the found GameObject.</param>
-		/// <returns></returns>
 		public bool HasComponent(IEnumerable<int> gameObjIndexPath, Type cmpType)
 		{
 			if (this.objTree == null) return false;
@@ -625,7 +622,6 @@ namespace Duality.Resources
 		/// Returns whether a specific object is affected by this PrefabLink.
 		/// </summary>
 		/// <param name="cmp"></param>
-		/// <returns></returns>
 		public bool AffectsObject(Component cmp)
 		{
 			return this.prefab.IsAvailable && this.prefab.Res.HasComponent(this.obj.GetIndexPathOfChild(cmp.GameObj), cmp.GetType());
@@ -633,8 +629,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Returns whether a specific object is affected by this PrefabLink.
 		/// </summary>
-		/// <param name="cmp"></param>
-		/// <returns></returns>
 		public bool AffectsObject(GameObject obj)
 		{
 			return this.prefab.IsAvailable && this.prefab.Res.HasGameObject(this.obj.GetIndexPathOfChild(obj));

--- a/Source/Core/Duality/Resources/RenderSetup/PickingRenderSetup.cs
+++ b/Source/Core/Duality/Resources/RenderSetup/PickingRenderSetup.cs
@@ -43,7 +43,6 @@ namespace Duality.Resources
 		/// </summary>
 		/// <param name="x"></param>
 		/// <param name="y"></param>
-		/// <returns></returns>
 		public ICmpRenderer LookupPickingMap(int x, int y)
 		{
 			if (this.pickingBuffer == null) return null;
@@ -81,7 +80,6 @@ namespace Duality.Resources
 		/// <param name="y"></param>
 		/// <param name="w"></param>
 		/// <param name="h"></param>
-		/// <returns></returns>
 		public IEnumerable<ICmpRenderer> LookupPickingMap(int x, int y, int w, int h)
 		{
 			if (this.pickingBuffer == null)

--- a/Source/Core/Duality/Resources/RenderSetup/RenderSetup.cs
+++ b/Source/Core/Duality/Resources/RenderSetup/RenderSetup.cs
@@ -180,11 +180,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Renders a scene from the perspective of a single, pre-configured drawing device.
 		/// </summary>
-		/// <param name="scene"></param>
-		/// <param name="drawDevice"></param>
-		/// <param name="viewportRect"></param>
-		/// <param name="imageSize"></param>
-		/// <param name="outputTargetRect"></param>
 		public void RenderPointOfView(Scene scene, DrawDevice drawDevice, Rect viewportRect, Vector2 imageSize)
 		{
 			// Memorize projection matrix settings, so the drawing device can be properly reset later
@@ -210,7 +205,6 @@ namespace Duality.Resources
 		/// Applies auto-resizing rules to all <see cref="RenderTarget"/> resources that are in the resize list
 		/// of this <see cref="RenderSetup"/>.
 		/// </summary>
-		/// <param name="outputSize"></param>
 		protected void ApplyOutputAutoResize(Point2 outputSize)
 		{
 			foreach (RenderSetupTargetResize autoResize in this.autoResizeTargets)
@@ -271,12 +265,6 @@ namespace Duality.Resources
 		/// Performs the specified <see cref="RenderStep"/>. This method will do some basic, localized configuration on
 		/// the drawing device and then invoke <see cref="OnRenderSingleStep"/> for running the actual rendering operations.
 		/// </summary>
-		/// <param name="step"></param>
-		/// <param name="scene"></param>
-		/// <param name="drawDevice"></param>
-		/// <param name="viewportRect"></param>
-		/// <param name="imageSize"></param>
-		/// <param name="outputTargetRect"></param>
 		protected void RenderSingleStep(RenderStep step, Scene scene, DrawDevice drawDevice, Rect viewportRect, Vector2 imageSize)
 		{
 			// Memorize old draw device settings to reset them later
@@ -345,7 +333,6 @@ namespace Duality.Resources
 		/// </summary>
 		/// <param name="scene"></param>
 		/// <param name="drawDevice"></param>
-		/// <param name="pickingMap"></param>
 		protected void CollectRendererDrawcalls(Scene scene, DrawDevice drawDevice)
 		{
 			Profile.TimeCollectDrawcalls.BeginMeasure();
@@ -472,11 +459,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Called to render a scene from the perspective of a single, pre-configured drawing device.
 		/// </summary>
-		/// <param name="scene"></param>
-		/// <param name="drawDevice"></param>
-		/// <param name="viewportRect"></param>
-		/// <param name="imageSize"></param>
-		/// <param name="outputTargetRect"></param>
 		protected virtual void OnRenderPointOfView(Scene scene, DrawDevice drawDevice, Rect viewportRect, Vector2 imageSize)
 		{
 			// Resize all render targets to the viewport size we're dealing with
@@ -491,8 +473,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Called to process the specified <see cref="RenderStep"/>.
 		/// </summary>
-		/// <param name="step"></param>
-		/// <param name="drawDevice"></param>
 		protected virtual void OnRenderSingleStep(RenderStep step, Scene scene, DrawDevice drawDevice)
 		{
 			drawDevice.PrepareForDrawcalls();

--- a/Source/Core/Duality/Resources/Scene.cs
+++ b/Source/Core/Duality/Resources/Scene.cs
@@ -199,7 +199,6 @@ namespace Duality.Resources
 		/// Performs a <see cref="Scene"/> switch operation that was scheduled using
 		/// <see cref="Scene.SwitchTo"/>.
 		/// </summary>
-		/// <returns></returns>
 		internal static bool PerformScheduledSwitch()
 		{
 			if (!switchToScheduled) return false;
@@ -731,7 +730,6 @@ namespace Duality.Resources
 		/// Finds all GameObjects in the Scene that match the specified name or name path.
 		/// </summary>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		public IEnumerable<GameObject> FindGameObjects(string name)
 		{
 			return this.AllObjects.ByName(name);
@@ -739,8 +737,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Finds all GameObjects in the Scene which have a Component of the specified type.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <returns></returns>
 		public IEnumerable<GameObject> FindGameObjects(Type hasComponentOfType)
 		{
 			return this.FindComponents(hasComponentOfType).GameObject();
@@ -748,8 +744,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Finds all GameObjects in the Scene which have a Component of the specified type.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <returns></returns>
 		public IEnumerable<GameObject> FindGameObjects<T>() where T : class
 		{
 			return this.FindComponents<T>().OfType<Component>().GameObject();
@@ -757,8 +751,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Finds all Components of the specified type in this Scene.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <returns></returns>
 		public IEnumerable<T> FindComponents<T>() where T : class
 		{
 			return FindComponents(typeof(T)).OfType<T>();
@@ -766,8 +758,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Finds all Components of the specified type in this Scene.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <returns></returns>
 		public IEnumerable<Component> FindComponents(Type type)
 		{
 			TypeInfo typeInfo = type.GetTypeInfo();
@@ -819,8 +809,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Finds a single GameObjects in the Scene that match the specified name or name path.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <returns></returns>
 		public GameObject FindGameObject(string name, bool activeOnly = true)
 		{
 			return (activeOnly ? this.ActiveObjects : this.AllObjects).ByName(name).FirstOrDefault();
@@ -828,8 +816,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Finds a single GameObject in the Scene that has a Component of the specified type.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <returns></returns>
 		public GameObject FindGameObject(Type hasComponentOfType, bool activeOnly = true)
 		{
 			Component cmp = this.FindComponent(hasComponentOfType, activeOnly);
@@ -838,8 +824,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Finds a single GameObject in the Scene that has a Component of the specified type.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <returns></returns>
 		public GameObject FindGameObject<T>(bool activeOnly = true) where T : class
 		{
 			Component cmp = this.FindComponent<T>(activeOnly) as Component;
@@ -848,8 +832,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Finds a single Component of the specified type in this Scene.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <returns></returns>
 		public T FindComponent<T>(bool activeOnly = true) where T : class
 		{
 			return FindComponent(typeof(T), activeOnly) as T;
@@ -857,8 +839,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Finds a single Component of the specified type in this Scene.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <returns></returns>
 		public Component FindComponent(Type type, bool activeOnly = true)
 		{
 			TypeInfo typeInfo = type.GetTypeInfo();

--- a/Source/Core/Duality/Resources/Shaders/ShaderSourceBuilder.cs
+++ b/Source/Core/Duality/Resources/Shaders/ShaderSourceBuilder.cs
@@ -134,7 +134,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Builds the merged, preprocessed source code.
 		/// </summary>
-		/// <returns></returns>
 		public string Build()
 		{
 			this.fields.Clear();
@@ -236,7 +235,6 @@ namespace Duality.Resources
 		/// </summary>
 		/// <param name="source"></param>
 		/// <param name="ignoreRegions"></param>
-		/// <returns></returns>
 		private Dictionary<IndexRange,List<IndexRange>> IdentifyMetadataBlocks(string source, List<IndexRange> ignoreRegions)
 		{
 			Dictionary<IndexRange, List<IndexRange>> metadataBlocks = new Dictionary<IndexRange, List<IndexRange>>();
@@ -408,7 +406,6 @@ namespace Duality.Resources
 		/// <param name="source"></param>
 		/// <param name="ignoreRegions"></param>
 		/// <param name="removeSchedule"></param>
-		/// <returns></returns>
 		private void ParseFields(string source, List<IndexRange> ignoreRegions, List<IndexRange> removeSchedule)
 		{
 			// Read the source line by line and parse it along the way
@@ -478,7 +475,6 @@ namespace Duality.Resources
 		/// </summary>
 		/// <param name="line"></param>
 		/// <param name="fieldMetadata"></param>
-		/// <returns></returns>
 		private ShaderFieldInfo ParseFieldDeclaration(string line, IReadOnlyList<string> fieldMetadata)
 		{
 			// Parse the field scope and detect whether the line is a field declaration at all
@@ -618,7 +614,6 @@ namespace Duality.Resources
 		/// </summary>
 		/// <param name="text"></param>
 		/// <param name="range"></param>
-		/// <returns></returns>
 		private IndexRange ExpandToLine(string text, IndexRange range)
 		{
 			int lineBeginIndex = text.LastIndexOfAny(new char[] { '\n', '\r' }, range.Index) + 1;
@@ -630,7 +625,6 @@ namespace Duality.Resources
 		/// </summary>
 		/// <param name="range"></param>
 		/// <param name="compareToRanges"></param>
-		/// <returns></returns>
 		private bool AnyRangeOverlap(IndexRange range, List<IndexRange> compareToRanges)
 		{
 			foreach (IndexRange ignoreRange in compareToRanges)

--- a/Source/Core/Duality/Resources/Sound.cs
+++ b/Source/Core/Duality/Resources/Sound.cs
@@ -217,7 +217,6 @@ namespace Duality.Resources
 		/// Upon playing the Sound, this method is called once to determine which of the referenced
 		/// <see cref="Duality.Resources.AudioData"/> objects is to be played.
 		/// </summary>
-		/// <returns></returns>
 		public ContentRef<AudioData> FetchData()
 		{
 			return MathF.Rnd.OneOf(this.audioData);

--- a/Source/Core/Duality/Resources/Texture.cs
+++ b/Source/Core/Duality/Resources/Texture.cs
@@ -421,7 +421,6 @@ namespace Duality.Resources
 		/// <summary>
 		/// Retrieves the pixel data that is currently stored in video memory.
 		/// </summary>
-		/// <returns></returns>
 		public PixelData GetPixelData()
 		{
 			PixelData result = new PixelData();

--- a/Source/Core/Duality/Serialization/DataType.cs
+++ b/Source/Core/Duality/Serialization/DataType.cs
@@ -112,7 +112,6 @@ namespace Duality.Serialization
 		/// Returns whether the <see cref="Duality.Serialization.DataType"/> represents a primitive data type.
 		/// </summary>
 		/// <param name="dt"></param>
-		/// <returns></returns>
 		public static bool IsPrimitiveType(this DataType dt)
 		{
 			return ((ushort)dt >= (ushort)DataType.Bool && (ushort)dt <= (ushort)DataType.Char) || dt == DataType.String;
@@ -121,7 +120,6 @@ namespace Duality.Serialization
 		/// Returns whether the <see cref="Duality.Serialization.DataType"/> represents a <see cref="System.Reflection.MemberInfo"/> type.
 		/// </summary>
 		/// <param name="dt"></param>
-		/// <returns></returns>
 		public static bool IsMemberInfoType(this DataType dt)
 		{
 			return 
@@ -134,7 +132,6 @@ namespace Duality.Serialization
 		/// Returns whether the specified <see cref="DataType"/> requires an explicit type name during serialization.
 		/// </summary>
 		/// <param name="dt"></param>
-		/// <returns></returns>
 		public static bool HasTypeName(this DataType dt)
 		{
 			return dt == DataType.Struct || dt == DataType.Array || dt == DataType.Delegate || dt == DataType.Enum;
@@ -143,7 +140,6 @@ namespace Duality.Serialization
 		/// Returns whether the specified <see cref="DataType"/> requires a unique object id during serialization.
 		/// </summary>
 		/// <param name="dt"></param>
-		/// <returns></returns>
 		public static bool HasObjectId(this DataType dt)
 		{
 			return dt == DataType.Struct || dt == DataType.Array || dt == DataType.Delegate || dt.IsMemberInfoType();
@@ -152,7 +148,6 @@ namespace Duality.Serialization
 		/// Returns the actual <see cref="System.Type"/> that is associated with the <see cref="Duality.Serialization.DataType"/>.
 		/// </summary>
 		/// <param name="dt"></param>
-		/// <returns></returns>
 		public static Type ToActualType(this DataType dt)
 		{
 			switch (dt)

--- a/Source/Core/Duality/Serialization/ObjectIdManager.cs
+++ b/Source/Core/Duality/Serialization/ObjectIdManager.cs
@@ -57,7 +57,6 @@ namespace Duality.Serialization
 		/// </summary>
 		/// <param name="obj"></param>
 		/// <param name="isNewId"></param>
-		/// <returns></returns>
 		public uint Request(object obj, out bool isNewId)
 		{
 			uint id;
@@ -122,7 +121,6 @@ namespace Duality.Serialization
 		/// </summary>
 		/// <param name="id"></param>
 		/// <param name="obj"></param>
-		/// <returns></returns>
 		public bool Lookup(uint id, out object obj)
 		{
 			return this.idObjRefMap.TryGetValue(id, out obj);

--- a/Source/Core/Duality/Serialization/SerializeType.cs
+++ b/Source/Core/Duality/Serialization/SerializeType.cs
@@ -125,7 +125,6 @@ namespace Duality.Serialization
 		/// Retrieves a serialized field of this type by name.
 		/// </summary>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		public FieldInfo GetFieldByName(string name)
 		{
 			for (int i = 0; i < this.fields.Length; i++)

--- a/Source/Core/Duality/Serialization/Serializer.cs
+++ b/Source/Core/Duality/Serialization/Serializer.cs
@@ -20,7 +20,6 @@ namespace Duality.Serialization
 		/// </summary>
 		/// <param name="field"></param>
 		/// <param name="obj"></param>
-		/// <returns></returns>
 		public delegate bool FieldBlocker(FieldInfo field, object obj);
 
 		/// <summary>
@@ -315,7 +314,6 @@ namespace Duality.Serialization
 		/// <summary>
 		/// Reads a single object and returns it.
 		/// </summary>
-		/// <returns></returns>
 		public object ReadObject()
 		{
 			if (!this.CanRead) throw new InvalidOperationException("Can't read object from a write-only serializer!");
@@ -328,7 +326,6 @@ namespace Duality.Serialization
 		/// Reads a single object, casts it to the specified Type and returns it.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
-		/// <returns></returns>
 		public T ReadObject<T>()
 		{
 			object result = this.ReadObject();
@@ -408,12 +405,10 @@ namespace Duality.Serialization
 		/// used for any given input <see cref="Stream"/>.
 		/// </summary>
 		/// <param name="stream"></param>
-		/// <returns></returns>
 		protected abstract bool MatchesStreamFormat(Stream stream);
 		/// <summary>
 		/// Writes the specified object including all referenced objects.
 		/// </summary>
-		/// <param name="obj">The object to write.</param>
 		protected abstract object ReadObjectData();
 		/// <summary>
 		/// Reads an object including all referenced objects.
@@ -596,10 +591,6 @@ namespace Duality.Serialization
 		/// <summary>
 		/// Assigns the specified value to a specific array index.
 		/// </summary>
-		/// <param name="objSerializeType"></param>
-		/// <param name="obj"></param>
-		/// <param name="fieldName"></param>
-		/// <param name="fieldValue"></param>
 		protected void AssignValueToArray(SerializeType elementSerializeType, Array array, int index, object value)
 		{
 			if (array == null) return;
@@ -620,7 +611,6 @@ namespace Duality.Serialization
 		/// </summary>
 		/// <param name="typeId"></param>
 		/// <param name="objId"></param>
-		/// <returns></returns>
 		protected Type ResolveType(string typeId, uint objId = 0)
 		{
 			// Re-use already resolved type IDs from the local cache, if possible
@@ -648,7 +638,6 @@ namespace Duality.Serialization
 		/// </summary>
 		/// <param name="memberId"></param>
 		/// <param name="objId"></param>
-		/// <returns></returns>
 		protected MemberInfo ResolveMember(string memberId, uint objId = 0)
 		{
 			// Re-use already resolved member IDs from the local cache, if possible
@@ -677,7 +666,6 @@ namespace Duality.Serialization
 		/// <param name="enumType"></param>
 		/// <param name="enumField"></param>
 		/// <param name="value"></param>
-		/// <returns></returns>
 		protected Enum ResolveEnumValue(Type enumType, string enumField, long value)
 		{
 			try
@@ -832,7 +820,6 @@ namespace Duality.Serialization
 		/// Uses a (seekable, random access) Stream to detect the serializer that can handle it.
 		/// </summary>
 		/// <param name="stream"></param>
-		/// <returns></returns>
 		public static Type Detect(Stream stream)
 		{
 			if (!stream.CanRead || !stream.CanSeek) throw new ArgumentException("The specified Stream needs to be readable, seekable and provide random-access functionality.");
@@ -903,7 +890,6 @@ namespace Duality.Serialization
 		/// <typeparam name="T"></typeparam>
 		/// <param name="file"></param>
 		/// <param name="preferredSerializer"></param>
-		/// <returns></returns>
 		public static T TryReadObject<T>(string file, Type preferredSerializer = null)
 		{
 			try
@@ -927,7 +913,6 @@ namespace Duality.Serialization
 		/// <typeparam name="T"></typeparam>
 		/// <param name="stream"></param>
 		/// <param name="preferredSerializer"></param>
-		/// <returns></returns>
 		public static T TryReadObject<T>(Stream stream, Type preferredSerializer = null)
 		{
 			try
@@ -948,7 +933,6 @@ namespace Duality.Serialization
 		/// <typeparam name="T"></typeparam>
 		/// <param name="file"></param>
 		/// <param name="preferredSerializer"></param>
-		/// <returns></returns>
 		public static T ReadObject<T>(string file, Type preferredSerializer = null)
 		{
 			using (Stream str = FileOp.Open(file, FileAccessMode.Read))
@@ -962,7 +946,6 @@ namespace Duality.Serialization
 		/// <typeparam name="T"></typeparam>
 		/// <param name="stream"></param>
 		/// <param name="preferredSerializer"></param>
-		/// <returns></returns>
 		public static T ReadObject<T>(Stream stream, Type preferredSerializer = null)
 		{
 			using (Serializer formatter = Serializer.Create(stream, preferredSerializer))
@@ -1006,7 +989,6 @@ namespace Duality.Serialization
 		/// Returns the <see cref="SerializeType"/> of a Type.
 		/// </summary>
 		/// <param name="type"></param>
-		/// <returns></returns>
 		protected static SerializeType GetSerializeType(Type type)
 		{
 			if (type == null) return null;
@@ -1021,8 +1003,7 @@ namespace Duality.Serialization
 		/// <summary>
 		/// Retrieves a matching <see cref="Duality.Serialization.ISerializeSurrogate"/> for the specified <see cref="System.Type"/>.
 		/// </summary>
-		/// <param name="t">The <see cref="System.Type"/> to retrieve a <see cref="Duality.Serialization.ISerializeSurrogate"/> for.</param>
-		/// <returns></returns>
+		/// <param name="type">The <see cref="System.Type"/> to retrieve a <see cref="Duality.Serialization.ISerializeSurrogate"/> for.</param>
 		internal static ISerializeSurrogate GetSurrogateFor(TypeInfo type)
 		{
 			if (surrogates == null)

--- a/Source/Core/Duality/Serialization/UniqueIdentifyableHelper.cs
+++ b/Source/Core/Duality/Serialization/UniqueIdentifyableHelper.cs
@@ -17,7 +17,6 @@ namespace Duality.Serialization
 		/// It is guaranteed to remain the same across .NET runtimes, libraries and platforms.
 		/// </summary>
 		/// <param name="value"></param>
-		/// <returns></returns>
 		public static int GetIdentifier(string value)
 		{
 			// Based on https://stackoverflow.com/a/2351171
@@ -36,7 +35,6 @@ namespace Duality.Serialization
 		/// It is guaranteed to remain the same across .NET runtimes, libraries and platforms.
 		/// </summary>
 		/// <param name="guid"></param>
-		/// <returns></returns>
 		public static int GetIdentifier(Guid guid)
 		{
 			// Based on https://stackoverflow.com/a/2351171

--- a/Source/Core/Duality/Serialization/XmlSerializer.cs
+++ b/Source/Core/Duality/Serialization/XmlSerializer.cs
@@ -822,7 +822,6 @@ namespace Duality.Serialization
 		/// </summary>
 		/// <param name="array"></param>
 		/// <param name="elementType"></param>
-		/// <returns></returns>
 		private int GetArrayNonDefaultElementCount(Array array, TypeInfo elementType)
 		{
 			if (array.Length == 0) return 0;
@@ -841,7 +840,6 @@ namespace Duality.Serialization
 		/// Wraps the specified <see cref="Stream"/> in a sub-stream that can only access the next available XML document section.
 		/// </summary>
 		/// <param name="stream"></param>
-		/// <returns></returns>
 		private static Stream ReadSingleDocument(Stream stream)
 		{
 			if (!stream.CanSeek) throw new InvalidOperationException("The specified stream needs to be seekable.");

--- a/Source/Core/Duality/Utility/EditorHints/EditorHintAttribute.cs
+++ b/Source/Core/Duality/Utility/EditorHints/EditorHintAttribute.cs
@@ -16,8 +16,7 @@ namespace Duality.Editor
 		/// </summary>
 		/// <typeparam name="T">The Type of editor hint to retrieve.</typeparam>
 		/// <param name="member">The member to extract the hint from. May be null.</param>
-		/// <param name="overrideHint">An optional override hint, that will be preferred, if applicable.</param>
-		/// <returns></returns>
+		/// <param name="overrideHints">An optional override hint, that will be preferred, if applicable.</param>
 		public static T Get<T>(MemberInfo member, IEnumerable<EditorHintAttribute> overrideHints = null) where T : EditorHintAttribute
 		{
 			T hint = member != null ? member.GetAttributesCached<T>().FirstOrDefault() : null;
@@ -34,7 +33,6 @@ namespace Duality.Editor
 		/// <typeparam name="T">The Type of editor hints to retrieve.</typeparam>
 		/// <param name="member">The member to extract the hints from. May be null.</param>
 		/// <param name="overrideHints">An optional collection of override hints, that will be preferred, if applicable.</param>
-		/// <returns></returns>
 		public static IEnumerable<T> GetAll<T>(MemberInfo member, IEnumerable<EditorHintAttribute> overrideHints = null) where T : EditorHintAttribute
 		{
 			IEnumerable<T> hints = member != null ? member.GetAttributesCached<T>() : null;

--- a/Source/Core/Duality/Utility/EventArgs/GameObjectGroupEventArgs.cs
+++ b/Source/Core/Duality/Utility/EventArgs/GameObjectGroupEventArgs.cs
@@ -23,7 +23,6 @@ namespace Duality
 		/// Note that the list is not copied for performance reasons. However, the event also does not
 		/// provide any write access to that internal list either.
 		/// </summary>
-		/// <param name="rootObjects"></param>
 		public GameObjectGroupEventArgs(List<GameObject> objects)
 		{
 			this.objects = objects;

--- a/Source/Core/Duality/Utility/Extensions/ExtMethodsIColorData.cs
+++ b/Source/Core/Duality/Utility/Extensions/ExtMethodsIColorData.cs
@@ -13,7 +13,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="source"></param>
-		/// <returns></returns>
 		public static T ConvertTo<T>(this IColorData source) where T : IColorData
 		{
 			T clr = default(T);
@@ -33,7 +32,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="source"></param>
 		/// <param name="type"></param>
-		/// <returns></returns>
 		public static IColorData ConvertTo(this IColorData source, Type type)
 		{
 			TypeInfo typeInfo = type.GetTypeInfo();

--- a/Source/Core/Duality/Utility/Extensions/ExtMethodsIEnumerable.cs
+++ b/Source/Core/Duality/Utility/Extensions/ExtMethodsIEnumerable.cs
@@ -14,7 +14,6 @@ namespace Duality
 		/// Enumerates the <see cref="Duality.GameObject">GameObjects</see> children.
 		/// </summary>
 		/// <param name="objEnum"></param>
-		/// <returns></returns>
 		public static IEnumerable<GameObject> Children(this IEnumerable<GameObject> objEnum)
 		{
 			List<GameObject> result = new List<GameObject>();
@@ -28,7 +27,6 @@ namespace Duality
 		/// Enumerates the <see cref="Duality.GameObject">GameObjects</see> children, grandchildren, etc.
 		/// </summary>
 		/// <param name="objEnum"></param>
-		/// <returns></returns>
 		public static IEnumerable<GameObject> ChildrenDeep(this IEnumerable<GameObject> objEnum)
 		{
 			List<GameObject> result = new List<GameObject>();
@@ -43,7 +41,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="objEnum"></param>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		public static IEnumerable<GameObject> ByName(this IEnumerable<GameObject> objEnum, string name)
 		{
 			if (name.IndexOf('/') != -1)
@@ -65,7 +62,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="objEnum"></param>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		public static GameObject FirstByName(this IEnumerable<GameObject> objEnum, string name)
 		{
 			if (name.IndexOf('/') != -1)
@@ -86,10 +82,6 @@ namespace Duality
 		/// <summary>
 		/// Enumerates all <see cref="Duality.GameObject">GameObjects</see> <see cref="Component">Components</see> of the specified type.
 		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="objEnum"></param>
-		/// <param name="activeOnly"></param>
-		/// <returns></returns>
 		public static IEnumerable<T> GetComponents<T>(this IEnumerable<GameObject> objEnum) where T : class
 		{
 			return objEnum.SelectMany(o => o.GetComponents<T>());
@@ -97,10 +89,6 @@ namespace Duality
 		/// <summary>
 		/// Enumerates all <see cref="Duality.GameObject">GameObjects</see> childrens <see cref="Component">Components</see> of the specified type.
 		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="objEnum"></param>
-		/// <param name="activeOnly"></param>
-		/// <returns></returns>
 		public static IEnumerable<T> GetComponentsInChildren<T>(this IEnumerable<GameObject> objEnum) where T : class
 		{
 			return objEnum.SelectMany(o => o.GetComponentsInChildren<T>());
@@ -108,10 +96,6 @@ namespace Duality
 		/// <summary>
 		/// Enumerates all <see cref="Duality.GameObject">GameObjects</see> (and their childrens) <see cref="Component">Components</see> of the specified type.
 		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="objEnum"></param>
-		/// <param name="activeOnly"></param>
-		/// <returns></returns>
 		public static IEnumerable<T> GetComponentsDeep<T>(this IEnumerable<GameObject> objEnum) where T : class
 		{
 			return objEnum.SelectMany(o => o.GetComponentsDeep<T>());
@@ -120,9 +104,6 @@ namespace Duality
 		/// <summary>
 		/// Enumerates all <see cref="Duality.GameObject">GameObjects</see> <see cref="Duality.Components.Transform"/> Components.
 		/// </summary>
-		/// <param name="objEnum"></param>
-		/// <param name="activeOnly"></param>
-		/// <returns></returns>
 		public static IEnumerable<Components.Transform> Transform(this IEnumerable<GameObject> objEnum)
 		{
 			return objEnum.Select(o => o.Transform).NotNull();
@@ -131,9 +112,6 @@ namespace Duality
 		/// <summary>
 		/// Enumerates all <see cref="Component">Components</see> parent <see cref="Duality.GameObject">GameObjects</see>.
 		/// </summary>
-		/// <param name="compEnum"></param>
-		/// <param name="activeOnly"></param>
-		/// <returns></returns>
 		public static IEnumerable<GameObject> GameObject(this IEnumerable<Component> compEnum)
 		{
 			return compEnum.Select(c => c.GameObj).NotNull();
@@ -144,7 +122,6 @@ namespace Duality
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="res"></param>
-		/// <returns></returns>
 		public static IEnumerable<ContentRef<T>> Ref<T>(this IEnumerable<T> res) where T : Resource
 		{
 			return res.Select(r => new ContentRef<T>(r));
@@ -154,7 +131,6 @@ namespace Duality
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="res"></param>
-		/// <returns></returns>
 		public static IEnumerable<T> Res<T>(this IEnumerable<ContentRef<T>> res) where T : Resource
 		{
 			return res.Select(r => r.Res);
@@ -163,7 +139,6 @@ namespace Duality
 		/// Converts an enumeration of content references to an enumeration of Resources.
 		/// </summary>
 		/// <param name="res"></param>
-		/// <returns></returns>
 		public static IEnumerable<Resource> Res(this IEnumerable<IContentRef> res)
 		{
 			return res.Select(r => r.Res);
@@ -175,7 +150,6 @@ namespace Duality
 		/// <typeparam name="T">The type of the incoming objects.</typeparam>
 		/// <param name="collection">A set of objects.</param>
 		/// <param name="separator">The string to use as separator between two string values.</param>
-		/// <returns></returns>
 		public static string ToString<T>(this IEnumerable<T> collection, string separator)
 		{
 			StringBuilder sb = new StringBuilder();
@@ -193,7 +167,6 @@ namespace Duality
 		/// <param name="collection">A set of objects.</param>
 		/// <param name="toString">A function that transforms objects to strings.</param>
 		/// <param name="separator">The string to use as separator between two string values.</param>
-		/// <returns></returns>
 		public static string ToString<T>(this IEnumerable<T> collection, Func<T, string> toString, string separator)
 		{
 			StringBuilder sb = new StringBuilder();
@@ -210,7 +183,6 @@ namespace Duality
 		/// </summary>
 		/// <typeparam name="T">The type of the incoming objects.</typeparam>
 		/// <param name="collection">A set of objects.</param>
-		/// <returns></returns>
 		public static IEnumerable<T> NotNull<T>(this IEnumerable<T> collection) where T : class
 		{
 			return collection.Where(i => i != null);
@@ -222,7 +194,6 @@ namespace Duality
 		/// <param name="collection">A set of objects.</param>
 		/// <param name="startIndex">Index of the first object to be enumerated.</param>
 		/// <param name="length">Number of objects to be enumerated.</param>
-		/// <returns></returns>
 		public static IEnumerable<T> Range<T>(this IEnumerable<T> collection, int startIndex, int length)
 		{
 			return collection.Skip(startIndex).Take(length);
@@ -236,7 +207,6 @@ namespace Duality
 		/// <param name="first"></param>
 		/// <param name="second"></param>
 		/// <param name="comparer"></param>
-		/// <returns></returns>
 		public static bool SetEqual<T>(this IEnumerable<T> first, IEnumerable<T> second, IEqualityComparer<T> comparer)
 		{
 			if (object.ReferenceEquals(first, second)) return true;
@@ -276,7 +246,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static bool SetEqual<T>(this IEnumerable<T> first, IEnumerable<T> second)
 		{
 			return SetEqual<T>(first, second, EqualityComparer<T>.Default);

--- a/Source/Core/Duality/Utility/Extensions/ExtMethodsIList.cs
+++ b/Source/Core/Duality/Utility/Extensions/ExtMethodsIList.cs
@@ -58,8 +58,8 @@ namespace Duality
 		/// Performs a zero-alloc stable sort on the specified list. Requires
 		/// a buffer of at least the size of the array that is to be sorted.
 		/// </summary>
-		/// <typeparam name="T">The array element type.</typeparam>
-		/// <param name="array">Array to perform the sort operation on.</param>
+		/// <typeparam name="T">The list element type.</typeparam>
+		/// <param name="list">List to perform the sort operation on.</param>
 		/// <param name="buffer"></param>
 		public static void StableSort<T>(this IList<T> list, IList<T> buffer)
 		{
@@ -69,8 +69,8 @@ namespace Duality
 		/// Performs a zero-alloc stable sort on the specified list. Requires
 		/// a buffer of at least the size of the array that is to be sorted.
 		/// </summary>
-		/// <typeparam name="T">The array element type.</typeparam>
-		/// <param name="array">Array to perform the sort operation on.</param>
+		/// <typeparam name="T">The list element type.</typeparam>
+		/// <param name="list">List to perform the sort operation on.</param>
 		/// <param name="buffer"></param>
 		/// <param name="comparison"></param>
 		public static void StableSort<T>(this IList<T> list, IList<T> buffer, Comparison<T> comparison)
@@ -81,8 +81,8 @@ namespace Duality
 		/// Performs a zero-alloc stable sort on the specified list. Requires
 		/// a buffer of at least the size of the array that is to be sorted.
 		/// </summary>
-		/// <typeparam name="T">The array element type.</typeparam>
-		/// <param name="array">Array to perform the sort operation on.</param>
+		/// <typeparam name="T">The list element type.</typeparam>
+		/// <param name="list">List to perform the sort operation on.</param>
 		/// <param name="buffer"></param>
 		/// <param name="index"></param>
 		/// <param name="count"></param>
@@ -94,8 +94,8 @@ namespace Duality
 		/// Performs a zero-alloc stable sort on the specified list. Requires
 		/// a buffer of at least the size of the array that is to be sorted.
 		/// </summary>
-		/// <typeparam name="T">The array element type.</typeparam>
-		/// <param name="array">Array to perform the sort operation on.</param>
+		/// <typeparam name="T">The list element type.</typeparam>
+		/// <param name="list">List to perform the sort operation on.</param>
 		/// <param name="buffer"></param>
 		/// <param name="index"></param>
 		/// <param name="count"></param>
@@ -320,7 +320,6 @@ namespace Duality
 		/// <typeparam name="T">The lists object type.</typeparam>
 		/// <param name="collection">List to perform the sort operation on.</param>
 		/// <param name="val">Object to compare the lists contents to.</param>
-		/// <returns></returns>
 		public static int IndexOfFirst<T>(this IList<T> collection, T val)
 		{
 			var cmp = EqualityComparer<T>.Default;
@@ -334,7 +333,6 @@ namespace Duality
 		/// <typeparam name="T">The lists object type.</typeparam>
 		/// <param name="collection">List to perform the sort operation on.</param>
 		/// <param name="pred">The predicate to use on the lists contents.</param>
-		/// <returns></returns>
 		public static int IndexOfFirst<T>(this IList<T> collection, Predicate<T> pred)
 		{
 			for (int i = 0; i < collection.Count; i++)
@@ -347,7 +345,6 @@ namespace Duality
 		/// <typeparam name="T">The lists object type.</typeparam>
 		/// <param name="collection">List to perform the sort operation on.</param>
 		/// <param name="val">Object to compare the lists contents to.</param>
-		/// <returns></returns>
 		public static int IndexOfLast<T>(this IList<T> collection, T val)
 		{
 			var cmp = EqualityComparer<T>.Default;
@@ -361,7 +358,6 @@ namespace Duality
 		/// <typeparam name="T">The lists object type.</typeparam>
 		/// <param name="collection">List to perform the sort operation on.</param>
 		/// <param name="pred">The predicate to use on the lists contents.</param>
-		/// <returns></returns>
 		public static int IndexOfLast<T>(this IList<T> collection, Predicate<T> pred)
 		{
 			for (int i = collection.Count - 1; i >= 0; i--)
@@ -372,8 +368,6 @@ namespace Duality
 		/// <summary>
 		/// Returns the combined hash code of the specified byte list.
 		/// </summary>
-		/// <param name="list"></param>
-		/// <returns></returns>
 		public static int GetCombinedHashCode(this IList<byte> list, int firstIndex = 0, int length = -1)
 		{
 			if (length == -1) length = list.Count;
@@ -392,8 +386,6 @@ namespace Duality
 		/// <summary>
 		/// Returns the combined hash code of the specified list.
 		/// </summary>
-		/// <param name="list"></param>
-		/// <returns></returns>
 		public static int GetCombinedHashCode<T>(this IList<T> list, int firstIndex = 0, int length = -1)
 		{
 			if (length == -1) length = list.Count;
@@ -414,7 +406,6 @@ namespace Duality
 		/// Determines the bounding box of a list of vectors.
 		/// </summary>
 		/// <param name="list"></param>
-		/// <returns></returns>
 		public static Rect BoundingBox(this IList<Vector2> list)
 		{
 			Rect pointBoundingRect = new Rect(

--- a/Source/Core/Duality/Utility/Extensions/ExtMethodsMemberInfo.cs
+++ b/Source/Core/Duality/Utility/Extensions/ExtMethodsMemberInfo.cs
@@ -13,7 +13,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static bool IsEquivalent(this MemberInfo first, MemberInfo second)
 		{
 			if (first == second)

--- a/Source/Core/Duality/Utility/Extensions/ExtMethodsRandom.cs
+++ b/Source/Core/Duality/Utility/Extensions/ExtMethodsRandom.cs
@@ -14,7 +14,6 @@ namespace Duality
 		/// Returns a random byte.
 		/// </summary>
 		/// <param name="r">A random number generator.</param>
-		/// <returns></returns>
 		public static byte NextByte(this Random r)
 		{
 			return (byte)(r.Next() % 256);
@@ -24,7 +23,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="r">A random number generator.</param>
 		/// <param name="max">Exclusive maximum value.</param>
-		/// <returns></returns>
 		public static byte NextByte(this Random r, byte max)
 		{
 			return (byte)(r.Next() % ((int)max + 1));
@@ -35,7 +33,6 @@ namespace Duality
 		/// <param name="r">A random number generator.</param>
 		/// <param name="min">Inclusive minimum value.</param>
 		/// <param name="max">Exclusive maximum value.</param>
-		/// <returns></returns>
 		public static byte NextByte(this Random r, byte min, byte max)
 		{
 			return (byte)(min + (r.Next() % ((int)max - min + 1)));
@@ -45,7 +42,6 @@ namespace Duality
 		/// Returns a random float.
 		/// </summary>
 		/// <param name="r">A random number generator.</param>
-		/// <returns></returns>
 		public static float NextFloat(this Random r)
 		{
 			return (float)r.NextDouble();
@@ -55,7 +51,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="r">A random number generator.</param>
 		/// <param name="max">Exclusive maximum value.</param>
-		/// <returns></returns>
 		public static float NextFloat(this Random r, float max)
 		{
 			return max * (float)r.NextDouble();
@@ -66,7 +61,6 @@ namespace Duality
 		/// <param name="r">A random number generator.</param>
 		/// <param name="min">Inclusive minimum value.</param>
 		/// <param name="max">Exclusive maximum value.</param>
-		/// <returns></returns>
 		public static float NextFloat(this Random r, float min, float max)
 		{
 			return min + (max - min) * (float)r.NextDouble();
@@ -76,7 +70,6 @@ namespace Duality
 		/// Returns a random bool.
 		/// </summary>
 		/// <param name="r">A random number generator.</param>
-		/// <returns></returns>
 		public static bool NextBool(this Random r)
 		{
 			return r.NextDouble() > 0.5d;
@@ -86,7 +79,6 @@ namespace Duality
 		/// Returns a random <see cref="Vector2"/> with length one.
 		/// </summary>
 		/// <param name="r">A random number generator.</param>
-		/// <returns></returns>
 		public static Vector2 NextVector2(this Random r)
 		{
 			float angle = r.NextFloat(0.0f, MathF.RadAngle360);
@@ -97,7 +89,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="r">A random number generator.</param>
 		/// <param name="radius">Length of the vector.</param>
-		/// <returns></returns>
 		public static Vector2 NextVector2(this Random r, float radius)
 		{
 			float angle = r.NextFloat(0.0f, MathF.RadAngle360);
@@ -109,7 +100,6 @@ namespace Duality
 		/// <param name="r">A random number generator.</param>
 		/// <param name="minRadius">Minimum length of the vector</param>
 		/// <param name="maxRadius">Maximum length of the vector</param>
-		/// <returns></returns>
 		public static Vector2 NextVector2(this Random r, float minRadius, float maxRadius)
 		{
 			return r.NextVector2(r.NextFloat(minRadius, maxRadius));
@@ -122,7 +112,6 @@ namespace Duality
 		/// <param name="y">Rectangle that contains the random vector.</param>
 		/// <param name="w">Rectangle that contains the random vector.</param>
 		/// <param name="h">Rectangle that contains the random vector.</param>
-		/// <returns></returns>
 		public static Vector2 NextVector2(this Random r, float x, float y, float w, float h)
 		{
 			return new Vector2(r.NextFloat(x, x + w), r.NextFloat(y, y + h));
@@ -132,7 +121,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="r">A random number generator.</param>
 		/// <param name="rect">Rectangle that contains the random vector.</param>
-		/// <returns></returns>
 		public static Vector2 NextVector2(this Random r, Rect rect)
 		{
 			return new Vector2(r.NextFloat(rect.X, rect.X + rect.W), r.NextFloat(rect.Y, rect.Y + rect.H));
@@ -142,7 +130,6 @@ namespace Duality
 		/// Returns a random <see cref="Vector3"/> with length one.
 		/// </summary>
 		/// <param name="r">A random number generator.</param>
-		/// <returns></returns>
 		public static Vector3 NextVector3(this Random r)
 		{
 			Quaternion rot = Quaternion.Identity;
@@ -156,7 +143,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="r">A random number generator.</param>
 		/// <param name="radius">Maximum length of the vector.</param>
-		/// <returns></returns>
 		public static Vector3 NextVector3(this Random r, float radius)
 		{
 			Quaternion rot = Quaternion.Identity;
@@ -171,7 +157,6 @@ namespace Duality
 		/// <param name="r">A random number generator.</param>
 		/// <param name="minRadius">Minimum length of the vector</param>
 		/// <param name="maxRadius">Maximum length of the vector</param>
-		/// <returns></returns>
 		public static Vector3 NextVector3(this Random r, float minRadius, float maxRadius)
 		{
 			return r.NextVector3(r.NextFloat(minRadius, maxRadius));
@@ -182,9 +167,10 @@ namespace Duality
 		/// <param name="r">A random number generator.</param>
 		/// <param name="x">Cube that contains the random vector.</param>
 		/// <param name="y">Cube that contains the random vector.</param>
+		/// <param name="z"></param>
 		/// <param name="w">Cube that contains the random vector.</param>
 		/// <param name="h">Cube that contains the random vector.</param>
-		/// <returns></returns>
+		/// <param name="d"></param>
 		public static Vector3 NextVector3(this Random r, float x, float y, float z, float w, float h, float d)
 		{
 			return new Vector3(r.NextFloat(x, x + w), r.NextFloat(y, y + h), r.NextFloat(z, z + d));
@@ -194,7 +180,6 @@ namespace Duality
 		/// Returns a random <see cref="ColorRgba"/> with full saturation and maximum brightness.
 		/// </summary>
 		/// <param name="r"></param>
-		/// <returns></returns>
 		public static ColorRgba NextColorRgba(this Random r)
 		{
 			return NextColorHsva(r).ToRgba();
@@ -205,7 +190,6 @@ namespace Duality
 		/// <param name="r"></param>
 		/// <param name="min"></param>
 		/// <param name="max"></param>
-		/// <returns></returns>
 		public static ColorRgba NextColorRgba(this Random r, ColorRgba min, ColorRgba max)
 		{
 			return new ColorRgba(
@@ -218,7 +202,6 @@ namespace Duality
 		/// Returns a random <see cref="ColorHsva"/> with full saturation and maximum brightness.
 		/// </summary>
 		/// <param name="r"></param>
-		/// <returns></returns>
 		public static ColorHsva NextColorHsva(this Random r)
 		{
 			return new ColorHsva(r.NextFloat(), 1.0f, 1.0f, 1.0f);
@@ -229,7 +212,6 @@ namespace Duality
 		/// <param name="r"></param>
 		/// <param name="min"></param>
 		/// <param name="max"></param>
-		/// <returns></returns>
 		public static ColorHsva NextColorHsva(this Random r, ColorHsva min, ColorHsva max)
 		{
 			return new ColorHsva(
@@ -246,7 +228,6 @@ namespace Duality
 		/// <param name="r">A random number generator.</param>
 		/// <param name="values">A pool of values.</param>
 		/// <param name="weights">One weight for each value in the pool.</param>
-		/// <returns></returns>
 		public static T OneOfWeighted<T>(this Random r, IEnumerable<T> values, IEnumerable<float> weights)
 		{
 			float totalWeight = weights.Sum();
@@ -271,7 +252,6 @@ namespace Duality
 		/// <param name="r">A random number generator.</param>
 		/// <param name="values">A pool of values.</param>
 		/// <param name="weights">One weight for each value in the pool.</param>
-		/// <returns></returns>
 		public static T OneOfWeighted<T>(this Random r, IEnumerable<T> values, params float[] weights)
 		{
 			return OneOfWeighted<T>(r, values, weights as IEnumerable<float>);
@@ -282,7 +262,6 @@ namespace Duality
 		/// <typeparam name="T">Type of the random values.</typeparam>
 		/// <param name="r">A random number generator.</param>
 		/// <param name="weightedValues">A weighted value pool.</param>
-		/// <returns></returns>
 		public static T OneOfWeighted<T>(this Random r, IEnumerable<KeyValuePair<T,float>> weightedValues)
 		{
 			float totalWeight = weightedValues.Sum(v => v.Value);
@@ -302,7 +281,6 @@ namespace Duality
 		/// <typeparam name="T">Type of the random values.</typeparam>
 		/// <param name="r">A random number generator.</param>
 		/// <param name="weightedValues">A weighted value pool.</param>
-		/// <returns></returns>
 		public static T OneOfWeighted<T>(this Random r, params KeyValuePair<T,float>[] weightedValues)
 		{
 			return OneOfWeighted<T>(r, weightedValues as IEnumerable<KeyValuePair<T,float>>);
@@ -314,7 +292,6 @@ namespace Duality
 		/// <param name="r">A random number generator.</param>
 		/// <param name="values">A pool of values.</param>
 		/// <param name="weightFunc">A weight function that provides a weight for each value from the pool.</param>
-		/// <returns></returns>
 		public static T OneOfWeighted<T>(this Random r, IEnumerable<T> values, Func<T,float> weightFunc)
 		{
 			return OneOfWeighted<T>(r, values, values.Select(v => weightFunc(v)));
@@ -326,7 +303,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <param name="r"></param>
 		/// <param name="values"></param>
-		/// <returns></returns>
 		public static T OneOf<T>(this Random r, IEnumerable<T> values)
 		{
 			return values.ElementAt(r.Next(values.Count()));

--- a/Source/Core/Duality/Utility/Extensions/ExtMethodsString.cs
+++ b/Source/Core/Duality/Utility/Extensions/ExtMethodsString.cs
@@ -12,7 +12,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="source"></param>
 		/// <param name="times"></param>
-		/// <returns></returns>
 		public static string Multiply(this string source, int times)
 		{
 			StringBuilder builder = new StringBuilder();

--- a/Source/Core/Duality/Utility/Extensions/ExtMethodsTypeInfo.cs
+++ b/Source/Core/Duality/Utility/Extensions/ExtMethodsTypeInfo.cs
@@ -10,8 +10,6 @@ namespace Duality
 		/// <summary>
 		/// Returns whether the specified object is an instance of the specified TypeInfo.
 		/// </summary>
-		/// <param name="type"></param>
-		/// <returns></returns>
 		public static bool IsInstanceOfType(this TypeInfo type, object instance)
 		{
 			if (instance == null) return false;
@@ -21,7 +19,6 @@ namespace Duality
 		/// Returns a TypeInfos BaseType as a TypeInfo, or null if it was null.
 		/// </summary>
 		/// <param name="type"></param>
-		/// <returns></returns>
 		public static TypeInfo GetBaseTypeInfo(this TypeInfo type)
 		{
 			return type.BaseType != null ? type.BaseType.GetTypeInfo() : null;
@@ -30,8 +27,6 @@ namespace Duality
 		/// Returns a Types inheritance level. The <c>object</c>-Type has an inheritance level of
 		/// zero, each subsequent inheritance increases it by one.
 		/// </summary>
-		/// <param name="t"></param>
-		/// <returns></returns>
 		public static int GetInheritanceDepth(this TypeInfo type)
 		{
 			int level = 0;
@@ -47,8 +42,6 @@ namespace Duality
 		/// Returns all fields that are declared within this Type, or any of its base Types.
 		/// Includes public, non-public, static and instance fields.
 		/// </summary>
-		/// <param name="flags"></param>
-		/// <returns></returns>
 		public static IEnumerable<FieldInfo> DeclaredFieldsDeep(this TypeInfo type)
 		{
 			IEnumerable<FieldInfo> result = Enumerable.Empty<FieldInfo>();
@@ -65,8 +58,6 @@ namespace Duality
 		/// Returns all properties that are declared within this Type, or any of its base Types.
 		/// Includes public, non-public, static and instance properties.
 		/// </summary>
-		/// <param name="flags"></param>
-		/// <returns></returns>
 		public static IEnumerable<PropertyInfo> DeclaredPropertiesDeep(this TypeInfo type)
 		{
 			IEnumerable<PropertyInfo> result = Enumerable.Empty<PropertyInfo>();
@@ -83,8 +74,6 @@ namespace Duality
 		/// Returns all members that are declared within this Type, or any of its base Types.
 		/// Includes public, non-public, static and instance fields.
 		/// </summary>
-		/// <param name="flags"></param>
-		/// <returns></returns>
 		public static IEnumerable<MemberInfo> DeclaredMembersDeep(this TypeInfo type)
 		{
 			IEnumerable<MemberInfo> result = Enumerable.Empty<MemberInfo>();

--- a/Source/Core/Duality/Utility/Grid.cs
+++ b/Source/Core/Duality/Utility/Grid.cs
@@ -82,7 +82,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="x"></param>
 		/// <param name="y"></param>
-		/// <returns></returns>
 		public T this[int x, int y]
 		{
 			get
@@ -139,7 +138,6 @@ namespace Duality
 		/// Determines the two-dimensional grid index from the specified raw data index.
 		/// </summary>
 		/// <param name="dataIndex"></param>
-		/// <returns></returns>
 		public Point2 GetGridIndex(int dataIndex)
 		{
 			return new Point2(dataIndex % this.width, dataIndex / this.width);
@@ -149,7 +147,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="gridX"></param>
 		/// <param name="gridY"></param>
-		/// <returns></returns>
 		public int GetDataIndex(int gridX, int gridY)
 		{
 			return gridX + gridY * this.width;
@@ -159,7 +156,6 @@ namespace Duality
 		/// Determines the index of the specified item.
 		/// </summary>
 		/// <param name="item"></param>
-		/// <returns></returns>
 		public Point2 IndexOf(T item)
 		{
 			int index = Array.IndexOf(this.sequence.Data, item, 0, this.sequence.Count);
@@ -172,7 +168,6 @@ namespace Duality
 		/// Finds an item that matches the specified predicate.
 		/// </summary>
 		/// <param name="predicate"></param>
-		/// <returns></returns>
 		public T Find(Predicate<T> predicate)
 		{
 			T[] data = this.sequence.Data;
@@ -190,7 +185,6 @@ namespace Duality
 		/// Finds all items that match the specified predicate.
 		/// </summary>
 		/// <param name="predicate"></param>
-		/// <returns></returns>
 		public IEnumerable<T> FindAll(Predicate<T> predicate)
 		{
 			T[] data = this.sequence.Data;
@@ -208,7 +202,6 @@ namespace Duality
 		/// Finds the index of an item that matches the specified predicate.
 		/// </summary>
 		/// <param name="predicate"></param>
-		/// <returns></returns>
 		public Point2 FindIndex(Predicate<T> predicate)
 		{
 			T[] data = this.sequence.Data;
@@ -226,7 +219,6 @@ namespace Duality
 		/// Finds all indices of items that match the specified predicate.
 		/// </summary>
 		/// <param name="predicate"></param>
-		/// <returns></returns>
 		public IEnumerable<Point2> FindAllIndices(Predicate<T> predicate)
 		{
 			T[] data = this.sequence.Data;
@@ -244,7 +236,6 @@ namespace Duality
 		/// Determines whether the specified item is contained within this grid.
 		/// </summary>
 		/// <param name="item"></param>
-		/// <returns></returns>
 		public bool Contains(T item)
 		{
 			int index = Array.IndexOf(this.sequence.Data, item, 0, this.sequence.Count);
@@ -253,7 +244,6 @@ namespace Duality
 		/// <summary>
 		/// Determines the boundaries of the grids non-null content.
 		/// </summary>
-		/// <returns></returns>
 		public void GetContentBoundaries(out Point2 topLeft, out Point2 size)
 		{
 			topLeft = new Point2(this.width, this.height);
@@ -313,7 +303,6 @@ namespace Duality
 		/// Removes the specified item from the grid.
 		/// </summary>
 		/// <param name="item"></param>
-		/// <returns></returns>
 		public bool Remove(T item)
 		{
 			int index = Array.IndexOf(this.sequence.Data, item, 0, this.sequence.Count);
@@ -331,7 +320,6 @@ namespace Duality
 		/// Removes all items from the grid that match the specified criteria.
 		/// </summary>
 		/// <param name="predicate"></param>
-		/// <returns></returns>
 		public int RemoveAll(Predicate<T> predicate)
 		{
 			int matchCount = 0;
@@ -431,9 +419,6 @@ namespace Duality
 		/// Resizes the grid and clears its contents. The fact that the old contents can be discarded
 		/// allows to perform the resize operation more efficiently.
 		/// </summary>
-		/// <param name="newWidth"></param>
-		/// <param name="newHeight"></param>
-		/// <param name="origin"></param>
 		public void ResizeClear(int newWidth, int newHeight)
 		{
 			if (newWidth < 0) throw new ArgumentException("Width needs to be greater than or equal to zero.", "newWidth");
@@ -451,7 +436,6 @@ namespace Duality
 		/// <summary>
 		/// Shrinks the grid to match its non-null content boundaries.
 		/// </summary>
-		/// <param name="mode"></param>
 		public void ShrinkToFit(ShrinkMode mode = ShrinkMode.Both)
 		{
 			if (mode == ShrinkMode.None) return;

--- a/Source/Core/Duality/Utility/IReadOnlyGrid.cs
+++ b/Source/Core/Duality/Utility/IReadOnlyGrid.cs
@@ -27,7 +27,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="x"></param>
 		/// <param name="y"></param>
-		/// <returns></returns>
 		T this[int x, int y] { get; }
 	}
 }

--- a/Source/Core/Duality/Utility/InitState.cs
+++ b/Source/Core/Duality/Utility/InitState.cs
@@ -32,7 +32,6 @@ namespace Duality
 		/// after initialization and during disposal.
 		/// </summary>
 		/// <param name="state"></param>
-		/// <returns></returns>
 		public static bool IsActive(this InitState state)
 		{
 			return state == InitState.Initialized || state == InitState.Disposing;

--- a/Source/Core/Duality/Utility/Log/ExtMethodsVisualLogEntry.cs
+++ b/Source/Core/Duality/Utility/Log/ExtMethodsVisualLogEntry.cs
@@ -16,7 +16,6 @@ namespace Duality
 		/// <param name="entry"></param>
 		/// <param name="lifetime">The time in milliseconds that will be added to the log entries lifetime.</param>
 		/// <param name="lifetimeAsAlpha">Whether the lifetime of this entry should be used as alpha-value of the specified color. If set to true the entry will fade out over time.</param>
-		/// <returns></returns>
 		public static T KeepAlive<T>(this T entry, float lifetime, bool lifetimeAsAlpha = true) where T : VisualLogEntry
 		{
 			entry.Lifetime += lifetime;
@@ -30,7 +29,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <param name="entry"></param>
 		/// <param name="obj"></param>
-		/// <returns></returns>
 		public static T AnchorAt<T>(this T entry, GameObject obj) where T : VisualLogEntry
 		{
 			entry.AnchorObj = obj;
@@ -42,7 +40,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <param name="entry"></param>
 		/// <param name="color"></param>
-		/// <returns></returns>
 		public static T WithColor<T>(this T entry, ColorRgba color) where T : VisualLogEntry
 		{
 			entry.Color = color;
@@ -54,7 +51,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <param name="entry"></param>
 		/// <param name="depthOffset"></param>
-		/// <returns></returns>
 		public static T WithOffset<T>(this T entry, float depthOffset) where T : VisualLogEntry
 		{
 			entry.DepthOffset = depthOffset;
@@ -65,7 +61,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="entry"></param>
 		/// <param name="blockAlign"></param>
-		/// <returns></returns>
 		public static VisualLogTextEntry Align(this VisualLogTextEntry entry, Alignment blockAlign)
 		{
 			entry.BlockAlignment = blockAlign;
@@ -77,7 +72,6 @@ namespace Duality
 		/// <param name="entry"></param>
 		/// <param name="minAngle"></param>
 		/// <param name="maxAngle"></param>
-		/// <returns></returns>
 		public static VisualLogCircleEntry Segment(this VisualLogCircleEntry entry, float minAngle, float maxAngle)
 		{
 			entry.MinAngle = minAngle;
@@ -88,7 +82,6 @@ namespace Duality
 		/// Prohibits scale changes due to perspective transformation.
 		/// </summary>
 		/// <param name="entry"></param>
-		/// <returns></returns>
 		public static VisualLogCircleEntry DontScale(this VisualLogCircleEntry entry)
 		{
 			entry.InvariantScale = true;
@@ -98,7 +91,6 @@ namespace Duality
 		/// Prohibits scale changes due to perspective transformation.
 		/// </summary>
 		/// <param name="entry"></param>
-		/// <returns></returns>
 		public static VisualLogPolygonEntry DontScale(this VisualLogPolygonEntry entry)
 		{
 			entry.InvariantScale = true;
@@ -108,7 +100,6 @@ namespace Duality
 		/// Prohibits scale changes due to perspective transformation.
 		/// </summary>
 		/// <param name="entry"></param>
-		/// <returns></returns>
 		public static VisualLogVectorEntry DontScale(this VisualLogVectorEntry entry)
 		{
 			entry.InvariantScale = true;

--- a/Source/Core/Duality/Utility/Log/Log.cs
+++ b/Source/Core/Duality/Utility/Log/Log.cs
@@ -58,7 +58,6 @@ namespace Duality
 		/// <param name="name">The logs display name.</param>
 		/// <param name="id">The logs shorthand ID that will be displayed along with its log entries.</param>
 		/// <param name="customInfo">An optional <see cref="CustomLogInfo"/> object that acts as a tag.</param>
-		/// <param name="output">It will be initially connected to the specified outputs.</param>
 		public Log(string name, string id, CustomLogInfo customInfo = null)
 		{
 			this.name = name ?? string.Empty;

--- a/Source/Core/Duality/Utility/Log/LogFormat.cs
+++ b/Source/Core/Duality/Utility/Log/LogFormat.cs
@@ -45,7 +45,6 @@ namespace Duality
 		/// Generates a human-friendly string representation of a numeric ID value.
 		/// </summary>
 		/// <param name="id"></param>
-		/// <returns></returns>
 		public static string HumanFriendlyId(int id)
 		{
 			StringBuilder builder = new StringBuilder(48);
@@ -84,7 +83,6 @@ namespace Duality
 		/// <param name="callerInfoMember"></param>
 		/// <param name="callerInfoFile"></param>
 		/// <param name="callerInfoLine"></param>
-		/// <returns></returns>
 		public static string CurrentMethod([CallerMemberName] string callerInfoMember = null, [CallerFilePath] string callerInfoFile = null, [CallerLineNumber] int callerInfoLine = -1)
 		{
 			return string.Format("{0} in '{1}', line {2}.",
@@ -97,7 +95,6 @@ namespace Duality
 		/// Returns a string that can be used for representing a <see cref="System.Reflection.Assembly"/> in log entries.
 		/// </summary>
 		/// <param name="asm"></param>
-		/// <returns></returns>
 		public static string Assembly(Assembly asm)
 		{
 			if (asm == null) return "null";
@@ -116,7 +113,6 @@ namespace Duality
 		/// Returns a string that can be used for representing a <see cref="System.Type"/> in log entries.
 		/// </summary>
 		/// <param name="type"></param>
-		/// <returns></returns>
 		public static string Type(Type type)
 		{
 			if (type == null) return "null";
@@ -126,7 +122,6 @@ namespace Duality
 		/// Returns a string that can be used for representing a <see cref="System.Reflection.TypeInfo"/> in log entries.
 		/// </summary>
 		/// <param name="type"></param>
-		/// <returns></returns>
 		public static string Type(TypeInfo type)
 		{
 			if (type == null) return "null";
@@ -137,7 +132,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="info"></param>
 		/// <param name="includeDeclaringType">If true, the methods declaring type is included in the returned name.</param>
-		/// <returns></returns>
 		public static string MethodInfo(MethodInfo info, bool includeDeclaringType = true)
 		{
 			if (info == null) return "null";
@@ -158,7 +152,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="info"></param>
 		/// <param name="includeDeclaringType">If true, the methods or constructors declaring type is included in the returned name.</param>
-		/// <returns></returns>
 		public static string MethodInfo(MethodBase info, bool includeDeclaringType = true)
 		{
 			if (info is MethodInfo)
@@ -175,7 +168,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="info"></param>
 		/// <param name="includeDeclaringType">If true, the constructors declaring type is included in the returned name.</param>
-		/// <returns></returns>
 		public static string ConstructorInfo(ConstructorInfo info, bool includeDeclaringType = true)
 		{
 			if (info == null) return "null";
@@ -192,7 +184,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="info"></param>
 		/// <param name="includeDeclaringType">If true, the properties declaring type is included in the returned name.</param>
-		/// <returns></returns>
 		public static string PropertyInfo(PropertyInfo info, bool includeDeclaringType = true)
 		{
 			if (info == null) return "null";
@@ -211,7 +202,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="info"></param>
 		/// <param name="includeDeclaringType">If true, the fields declaring type is included in the returned name.</param>
-		/// <returns></returns>
 		public static string FieldInfo(FieldInfo info, bool includeDeclaringType = true)
 		{
 			if (info == null) return "null";
@@ -228,7 +218,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="info"></param>
 		/// <param name="includeDeclaringType">If true, the events declaring type is included in the returned name.</param>
-		/// <returns></returns>
 		public static string EventInfo(EventInfo info, bool includeDeclaringType = true)
 		{
 			if (info == null) return "null";
@@ -245,7 +234,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="info"></param>
 		/// <param name="includeDeclaringType">If true, the members declaring type is included in the returned name.</param>
-		/// <returns></returns>
 		public static string MemberInfo(MemberInfo info, bool includeDeclaringType = true)
 		{
 			if (info is MethodInfo)
@@ -271,8 +259,6 @@ namespace Duality
 		/// It usually does not include the full call stack and is significantly shorter than
 		/// an <see cref="System.Exception">Exceptions</see> ToString method.
 		/// </summary>
-		/// <param name="e"></param>
-		/// <returns></returns>
 		public static string Exception(Exception e, bool callStack = true)
 		{
 			if (e == null) return "null";

--- a/Source/Core/Duality/Utility/Log/Logs.cs
+++ b/Source/Core/Duality/Utility/Log/Logs.cs
@@ -109,7 +109,6 @@ namespace Duality
 		/// implementation, as provided via generic type parameter.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
-		/// <returns></returns>
 		public static Log Get<T>() where T : CustomLogInfo, new()
 		{
 			return CustomLogHolder<T>.Instance;

--- a/Source/Core/Duality/Utility/Log/VisualLog.cs
+++ b/Source/Core/Duality/Utility/Log/VisualLog.cs
@@ -83,7 +83,6 @@ namespace Duality
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="entry"></param>
-		/// <returns></returns>
 		public void Draw<T>(T entry) where T : VisualLogEntry
 		{
 			if (!this.visible) return;
@@ -95,7 +94,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="screenX"></param>
 		/// <param name="screenY"></param>
-		/// <returns></returns>
 		public VisualLogPointEntry DrawPoint(float screenX, float screenY)
 		{
 			VisualLogPointEntry entry = new VisualLogPointEntry();
@@ -107,7 +105,6 @@ namespace Duality
 		/// Draws a point in screen space.
 		/// </summary>
 		/// <param name="screenPos"></param>
-		/// <returns></returns>
 		public VisualLogPointEntry DrawPoint(Vector2 screenPos)
 		{
 			return this.DrawPoint(screenPos.X, screenPos.Y);
@@ -119,7 +116,6 @@ namespace Duality
 		/// <param name="worldX"></param>
 		/// <param name="worldY"></param>
 		/// <param name="worldZ"></param>
-		/// <returns></returns>
 		public VisualLogPointEntry DrawPoint(float worldX, float worldY, float worldZ)
 		{
 			VisualLogPointEntry entry = new VisualLogPointEntry();
@@ -133,7 +129,6 @@ namespace Duality
 		/// regardless of perspective settings or distance to the Camera.
 		/// </summary>
 		/// <param name="worldPos"></param>
-		/// <returns></returns>
 		public VisualLogPointEntry DrawPoint(Vector3 worldPos)
 		{
 			return this.DrawPoint(worldPos.X, worldPos.Y, worldPos.Z);
@@ -144,7 +139,6 @@ namespace Duality
 		/// <param name="screenX"></param>
 		/// <param name="screenY"></param>
 		/// <param name="radius"></param>
-		/// <returns></returns>
 		public VisualLogCircleEntry DrawCircle(float screenX, float screenY, float radius)
 		{
 			VisualLogCircleEntry entry = new VisualLogCircleEntry();
@@ -158,7 +152,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="screenPos"></param>
 		/// <param name="radius"></param>
-		/// <returns></returns>
 		public VisualLogCircleEntry DrawCircle(Vector2 screenPos, float radius)
 		{
 			return this.DrawCircle(screenPos.X, screenPos.Y, radius);
@@ -170,7 +163,6 @@ namespace Duality
 		/// <param name="worldY"></param>
 		/// <param name="worldZ"></param>
 		/// <param name="radius"></param>
-		/// <returns></returns>
 		public VisualLogCircleEntry DrawCircle(float worldX, float worldY, float worldZ, float radius)
 		{
 			VisualLogCircleEntry entry = new VisualLogCircleEntry();
@@ -185,7 +177,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="worldPos"></param>
 		/// <param name="radius"></param>
-		/// <returns></returns>
 		public VisualLogCircleEntry DrawCircle(Vector3 worldPos, float radius)
 		{
 			return this.DrawCircle(worldPos.X, worldPos.Y, worldPos.Z, radius);
@@ -198,7 +189,6 @@ namespace Duality
 		/// <param name="screenY">The vectors screen origin.</param>
 		/// <param name="vectorX">The vector to display.</param>
 		/// <param name="vectorY">The vector to display.</param>
-		/// <returns></returns>
 		public VisualLogVectorEntry DrawVector(float screenX, float screenY, float vectorX, float vectorY)
 		{
 			VisualLogVectorEntry entry = new VisualLogVectorEntry();
@@ -213,7 +203,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="screenPos">The vectors screen origin.</param>
 		/// <param name="vector">The vector to display.</param>
-		/// <returns></returns>
 		public VisualLogVectorEntry DrawVector(Vector2 screenPos, Vector2 vector)
 		{
 			return this.DrawVector(screenPos.X, screenPos.Y, vector.X, vector.Y);
@@ -227,7 +216,6 @@ namespace Duality
 		/// <param name="worldZ">The vectors world origin.</param>
 		/// <param name="vectorX">The vector to display.</param>
 		/// <param name="vectorY">The vector to display.</param>
-		/// <returns></returns>
 		public VisualLogVectorEntry DrawVector(float worldX, float worldY, float worldZ, float vectorX, float vectorY)
 		{
 			VisualLogVectorEntry entry = new VisualLogVectorEntry();
@@ -243,7 +231,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="worldPos">The vectors world origin.</param>
 		/// <param name="vector">The vector to display.</param>
-		/// <returns></returns>
 		public VisualLogVectorEntry DrawVector(Vector3 worldPos, Vector2 vector)
 		{
 			return this.DrawVector(worldPos.X, worldPos.Y, worldPos.Z, vector.X, vector.Y);
@@ -255,7 +242,6 @@ namespace Duality
 		/// <param name="screenY1"></param>
 		/// <param name="screenX2"></param>
 		/// <param name="screenY2"></param>
-		/// <returns></returns>
 		public VisualLogConnectionEntry DrawConnection(float screenX1, float screenY1, float screenX2, float screenY2)
 		{
 			VisualLogConnectionEntry entry = new VisualLogConnectionEntry();
@@ -269,7 +255,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="screenPos1"></param>
 		/// <param name="screenPos2"></param>
-		/// <returns></returns>
 		public VisualLogConnectionEntry DrawConnection(Vector2 screenPos1, Vector2 screenPos2)
 		{
 			return this.DrawConnection(screenPos1.X, screenPos1.Y, screenPos2.X, screenPos2.Y);
@@ -282,7 +267,6 @@ namespace Duality
 		/// <param name="worldZ"></param>
 		/// <param name="worldX2"></param>
 		/// <param name="worldY2"></param>
-		/// <returns></returns>
 		public VisualLogConnectionEntry DrawConnection(float worldX1, float worldY1, float worldZ, float worldX2, float worldY2)
 		{
 			VisualLogConnectionEntry entry = new VisualLogConnectionEntry();
@@ -297,7 +281,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="worldPos1"></param>
 		/// <param name="worldPos2"></param>
-		/// <returns></returns>
 		public VisualLogConnectionEntry DrawConnection(Vector3 worldPos1, Vector2 worldPos2)
 		{
 			return this.DrawConnection(worldPos1.X, worldPos1.Y, worldPos1.Z, worldPos2.X, worldPos2.Y);
@@ -308,7 +291,6 @@ namespace Duality
 		/// <param name="screenX"></param>
 		/// <param name="screenY"></param>
 		/// <param name="polygon"></param>
-		/// <returns></returns>
 		public VisualLogPolygonEntry DrawPolygon(float screenX, float screenY, Vector2[] polygon)
 		{
 			VisualLogPolygonEntry entry = new VisualLogPolygonEntry();
@@ -322,7 +304,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="screenPos"></param>
 		/// <param name="polygon"></param>
-		/// <returns></returns>
 		public VisualLogPolygonEntry DrawPolygon(Vector2 screenPos, Vector2[] polygon)
 		{
 			return this.DrawPolygon(screenPos.X, screenPos.Y, polygon);
@@ -334,7 +315,6 @@ namespace Duality
 		/// <param name="worldY"></param>
 		/// <param name="worldZ"></param>
 		/// <param name="polygon"></param>
-		/// <returns></returns>
 		public VisualLogPolygonEntry DrawPolygon(float worldX, float worldY, float worldZ, Vector2[] polygon)
 		{
 			VisualLogPolygonEntry entry = new VisualLogPolygonEntry();
@@ -349,7 +329,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="worldPos"></param>
 		/// <param name="polygon"></param>
-		/// <returns></returns>
 		public VisualLogPolygonEntry DrawPolygon(Vector3 worldPos, Vector2[] polygon)
 		{
 			return this.DrawPolygon(worldPos.X, worldPos.Y, worldPos.Z, polygon);
@@ -361,7 +340,6 @@ namespace Duality
 		/// <param name="screenX"></param>
 		/// <param name="screenY"></param>
 		/// <param name="text"></param>
-		/// <returns></returns>
 		public VisualLogTextEntry DrawText(float screenX, float screenY, string text)
 		{
 			VisualLogTextEntry entry = new VisualLogTextEntry();
@@ -376,7 +354,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="screenPos"></param>
 		/// <param name="text"></param>
-		/// <returns></returns>
 		public VisualLogTextEntry DrawText(Vector2 screenPos, string text)
 		{
 			return this.DrawText(screenPos.X, screenPos.Y, text);
@@ -389,7 +366,6 @@ namespace Duality
 		/// <param name="worldY"></param>
 		/// <param name="worldZ"></param>
 		/// <param name="text"></param>
-		/// <returns></returns>
 		public VisualLogTextEntry DrawText(float worldX, float worldY, float worldZ, string text)
 		{
 			VisualLogTextEntry entry = new VisualLogTextEntry();
@@ -405,7 +381,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="worldPos"></param>
 		/// <param name="text"></param>
-		/// <returns></returns>
 		public VisualLogTextEntry DrawText(Vector3 worldPos, string text)
 		{
 			return this.DrawText(worldPos.X, worldPos.Y, worldPos.Z, text);

--- a/Source/Core/Duality/Utility/Log/VisualLogs.cs
+++ b/Source/Core/Duality/Utility/Log/VisualLogs.cs
@@ -50,7 +50,6 @@ namespace Duality
 		/// implementation, as provided via generic type parameter.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
-		/// <returns></returns>
 		public static VisualLog Get<T>() where T : CustomVisualLogInfo, new()
 		{
 			return CustomLogHolder<T>.Instance;

--- a/Source/Core/Duality/Utility/Math/ExtMethodsTargetResize.cs
+++ b/Source/Core/Duality/Utility/Math/ExtMethodsTargetResize.cs
@@ -10,7 +10,6 @@ namespace Duality
 		/// <param name="mode"></param>
 		/// <param name="baseSize"></param>
 		/// <param name="targetSize"></param>
-		/// <returns></returns>
 		public static Vector2 Apply(this TargetResize mode, Vector2 baseSize, Vector2 targetSize)
 		{
 			Vector2 sizeRatio;

--- a/Source/Core/Duality/Utility/Math/GenericOperator.cs
+++ b/Source/Core/Duality/Utility/Math/GenericOperator.cs
@@ -20,7 +20,6 @@ namespace Duality
 		/// <typeparam name="U"></typeparam>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static T Add<T,U>(T first, U second)
 		{
 			return DualType<T,U>.Add(first, second);
@@ -32,7 +31,6 @@ namespace Duality
 		/// <typeparam name="U"></typeparam>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static T Subtract<T,U>(T first, U second)
 		{
 			return DualType<T,U>.Subtract(first, second);
@@ -44,7 +42,6 @@ namespace Duality
 		/// <typeparam name="U"></typeparam>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static T Multiply<T,U>(T first, U second)
 		{
 			return DualType<T,U>.Multiply(first, second);
@@ -56,7 +53,6 @@ namespace Duality
 		/// <typeparam name="U"></typeparam>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static T Divide<T,U>(T first, U second)
 		{
 			return DualType<T,U>.Divide(first, second);
@@ -67,7 +63,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static T Modulo<T>(T first, T second)
 		{
 			return SingleType<T>.Modulo(first, second);
@@ -77,7 +72,6 @@ namespace Duality
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="value"></param>
-		/// <returns></returns>
 		public static T Negate<T>(T value)
 		{
 			return SingleType<T>.Negate(value);
@@ -87,7 +81,6 @@ namespace Duality
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="value"></param>
-		/// <returns></returns>
 		public static T Abs<T>(T value)
 		{
 			return SingleType<T>.Abs(value);
@@ -99,7 +92,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static T Or<T>(T first, T second)
 		{
 			return SingleType<T>.Or(first, second);
@@ -110,7 +102,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static T And<T>(T first, T second)
 		{
 			return SingleType<T>.And(first, second);
@@ -121,7 +112,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static T Xor<T>(T first, T second)
 		{
 			return SingleType<T>.Xor(first, second);
@@ -129,10 +119,6 @@ namespace Duality
 		/// <summary>
 		/// Performs a bitwise NOT on a generic value.
 		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="first"></param>
-		/// <param name="second"></param>
-		/// <returns></returns>
 		public static T Not<T>(T value)
 		{
 			return SingleType<T>.Not(value);
@@ -144,7 +130,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static bool Equal<T>(T first, T second)
 		{
 			return SingleType<T>.Equal(first, second);
@@ -155,7 +140,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static bool GreaterThan<T>(T first, T second)
 		{
 			return SingleType<T>.GreaterThan(first, second);
@@ -166,7 +150,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static bool GreaterThanOrEqual<T>(T first, T second)
 		{
 			return SingleType<T>.GreaterThanOrEqual(first, second);
@@ -177,7 +160,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static bool LessThan<T>(T first, T second)
 		{
 			return SingleType<T>.LessThan(first, second);
@@ -188,7 +170,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <param name="first"></param>
 		/// <param name="second"></param>
-		/// <returns></returns>
 		public static bool LessThanOrEqual<T>(T first, T second)
 		{
 			return SingleType<T>.LessThanOrEqual(first, second);
@@ -200,7 +181,6 @@ namespace Duality
 		/// <typeparam name="T"></typeparam>
 		/// <typeparam name="U"></typeparam>
 		/// <param name="value"></param>
-		/// <returns></returns>
 		public static U Convert<T,U>(T value)
 		{
 			return DualType<T,U>.Convert(value);
@@ -213,7 +193,6 @@ namespace Duality
 		/// <param name="first"></param>
 		/// <param name="second"></param>
 		/// <param name="factor"></param>
-		/// <returns></returns>
 		public static T Lerp<T>(T first, T second, float factor)
 		{
 			return SingleType<T>.Lerp(first, second, factor);

--- a/Source/Core/Duality/Utility/Math/Range.cs
+++ b/Source/Core/Duality/Utility/Math/Range.cs
@@ -71,7 +71,6 @@ namespace Duality
 		/// Performs a linear interpolation between the Ranges minimum and maximum value using the specified blend factor.
 		/// </summary>
 		/// <param name="ratio"></param>
-		/// <returns></returns>
 		public float Lerp(float ratio)
 		{
 			return MathF.Lerp(this.MinValue, this.MaxValue, ratio);
@@ -90,7 +89,6 @@ namespace Duality
 		/// Returns whether this Range contains a certain value.
 		/// </summary>
 		/// <param name="value"></param>
-		/// <returns></returns>
 		public bool Contains(float value)
 		{
 			return this.MinValue <= value && this.MaxValue >= value;
@@ -99,7 +97,6 @@ namespace Duality
 		/// Returns whether this Range contains a certain other range.
 		/// </summary>
 		/// <param name="value"></param>
-		/// <returns></returns>
 		public bool Contains(Range value)
 		{
 			return this.Contains(value.MinValue) && this.Contains(value.MaxValue);
@@ -132,7 +129,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="left"></param>
 		/// <param name="right"></param>
-		/// <returns></returns>
 		public static bool operator ==(Range left, Range right)
 		{
 			return left.Equals(right);
@@ -142,7 +138,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="left"></param>
 		/// <param name="right"></param>
-		/// <returns></returns>
 		public static bool operator !=(Range left, Range right)
 		{
 			return !left.Equals(right);
@@ -153,7 +148,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="left"></param>
 		/// <param name="right"></param>
-		/// <returns></returns>
 		public static Range operator +(Range left, Range right)
 		{
 			return new Range(
@@ -165,7 +159,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="left"></param>
 		/// <param name="right"></param>
-		/// <returns></returns>
 		public static Range operator -(Range left, Range right)
 		{
 			return new Range(
@@ -177,7 +170,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="left"></param>
 		/// <param name="right"></param>
-		/// <returns></returns>
 		public static Range operator *(Range left, Range right)
 		{
 			return new Range(
@@ -189,7 +181,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="left"></param>
 		/// <param name="right"></param>
-		/// <returns></returns>
 		public static Range operator /(Range left, Range right)
 		{
 			return new Range(
@@ -201,7 +192,6 @@ namespace Duality
 		/// Performs an implicit conversion from a single value to a ranged value.
 		/// </summary>
 		/// <param name="value"></param>
-		/// <returns></returns>
 		public static implicit operator Range(float value)
 		{
 			return new Range(value);

--- a/Source/Core/Duality/Utility/ObjectCreator.cs
+++ b/Source/Core/Duality/Utility/ObjectCreator.cs
@@ -48,8 +48,6 @@ namespace Duality
 		/// <summary>
 		/// Returns the default instance of a Type. Equals <c>default(T)</c>, but works for Reflection.
 		/// </summary>
-		/// <param name="instanceType">The Type to create a default instance of.</param>
-		/// <returns></returns>
 		public static object GetDefaultOf(this TypeInfo typeInfo)
 		{
 			if (typeInfo.IsValueType)

--- a/Source/Core/Duality/Utility/Profiling/Profile.cs
+++ b/Source/Core/Duality/Utility/Profiling/Profile.cs
@@ -106,7 +106,6 @@ namespace Duality
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="name">The <see cref="ProfileCounter"/> name to use for this measurement. For nested measurements, use path strings, e.g. "ParentCounter\ChildCounter"</param>
-		/// <returns></returns>
 		public static T GetCounter<T>(string name) where T : ProfileCounter
 		{
 			if (name == null) return null;
@@ -123,7 +122,6 @@ namespace Duality
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="name">The <see cref="ProfileCounter"/> name to use for this measurement. For nested measurements, use path strings, e.g. "ParentCounter\ChildCounter"</param>
-		/// <returns></returns>
 		public static T RequestCounter<T>(string name) where T : ProfileCounter, new()
 		{
 			if (name == null) return null;
@@ -139,7 +137,6 @@ namespace Duality
 		/// <summary>
 		/// Enumerates all <see cref="ProfileCounter"/> objects that have been actively used this frame.
 		/// </summary>
-		/// <returns></returns>
 		public static IEnumerable<ProfileCounter> GetUsedCounters()
 		{
 			return counterMap.Values.Where(p => p.WasUsed);
@@ -149,7 +146,6 @@ namespace Duality
 		/// Begins time measurement using a new or existing <see cref="ProfileCounter"/> with the specified name.
 		/// </summary>
 		/// <param name="counter">The <see cref="ProfileCounter"/> name to use for this measurement. For nested measurements, use path strings, e.g. "ParentCounter\ChildCounter"</param>
-		/// <returns></returns>
 		public static TimeCounter BeginMeasure(string counter)
 		{
 			TimeCounter tc = RequestCounter<TimeCounter>(counter);
@@ -169,7 +165,6 @@ namespace Duality
 		/// Queries this frames time measurement value from an existing <see cref="ProfileCounter"/> with the specified name.
 		/// </summary>
 		/// <param name="counter">The <see cref="ProfileCounter"/> name to use for this measurement. For nested measurements, use path strings, e.g. "ParentCounter\ChildCounter"</param>
-		/// <returns></returns>
 		public static float GetMeasure(string counter)
 		{
 			TimeCounter tc = GetCounter<TimeCounter>(counter);
@@ -193,7 +188,6 @@ namespace Duality
 		/// Queries a statistical information value from an existing <see cref="ProfileCounter"/> with the specified name.
 		/// </summary>
 		/// <param name="counter">The <see cref="ProfileCounter"/> name to use for this measurement. For nested measurements, use path strings, e.g. "ParentCounter\ChildCounter"</param>
-		/// <param name="value"></param>
 		public static int GetStat(string counter)
 		{
 			StatCounter sc = RequestCounter<StatCounter>(counter);
@@ -217,7 +211,6 @@ namespace Duality
 		/// <summary>
 		/// Saves a text report of the current profiling data to the specified stream.
 		/// </summary>
-		/// <param name="filePath"></param>
 		public static void SaveTextReport(Stream stream)
 		{
 			string report = GetTextReport(counterMap.Values.Where(c => c.HasData), 
@@ -235,7 +228,6 @@ namespace Duality
 		/// <summary>
 		/// Creates a text report of the current profiling data and returns it as string.
 		/// </summary>
-		/// <param name="filePath"></param>
 		public static string GetTextReport(IEnumerable<ProfileCounter> reportCounters, ProfileReportOptions options = ProfileReportOptions.LastValue)
 		{
 			bool omitMinor = (options & ProfileReportOptions.OmitMinorValues) != ProfileReportOptions.None;

--- a/Source/Core/Duality/Utility/Profiling/ProfileCounter.cs
+++ b/Source/Core/Duality/Utility/Profiling/ProfileCounter.cs
@@ -117,8 +117,6 @@ namespace Duality
 		/// <summary>
 		/// Gathers ProfileCounter data for generating a profile report.
 		/// </summary>
-		/// <param name="data"></param>
-		/// <param name="options"></param>
 		public abstract void GetReportData(out ProfileReportCounterData data);
 		protected virtual void OnFrameTick() {}
 

--- a/Source/Core/Duality/Utility/RawList.cs
+++ b/Source/Core/Duality/Utility/RawList.cs
@@ -69,7 +69,6 @@ namespace Duality
 		/// when attempting to access indices exceeding <see cref="Count"/>.
 		/// </summary>
 		/// <param name="index"></param>
-		/// <returns></returns>
 		public T this[int index]
 		{
 			get
@@ -126,7 +125,6 @@ namespace Duality
 		/// Returns the first index of the specified item within the used range of the internal array. Returns -1, if not found.
 		/// </summary>
 		/// <param name="item"></param>
-		/// <returns></returns>
 		public int IndexOf(T item)
 		{
 			return Array.IndexOf(this.data, item, 0, this.count);
@@ -135,7 +133,6 @@ namespace Duality
 		/// Returns whether the specified item is contained within the used range of the internal array.
 		/// </summary>
 		/// <param name="item"></param>
-		/// <returns></returns>
 		public bool Contains(T item)
 		{
 			return Array.IndexOf(this.data, item, 0, this.count) >= 0;
@@ -221,7 +218,6 @@ namespace Duality
 		/// Removes the first matching item from the list.
 		/// </summary>
 		/// <param name="item"></param>
-		/// <returns></returns>
 		public bool Remove(T item)
 		{
 			int index = this.IndexOf(item);
@@ -272,7 +268,6 @@ namespace Duality
 		/// Removes all matching items from the list.
 		/// </summary>
 		/// <param name="predicate"></param>
-		/// <returns></returns>
 		public int RemoveAll(Predicate<T> predicate)
 		{
 			// Iterate over the internal array with two indices:

--- a/Source/Core/Duality/Utility/RawListPool.cs
+++ b/Source/Core/Duality/Utility/RawListPool.cs
@@ -22,7 +22,6 @@ namespace Duality
 		/// Rents a list instance with the specified min capacity.
 		/// </summary>
 		/// <param name="minCapacity"></param>
-		/// <returns></returns>
 		public RawList<T> Rent(int minCapacity)
 		{
 			// No pooled instances available? Create perfectly fitting one on-the-fly.

--- a/Source/Core/Duality/Utility/ReflectionHelper.cs
+++ b/Source/Core/Duality/Utility/ReflectionHelper.cs
@@ -54,7 +54,6 @@ namespace Duality
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="member"></param>
-		/// <returns></returns>
 		public static IEnumerable<T> GetAttributesCached<T>(this MemberInfo member) where T : Attribute
 		{
 			lock (customMemberAttribCache)
@@ -139,7 +138,6 @@ namespace Duality
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="member"></param>
-		/// <returns></returns>
 		public static bool HasAttributeCached<T>(this MemberInfo member) where T : Attribute
 		{
 			return GetAttributesCached<T>(member).Any();
@@ -364,7 +362,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="sourceResType"></param>
 		/// <param name="targetResType"></param>
-		/// <returns></returns>
 		public static bool CanReferenceResource(Type sourceResType, Type targetResType)
 		{
 			lock (resRefCache)
@@ -412,7 +409,6 @@ namespace Duality
 		/// Types where this is false are completely irrelevant to garbage collection.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
-		/// <returns></returns>
 		public static bool IsReferenceOrContainsReferences<T>()
 		{
 			return StaticLookup<T>.IsReferenceOrContainsReferences;
@@ -422,7 +418,6 @@ namespace Duality
 		/// Types where this is false are completely irrelevant to garbage collection.
 		/// </summary>
 		/// <param name="typeInfo"></param>
-		/// <returns></returns>
 		public static bool IsReferenceOrContainsReferences(this TypeInfo typeInfo)
 		{
 			// Early-out for some obvious cases
@@ -464,7 +459,6 @@ namespace Duality
 		/// consists only of those types, allowing to do a deep-copy by simply assigning it.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
-		/// <returns></returns>
 		public static bool IsDeepCopyByAssignment<T>()
 		{
 			return StaticLookup<T>.IsDeepCopyByAssignment;
@@ -473,8 +467,6 @@ namespace Duality
 		/// Returns whether the specified type is a primitive, enum, string, decimal, or struct that
 		/// consists only of those types, allowing to do a deep-copy by simply assigning it.
 		/// </summary>
-		/// <param name="baseObj"></param>
-		/// <returns></returns>
 		public static bool IsDeepCopyByAssignment(this TypeInfo typeInfo)
 		{
 			// Early-out for some obvious cases
@@ -524,7 +516,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="typeString">The type string to resolve.</param>
 		/// <param name="declaringMethod">The generic method that is declaring the Type. Only necessary when resolving a generic methods parameter Type.</param>
-		/// <returns></returns>
 		public static Type ResolveType(string typeString, MethodInfo declaringMethod = null)
 		{
 			return ResolveType(typeString, null, declaringMethod);
@@ -533,8 +524,6 @@ namespace Duality
 		/// Resolves a Member based on its <see cref="GetMemberId">member id</see>.
 		/// </summary>
 		/// <param name="memberString">The <see cref="GetMemberId">member id</see> of the member.</param>
-		/// <param name="throwOnError">If true, an Exception is thrown on failure.</param>
-		/// <returns></returns>
 		public static MemberInfo ResolveMember(string memberString)
 		{
 			lock (memberResolveCache)
@@ -561,7 +550,6 @@ namespace Duality
 		/// Returns the short version of an Assembly name.
 		/// </summary>
 		/// <param name="assembly"></param>
-		/// <returns></returns>
 		public static string GetShortAssemblyName(this Assembly assembly)
 		{
 			return assembly.FullName.Split(',')[0];
@@ -570,7 +558,6 @@ namespace Duality
 		/// Returns the short version of an Assembly name.
 		/// </summary>
 		/// <param name="assemblyName"></param>
-		/// <returns></returns>
 		public static string GetShortAssemblyName(this AssemblyName assemblyName)
 		{
 			return assemblyName.FullName.Split(',')[0];
@@ -579,7 +566,6 @@ namespace Duality
 		/// Returns the short version of an Assembly name.
 		/// </summary>
 		/// <param name="assemblyName"></param>
-		/// <returns></returns>
 		public static string GetShortAssemblyName(string assemblyName)
 		{
 			return assemblyName.Split(',')[0];
@@ -589,7 +575,7 @@ namespace Duality
 		/// Returns a string describing a certain Type.
 		/// </summary>
 		/// <param name="type">The Type to describe</param>
-		/// <returns></returns>
+		/// <param name="shortName"></param>
 		public static string GetTypeCSCodeName(this Type type, bool shortName = false)
 		{
 			StringBuilder typeStr = new StringBuilder();
@@ -672,7 +658,6 @@ namespace Duality
 		/// Returns a string describing a certain Type.
 		/// </summary>
 		/// <param name="T">The Type to describe</param>
-		/// <returns></returns>
 		public static string GetTypeId(this Type T)
 		{
 			return T.FullName != null ? Regex.Replace(T.FullName, @"(, [^\]\[]*)", "") : T.Name;
@@ -681,7 +666,6 @@ namespace Duality
 		/// Returns a string describing a certain Member of a Type.
 		/// </summary>
 		/// <param name="member">The Member to describe.</param>
-		/// <returns></returns>
 		public static string GetMemberId(this MemberInfo member)
 		{
 			if (member is TypeInfo)
@@ -752,7 +736,6 @@ namespace Duality
 		/// <param name="popLevel">The char that decreases the current hierarchy level.</param>
 		/// <param name="separator">The char that separates two arguments.</param>
 		/// <param name="splitLevel">The hierarchy level at which to perform the split operation.</param>
-		/// <returns></returns>
 		public static string[] SplitArgs(string argList, char pushLevel, char popLevel, char separator, int splitLevel)
 		{
 			if (argList == null) return new string[0];

--- a/Source/Core/Physics/Collision/Collision.cs
+++ b/Source/Core/Physics/Collision/Collision.cs
@@ -1693,7 +1693,6 @@ namespace FarseerPhysics.Collision
 		/// <param name="normal">The normal.</param>
 		/// <param name="offset">The offset.</param>
 		/// <param name="vertexIndexA">The vertex index A.</param>
-		/// <returns></returns>
 		private static int ClipSegmentToLine(out FixedArray2<ClipVertex> vOut, ref FixedArray2<ClipVertex> vIn,
 											 Vector2 normal, float offset, int vertexIndexA)
 		{
@@ -1746,7 +1745,6 @@ namespace FarseerPhysics.Collision
 		/// <param name="edge1">The edge1.</param>
 		/// <param name="poly2">The poly2.</param>
 		/// <param name="xf2">The XF2.</param>
-		/// <returns></returns>
 		private static float EdgeSeparation(PolygonShape poly1, ref Transform xf1, int edge1,
 											PolygonShape poly2, ref Transform xf2)
 		{
@@ -1795,7 +1793,6 @@ namespace FarseerPhysics.Collision
 		/// <param name="xf1">The XF1.</param>
 		/// <param name="poly2">The poly2.</param>
 		/// <param name="xf2">The XF2.</param>
-		/// <returns></returns>
 		private static float FindMaxSeparation(out int edgeIndex,
 											   PolygonShape poly1, ref Transform xf1,
 											   PolygonShape poly2, ref Transform xf2)

--- a/Source/Core/Physics/Collision/Distance.cs
+++ b/Source/Core/Physics/Collision/Distance.cs
@@ -103,7 +103,6 @@ namespace FarseerPhysics.Collision
 		/// Get the supporting vertex index in the given direction.
 		/// </summary>
 		/// <param name="direction">The direction.</param>
-		/// <returns></returns>
 		public int GetSupport(Vector2 direction)
 		{
 			int bestIndex = 0;
@@ -125,7 +124,6 @@ namespace FarseerPhysics.Collision
 		/// Get the supporting vertex in the given direction.
 		/// </summary>
 		/// <param name="direction">The direction.</param>
-		/// <returns></returns>
 		public Vector2 GetSupportVertex(Vector2 direction)
 		{
 			int bestIndex = 0;

--- a/Source/Core/Physics/Collision/DynamicTree.cs
+++ b/Source/Core/Physics/Collision/DynamicTree.cs
@@ -252,7 +252,6 @@ namespace FarseerPhysics.Collision
 		/// Compute the height of the binary tree in O(N) time. Should not be
 		/// called often.
 		/// </summary>
-		/// <returns></returns>
 		public int ComputeHeight()
 		{
 			return ComputeHeight(this._root);

--- a/Source/Core/Physics/Collision/DynamicTreeBroadPhase.cs
+++ b/Source/Core/Physics/Collision/DynamicTreeBroadPhase.cs
@@ -106,7 +106,6 @@ namespace FarseerPhysics.Collision
 		/// UpdatePairs is called.
 		/// </summary>
 		/// <param name="proxy">The user data.</param>
-		/// <returns></returns>
 		public int AddProxy(ref FixtureProxy proxy)
 		{
 			int proxyId = this._tree.AddProxy(ref proxy.AABB, proxy);
@@ -149,7 +148,6 @@ namespace FarseerPhysics.Collision
 		/// Get user data from a proxy. Returns null if the id is invalid.
 		/// </summary>
 		/// <param name="proxyId">The proxy id.</param>
-		/// <returns></returns>
 		public FixtureProxy GetProxy(int proxyId)
 		{
 			return this._tree.GetUserData(proxyId);
@@ -160,7 +158,6 @@ namespace FarseerPhysics.Collision
 		/// </summary>
 		/// <param name="proxyIdA">The proxy id A.</param>
 		/// <param name="proxyIdB">The proxy id B.</param>
-		/// <returns></returns>
 		public bool TestOverlap(int proxyIdA, int proxyIdB)
 		{
 			AABB aabbA, aabbB;
@@ -264,7 +261,6 @@ namespace FarseerPhysics.Collision
 		/// <summary>
 		/// Compute the height of the embedded tree.
 		/// </summary>
-		/// <returns></returns>
 		public int ComputeHeight()
 		{
 			return this._tree.ComputeHeight();

--- a/Source/Core/Physics/Common/ConvexHull/ChainHull.cs
+++ b/Source/Core/Physics/Common/ConvexHull/ChainHull.cs
@@ -14,7 +14,6 @@ namespace FarseerPhysics.Common.ConvexHull
 		/// <remarks>
 		/// http://www.softsurfer.com/Archive/algorithm_0109/algorithm_0109.htm
 		/// </remarks>
-		/// <returns></returns>
 		public static Vertices GetConvexHull(Vertices P)
 		{
 			P.Sort(new PointComparer());

--- a/Source/Core/Physics/Common/ConvexHull/GiftWrap.cs
+++ b/Source/Core/Physics/Common/ConvexHull/GiftWrap.cs
@@ -23,7 +23,6 @@ namespace FarseerPhysics.Common.ConvexHull
 		/// Warning: May be buggy with colinear points on hull.
 		/// </summary>
 		/// <param name="vertices">The vertices.</param>
-		/// <returns></returns>
 		public static Vertices GetConvexHull(Vertices vertices)
 		{
 			if (vertices.Count < 3)

--- a/Source/Core/Physics/Common/Decomposition/EarclipDecomposer.cs
+++ b/Source/Core/Physics/Common/Decomposition/EarclipDecomposer.cs
@@ -275,7 +275,6 @@ namespace FarseerPhysics.Common.Decomposition
 		/// </summary>
 		/// <param name="x">The x.</param>
 		/// <param name="modulus">The modulus.</param>
-		/// <returns></returns>
 		private static int Remainder(int x, int modulus)
 		{
 			int rem = x % modulus;

--- a/Source/Core/Physics/Common/LineTools.cs
+++ b/Source/Core/Physics/Common/LineTools.cs
@@ -49,7 +49,6 @@ namespace FarseerPhysics.Common
 		/// <param name="b0"></param>
 		/// <param name="b1"></param>
 		/// <param name="intersectionPoint"></param>
-		/// <returns></returns>
 		public static bool LineIntersect2(Vector2 a0, Vector2 a1, Vector2 b0, Vector2 b1, out Vector2 intersectionPoint)
 		{
 			intersectionPoint = Vector2.Zero;

--- a/Source/Core/Physics/Common/Math.cs
+++ b/Source/Core/Physics/Common/Math.cs
@@ -150,7 +150,6 @@ namespace FarseerPhysics.Common
 		/// This is a approximate yet fast inverse square-root.
 		/// </summary>
 		/// <param name="x">The x.</param>
-		/// <returns></returns>
 		public static float InvSqrt(float x)
 		{
 			FloatConverter convert = new FloatConverter();
@@ -231,7 +230,6 @@ namespace FarseerPhysics.Common
 		/// <param name="a">First vertex</param>
 		/// <param name="b">Second vertex</param>
 		/// <param name="c">Third vertex</param>
-		/// <returns></returns>
 		public static bool Collinear(ref Vector2 a, ref Vector2 b, ref Vector2 c)
 		{
 			return Collinear(ref a, ref b, ref c, 0);
@@ -421,7 +419,6 @@ namespace FarseerPhysics.Common
 		/// than computing the inverse in one-shot cases.
 		/// </summary>
 		/// <param name="b">The b.</param>
-		/// <returns></returns>
 		public Vector2 Solve(Vector2 b)
 		{
 			float a11 = this.Col1.X, a12 = this.Col2.X, a21 = this.Col1.Y, a22 = this.Col2.Y;
@@ -476,7 +473,6 @@ namespace FarseerPhysics.Common
 		/// than computing the inverse in one-shot cases.
 		/// </summary>
 		/// <param name="b">The b.</param>
-		/// <returns></returns>
 		public Vector3 Solve33(Vector3 b)
 		{
 			float det = Vector3.Dot(this.Col1, Vector3.Cross(this.Col2, this.Col3));
@@ -496,7 +492,6 @@ namespace FarseerPhysics.Common
 		/// 2-by-2 matrix equation.
 		/// </summary>
 		/// <param name="b">The b.</param>
-		/// <returns></returns>
 		public Vector2 Solve22(Vector2 b)
 		{
 			float a11 = this.Col1.X, a12 = this.Col2.X, a21 = this.Col1.Y, a22 = this.Col2.Y;

--- a/Source/Core/Physics/Common/Path.cs
+++ b/Source/Core/Physics/Common/Path.cs
@@ -68,7 +68,6 @@ namespace FarseerPhysics.Common
 		/// Gets the next index of a controlpoint
 		/// </summary>
 		/// <param name="index">The index.</param>
-		/// <returns></returns>
 		public int NextIndex(int index)
 		{
 			if (index == this.ControlPoints.Count - 1)
@@ -82,7 +81,6 @@ namespace FarseerPhysics.Common
 		/// Gets the previous index of a controlpoint
 		/// </summary>
 		/// <param name="index">The index.</param>
-		/// <returns></returns>
 		public int PreviousIndex(int index)
 		{
 			if (index == 0)
@@ -145,7 +143,6 @@ namespace FarseerPhysics.Common
 		/// between each control point.
 		/// </summary>
 		/// <param name="divisions">Number of divisions between each control point.</param>
-		/// <returns></returns>
 		public Vertices GetVertices(int divisions)
 		{
 			Vertices verts = new Vertices();

--- a/Source/Core/Physics/Common/PathManager.cs
+++ b/Source/Core/Physics/Common/PathManager.cs
@@ -84,7 +84,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="type">The type.</param>
 		/// <param name="copies">The copies.</param>
 		/// <param name="userData"></param>
-		/// <returns></returns>
 		public static List<Body> EvenlyDistributeShapesAlongPath(World world, Path path, IEnumerable<Shape> shapes,
 																 BodyType type, int copies, object userData)
 		{
@@ -127,7 +126,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="type">The type.</param>
 		/// <param name="copies">The copies.</param>
 		/// <param name="userData">The user data.</param>
-		/// <returns></returns>
 		public static List<Body> EvenlyDistributeShapesAlongPath(World world, Path path, Shape shape, BodyType type,
 																 int copies, object userData)
 		{
@@ -208,7 +206,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="collideConnected">if set to <c>true</c> [collide connected].</param>
 		/// <param name="minLength">Minimum length of the slider joint.</param>
 		/// <param name="maxLength">Maximum length of the slider joint.</param>
-		/// <returns></returns>
 		public static List<SliderJoint> AttachBodiesWithSliderJoint(World world, List<Body> bodies, Vector2 localAnchorA,
 																	Vector2 localAnchorB, bool connectFirstAndLast,
 																	bool collideConnected, float minLength,

--- a/Source/Core/Physics/Common/PolygonManipulation/SimplifyTools.cs
+++ b/Source/Core/Physics/Common/PolygonManipulation/SimplifyTools.cs
@@ -279,7 +279,6 @@ namespace FarseerPhysics.Common.PolygonManipulation
 		/// Merges the identical points in the polygon.
 		/// </summary>
 		/// <param name="vertices">The vertices.</param>
-		/// <returns></returns>
 		public static Vertices MergeIdenticalPoints(Vertices vertices)
 		{
 			//We use a dictonary here because HashSet is not avaliable on all platforms.
@@ -304,7 +303,6 @@ namespace FarseerPhysics.Common.PolygonManipulation
 		/// </summary>
 		/// <param name="vertices">The vertices.</param>
 		/// <param name="distance">The distance between points. Points closer than this will be 'joined'.</param>
-		/// <returns></returns>
 		public static Vertices ReduceByDistance(Vertices vertices, float distance)
 		{
 			//We can't simplify polygons under 3 vertices
@@ -333,7 +331,6 @@ namespace FarseerPhysics.Common.PolygonManipulation
 		/// </summary>
 		/// <param name="vertices">The vertices.</param>
 		/// <param name="nth">The Nth point to remove. Example: 5.</param>
-		/// <returns></returns>
 		public static Vertices ReduceByNth(Vertices vertices, int nth)
 		{
 			//We can't simplify polygons under 3 vertices

--- a/Source/Core/Physics/Common/PolygonTools.cs
+++ b/Source/Core/Physics/Common/PolygonTools.cs
@@ -57,7 +57,6 @@ namespace FarseerPhysics.Common
 		/// <param name="xRadius">The rounding X radius.</param>
 		/// <param name="yRadius">The rounding Y radius.</param>
 		/// <param name="segments">The number of segments to subdivide the edges.</param>
-		/// <returns></returns>
 		public static Vertices CreateRoundedRectangle(float width, float height, float xRadius, float yRadius,
 													  int segments)
 		{
@@ -134,7 +133,6 @@ namespace FarseerPhysics.Common
 		/// </summary>
 		/// <param name="radius">The radius.</param>
 		/// <param name="numberOfEdges">The number of edges. The more edges, the more it resembles a circle</param>
-		/// <returns></returns>
 		public static Vertices CreateCircle(float radius, int numberOfEdges)
 		{
 			return CreateEllipse(radius, radius, numberOfEdges);
@@ -146,7 +144,6 @@ namespace FarseerPhysics.Common
 		/// <param name="xRadius">Width of the ellipse.</param>
 		/// <param name="yRadius">Height of the ellipse.</param>
 		/// <param name="numberOfEdges">The number of edges. The more edges, the more it resembles an ellipse</param>
-		/// <returns></returns>
 		public static Vertices CreateEllipse(float xRadius, float yRadius, int numberOfEdges)
 		{
 			Vertices vertices = new Vertices();
@@ -188,7 +185,6 @@ namespace FarseerPhysics.Common
 		/// <param name="height">Height (inner height + 2 * radius) of the capsule.</param>
 		/// <param name="endRadius">Radius of the capsule ends.</param>
 		/// <param name="edges">The number of edges of the capsule ends. The more edges, the more it resembles an capsule</param>
-		/// <returns></returns>
 		public static Vertices CreateCapsule(float height, float endRadius, int edges)
 		{
 			if (endRadius >= height / 2)
@@ -208,7 +204,6 @@ namespace FarseerPhysics.Common
 		/// <param name="topEdges">The number of edges of the top. The more edges, the more it resembles an capsule</param>
 		/// <param name="bottomRadius">Radius of bottom.</param>
 		/// <param name="bottomEdges">The number of edges of the bottom. The more edges, the more it resembles an capsule</param>
-		/// <returns></returns>
 		public static Vertices CreateCapsule(float height, float topRadius, int topEdges, float bottomRadius,
 											 int bottomEdges)
 		{
@@ -275,7 +270,6 @@ namespace FarseerPhysics.Common
 		/// <param name="numberOfTeeth">The number of teeth.</param>
 		/// <param name="tipPercentage">The tip percentage.</param>
 		/// <param name="toothHeight">Height of the tooth.</param>
-		/// <returns></returns>
 		public static Vertices CreateGear(float radius, int numberOfTeeth, float tipPercentage, float toothHeight)
 		{
 			Vertices vertices = new Vertices();
@@ -321,7 +315,6 @@ namespace FarseerPhysics.Common
 		/// </summary>
 		/// <param name="data">The texture data.</param>
 		/// <param name="width">The texture width.</param>
-		/// <returns></returns>
 		public static Vertices CreatePolygon(uint[] data, int width)
 		{
 			return TextureConverter.DetectVertices(data, width);
@@ -333,7 +326,6 @@ namespace FarseerPhysics.Common
 		/// <param name="data">The texture data.</param>
 		/// <param name="width">The texture width.</param>
 		/// <param name="holeDetection">if set to <c>true</c> it will perform hole detection.</param>
-		/// <returns></returns>
 		public static Vertices CreatePolygon(uint[] data, int width, bool holeDetection)
 		{
 			return TextureConverter.DetectVertices(data, width, holeDetection);
@@ -348,7 +340,6 @@ namespace FarseerPhysics.Common
 		/// <param name="alphaTolerance">The alpha tolerance.</param>
 		/// <param name="multiPartDetection">if set to <c>true</c> it will perform multi part detection.</param>
 		/// <param name="holeDetection">if set to <c>true</c> it will perform hole detection.</param>
-		/// <returns></returns>
 		public static List<Vertices> CreatePolygon(uint[] data, int width, float hullTolerance,
 												   byte alphaTolerance, bool multiPartDetection, bool holeDetection)
 		{

--- a/Source/Core/Physics/Common/TextureTools/MSTerrain.cs
+++ b/Source/Core/Physics/Common/TextureTools/MSTerrain.cs
@@ -224,7 +224,6 @@ namespace FarseerPhysics.Common
 		/// </summary>
 		/// <param name="texture">Texture to convert.</param>
 		/// <param name="tester"></param>
-		/// <returns></returns>
 		public static sbyte[,] ConvertTextureToData(int texture, TerrainTester tester)
 		{
 			throw new System.NotImplementedException();

--- a/Source/Core/Physics/Common/TextureTools/MarchingSquares.cs
+++ b/Source/Core/Physics/Common/TextureTools/MarchingSquares.cs
@@ -47,7 +47,6 @@ namespace FarseerPhysics.Common
 		/// <param name="f"></param>
 		/// <param name="lerpCount"></param>
 		/// <param name="combine"></param>
-		/// <returns></returns>
 		public static List<Vertices> DetectSquares(AABB domain, float cellWidth, float cellHeight, sbyte[,] f,
 												   int lerpCount, bool combine)
 		{

--- a/Source/Core/Physics/Common/TextureTools/TextureConverter.cs
+++ b/Source/Core/Physics/Common/TextureTools/TextureConverter.cs
@@ -291,7 +291,6 @@ namespace FarseerPhysics.Common
 		/// </summary>
 		/// <param name="data">The texture data.</param>
 		/// <param name="width">The texture width.</param>
-		/// <returns></returns>
 		public static Vertices DetectVertices(uint[] data, int width)
 		{
 			TextureConverter tc = new TextureConverter(data, width);
@@ -307,7 +306,6 @@ namespace FarseerPhysics.Common
 		/// <param name="data">The texture data.</param>
 		/// <param name="width">The texture width.</param>
 		/// <param name="holeDetection">if set to <c>true</c> it will perform hole detection.</param>
-		/// <returns></returns>
 		public static Vertices DetectVertices(uint[] data, int width, bool holeDetection)
 		{
 			TextureConverter tc =
@@ -330,7 +328,6 @@ namespace FarseerPhysics.Common
 		/// <param name="hullTolerance">The hull tolerance.</param>
 		/// <param name="alphaTolerance">The alpha tolerance.</param>
 		/// <param name="multiPartDetection">if set to <c>true</c> it will perform multi part detection.</param>
-		/// <returns></returns>
 		public static List<Vertices> DetectVertices(uint[] data, int width, float hullTolerance,
 													byte alphaTolerance, bool multiPartDetection, bool holeDetection)
 		{
@@ -1006,7 +1003,6 @@ namespace FarseerPhysics.Common
 		/// </summary>
 		/// <param name="entrance"></param>
 		/// <param name="last"></param>
-		/// <returns></returns>
 		private Vertices CreateSimplePolygon(Vector2 entrance, Vector2 last)
 		{
 			bool entranceFound = false;

--- a/Source/Core/Physics/Common/Vertices.cs
+++ b/Source/Core/Physics/Common/Vertices.cs
@@ -77,7 +77,6 @@ namespace FarseerPhysics.Common
 		/// Nexts the index.
 		/// </summary>
 		/// <param name="index">The index.</param>
-		/// <returns></returns>
 		public int NextIndex(int index)
 		{
 			if (index == this.Count - 1)
@@ -96,7 +95,6 @@ namespace FarseerPhysics.Common
 		/// Gets the previous index.
 		/// </summary>
 		/// <param name="index">The index.</param>
-		/// <returns></returns>
 		public int PreviousIndex(int index)
 		{
 			if (index == 0)
@@ -114,7 +112,6 @@ namespace FarseerPhysics.Common
 		/// <summary>
 		/// Gets the signed area.
 		/// </summary>
-		/// <returns></returns>
 		public float GetSignedArea()
 		{
 			int i;
@@ -133,7 +130,6 @@ namespace FarseerPhysics.Common
 		/// <summary>
 		/// Gets the area.
 		/// </summary>
-		/// <returns></returns>
 		public float GetArea()
 		{
 			int i;
@@ -152,7 +148,6 @@ namespace FarseerPhysics.Common
 		/// <summary>
 		/// Gets the centroid.
 		/// </summary>
-		/// <returns></returns>
 		public Vector2 GetCentroid()
 		{
 			// Same algorithm is used by Box2D
@@ -189,7 +184,6 @@ namespace FarseerPhysics.Common
 		/// <summary>
 		/// Gets the radius based on area.
 		/// </summary>
-		/// <returns></returns>
 		public float GetRadius()
 		{
 			float area = GetSignedArea();
@@ -206,7 +200,6 @@ namespace FarseerPhysics.Common
 		/// <summary>
 		/// Returns an AABB for vertex.
 		/// </summary>
-		/// <returns></returns>
 		public AABB GetCollisionBox()
 		{
 			AABB aabb;
@@ -337,7 +330,6 @@ namespace FarseerPhysics.Common
 		/// <summary>
 		/// Check for edge crossings
 		/// </summary>
-		/// <returns></returns>
 		public bool IsSimple()
 		{
 			for (int i = 0; i < this.Count; ++i)
@@ -420,7 +412,6 @@ namespace FarseerPhysics.Common
 		/// - if more than one, pick one with "rightest" next point (two possibilities for each)
 		/// </summary>
 		/// <param name="verts">The vertices.</param>
-		/// <returns></returns>
 		public Vertices TraceEdge(Vertices verts)
 		{
 			PolyNode[] nodes = new PolyNode[verts.Count * verts.Count];

--- a/Source/Core/Physics/Dynamics/Body.cs
+++ b/Source/Core/Physics/Dynamics/Body.cs
@@ -710,7 +710,6 @@ namespace FarseerPhysics.Dynamics
 		/// Warning: This function is locked during callbacks.
 		/// </summary>
 		/// <param name="shape">The shape.</param>
-		/// <returns></returns>
 		public Fixture CreateFixture(Shape shape)
 		{
 			return new Fixture(this, shape);
@@ -723,7 +722,6 @@ namespace FarseerPhysics.Dynamics
 		/// </summary>
 		/// <param name="shape">The shape.</param>
 		/// <param name="userData">Application specific data</param>
-		/// <returns></returns>
 		public Fixture CreateFixture(Shape shape, object userData)
 		{
 			return new Fixture(this, shape, userData);
@@ -1266,7 +1264,6 @@ namespace FarseerPhysics.Dynamics
 		/// It may lie, depending on the collideConnected flag.
 		/// </summary>
 		/// <param name="other">The other body.</param>
-		/// <returns></returns>
 		internal bool ShouldCollide(Body other)
 		{
 			// At least one body should be dynamic.

--- a/Source/Core/Physics/Dynamics/Fixture.cs
+++ b/Source/Core/Physics/Dynamics/Fixture.cs
@@ -414,7 +414,6 @@ namespace FarseerPhysics.Dynamics
 		/// Test a point for containment in this fixture.
 		/// </summary>
 		/// <param name="point">A point in world coordinates.</param>
-		/// <returns></returns>
 		public bool TestPoint(ref Vector2 point)
 		{
 			return this.Shape.TestPoint(ref this.Body.Xf, ref point);
@@ -426,7 +425,6 @@ namespace FarseerPhysics.Dynamics
 		/// <param name="output">The ray-cast results.</param>
 		/// <param name="input">The ray-cast input parameters.</param>
 		/// <param name="childIndex">Index of the child.</param>
-		/// <returns></returns>
 		public bool RayCast(out RayCastOutput output, ref RayCastInput input, int childIndex)
 		{
 			return this.Shape.RayCast(out output, ref input, ref this.Body.Xf, childIndex);

--- a/Source/Core/Physics/Dynamics/Joints/Joint.cs
+++ b/Source/Core/Physics/Dynamics/Joints/Joint.cs
@@ -214,14 +214,12 @@ namespace FarseerPhysics.Dynamics.Joints
 		/// Get the reaction force on body2 at the joint anchor in Newtons.
 		/// </summary>
 		/// <param name="inv_dt">The inv_dt.</param>
-		/// <returns></returns>
 		public abstract Vector2 GetReactionForce(float inv_dt);
 
 		/// <summary>
 		/// Get the reaction torque on body2 in N*m.
 		/// </summary>
 		/// <param name="inv_dt">The inv_dt.</param>
-		/// <returns></returns>
 		public abstract float GetReactionTorque(float inv_dt);
 
 		protected void WakeBodies()

--- a/Source/Core/Physics/Dynamics/World.cs
+++ b/Source/Core/Physics/Dynamics/World.cs
@@ -343,7 +343,6 @@ namespace FarseerPhysics.Dynamics
 		/// <summary>
 		/// Add a rigid body.
 		/// </summary>
-		/// <returns></returns>
 		internal void AddBody(Body body)
 		{
 			Debug.Assert(!this._bodyAddList.Contains(body), "You are adding the same body more than once.");
@@ -1312,7 +1311,6 @@ namespace FarseerPhysics.Dynamics
 		/// Returns a list of fixtures that are at the specified point.
 		/// </summary>
 		/// <param name="point">The point.</param>
-		/// <returns></returns>
 		public List<Fixture> TestPointAll(Vector2 point)
 		{
 			AABB aabb;

--- a/Source/Core/Physics/Factories/BodyFactory.cs
+++ b/Source/Core/Physics/Factories/BodyFactory.cs
@@ -233,7 +233,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="density">The density.</param>
 		/// <param name="position">The position.</param>
 		/// <param name="userData"></param>
-		/// <returns></returns>
 		public static Body CreateCapsule(World world, float height, float topRadius, int topEdges,
 										 float bottomRadius,
 										 int bottomEdges, float density, Vector2 position, object userData)
@@ -305,7 +304,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="density">The density.</param>
 		/// <param name="position">The position.</param>
 		/// <param name="userData"></param>
-		/// <returns></returns>
 		public static Body CreateRoundedRectangle(World world, float width, float height, float xRadius,
 												  float yRadius,
 												  int segments, float density, Vector2 position,

--- a/Source/Core/Physics/Factories/JointFactory.cs
+++ b/Source/Core/Physics/Factories/JointFactory.cs
@@ -17,7 +17,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="bodyA"></param>
 		/// <param name="bodyB"></param>
 		/// <param name="localAnchorB">The anchor of bodyB in local coordinates</param>
-		/// <returns></returns>
 		public static RevoluteJoint CreateRevoluteJoint(Body bodyA, Body bodyB, Vector2 localAnchorB)
 		{
 			Vector2 localanchorA = bodyA.GetLocalPoint(bodyB.GetWorldPoint(localAnchorB));
@@ -32,7 +31,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="bodyA"></param>
 		/// <param name="bodyB"></param>
 		/// <param name="anchor"></param>
-		/// <returns></returns>
 		public static RevoluteJoint CreateRevoluteJoint(World world, Body bodyA, Body bodyB, Vector2 anchor)
 		{
 			RevoluteJoint joint = CreateRevoluteJoint(bodyA, bodyB, anchor);
@@ -50,7 +48,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="bodyA"></param>
 		/// <param name="bodyB"></param>
 		/// <param name="localAnchor"></param>
-		/// <returns></returns>
 		public static WeldJoint CreateWeldJoint(Body bodyA, Body bodyB, Vector2 localAnchor)
 		{
 			WeldJoint joint = new WeldJoint(bodyA, bodyB, bodyA.GetLocalPoint(localAnchor),
@@ -65,7 +62,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="bodyA"></param>
 		/// <param name="bodyB"></param>
 		/// <param name="localanchorB"></param>
-		/// <returns></returns>
 		public static WeldJoint CreateWeldJoint(World world, Body bodyA, Body bodyB, Vector2 localanchorB)
 		{
 			WeldJoint joint = CreateWeldJoint(bodyA, bodyB, localanchorB);
@@ -92,7 +88,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="bodyB"></param>
 		/// <param name="localanchorB"></param>
 		/// <param name="axis"></param>
-		/// <returns></returns>
 		public static PrismaticJoint CreatePrismaticJoint(Body bodyA, Body bodyB, Vector2 localanchorB, Vector2 axis)
 		{
 			Vector2 localanchorA = bodyA.GetLocalPoint(bodyB.GetWorldPoint(localanchorB));
@@ -108,7 +103,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="bodyB"></param>
 		/// <param name="localanchorB"></param>
 		/// <param name="axis"></param>
-		/// <returns></returns>
 		public static PrismaticJoint CreatePrismaticJoint(World world, Body bodyA, Body bodyB, Vector2 localanchorB,
 														  Vector2 axis)
 		{
@@ -128,7 +122,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="bodyB"></param>
 		/// <param name="anchor"></param>
 		/// <param name="axis"></param>
-		/// <returns></returns>
 		public static LineJoint CreateLineJoint(Body bodyA, Body bodyB, Vector2 anchor, Vector2 axis)
 		{
 			LineJoint joint = new LineJoint(bodyA, bodyB, anchor, axis);
@@ -143,7 +136,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="bodyB"></param>
 		/// <param name="localanchorB"></param>
 		/// <param name="axis"></param>
-		/// <returns></returns>
 		public static LineJoint CreateLineJoint(World world, Body bodyA, Body bodyB, Vector2 localanchorB, Vector2 axis)
 		{
 			LineJoint joint = CreateLineJoint(bodyA, bodyB, localanchorB, axis);
@@ -161,7 +153,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="world">The world.</param>
 		/// <param name="bodyA">The first body.</param>
 		/// <param name="bodyB">The second body.</param>
-		/// <returns></returns>
 		public static AngleJoint CreateAngleJoint(World world, Body bodyA, Body bodyB)
 		{
 			AngleJoint angleJoint = new AngleJoint(bodyA, bodyB);

--- a/Source/Core/Physics/Factories/LinkFactory.cs
+++ b/Source/Core/Physics/Factories/LinkFactory.cs
@@ -18,7 +18,6 @@ namespace FarseerPhysics.Factories
 		/// <param name="linkHeight">The height.</param>
 		/// <param name="numberOfLinks">The number of links.</param>
 		/// <param name="linkDensity">The link density.</param>
-		/// <returns></returns>
 		public static Path CreateChain(World world, Vector2 start, Vector2 end, float linkWidth, float linkHeight, int numberOfLinks, float linkDensity)
 		{
 			//Chain start / end

--- a/Source/Core/Physics/Settings.cs
+++ b/Source/Core/Physics/Settings.cs
@@ -200,7 +200,6 @@ namespace FarseerPhysics
 		/// </summary>
 		/// <param name="friction1">The friction1.</param>
 		/// <param name="friction2">The friction2.</param>
-		/// <returns></returns>
 		public static float MixFriction(float friction1, float friction2)
 		{
 			return (float)Math.Sqrt(friction1 * friction2);
@@ -211,7 +210,6 @@ namespace FarseerPhysics
 		/// </summary>
 		/// <param name="restitution1">The restitution1.</param>
 		/// <param name="restitution2">The restitution2.</param>
-		/// <returns></returns>
 		public static float MixRestitution(float restitution1, float restitution2)
 		{
 			return restitution1 > restitution2 ? restitution1 : restitution2;

--- a/Source/Core/Primitives/Drawing/ColorFormat/ColorHsva.cs
+++ b/Source/Core/Primitives/Drawing/ColorFormat/ColorHsva.cs
@@ -156,7 +156,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Converts the color to int-Rgba.
 		/// </summary>
-		/// <returns></returns>
 		public int ToIntRgba()
 		{
 			return this.ToRgba().ToIntRgba();
@@ -164,7 +163,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Converts the color to int-Argb.
 		/// </summary>
-		/// <returns></returns>
 		public int ToIntArgb()
 		{
 			return this.ToRgba().ToIntArgb();
@@ -172,7 +170,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Converts the color to Rgba.
 		/// </summary>
-		/// <returns></returns>
 		public ColorRgba ToRgba()
 		{
 			float hTemp = NormalizeHue(this.H) * 360.0f / 60.0f;
@@ -263,7 +260,6 @@ namespace Duality.Drawing
 		/// Returns whether this color equals the specified one.
 		/// </summary>
 		/// <param name="other"></param>
-		/// <returns></returns>
 		public bool Equals(ColorHsva other)
 		{
 			return this.H == other.H && this.S == other.S && this.V == other.V && this.A == other.A;
@@ -288,7 +284,6 @@ namespace Duality.Drawing
 		/// Creates a new color based on an int-Rgba value.
 		/// </summary>
 		/// <param name="rgba"></param>
-		/// <returns></returns>
 		public static ColorHsva FromIntRgba(int rgba)
 		{
 			ColorHsva temp = new ColorHsva();
@@ -299,7 +294,6 @@ namespace Duality.Drawing
 		/// Creates a new color based on an int-Argb value.
 		/// </summary>
 		/// <param name="argb"></param>
-		/// <returns></returns>
 		public static ColorHsva FromIntArgb(int argb)
 		{
 			ColorHsva temp = new ColorHsva();
@@ -310,7 +304,6 @@ namespace Duality.Drawing
 		/// Creates a new color based on a Rgba value.
 		/// </summary>
 		/// <param name="rgba"></param>
-		/// <returns></returns>
 		public static ColorHsva FromRgba(ColorRgba rgba)
 		{
 			ColorHsva temp = new ColorHsva();
@@ -323,7 +316,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="left">The first color.</param>
 		/// <param name="right">The second color.</param>
-		/// <returns></returns>
 		public static bool operator ==(ColorHsva left, ColorHsva right)
 		{
 			return left.Equals(right);
@@ -333,7 +325,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="left">The first color.</param>
 		/// <param name="right">The second color.</param>
-		/// <returns></returns>
 		public static bool operator !=(ColorHsva left, ColorHsva right)
 		{
 			return !left.Equals(right);

--- a/Source/Core/Primitives/Drawing/ColorFormat/ColorRgba.cs
+++ b/Source/Core/Primitives/Drawing/ColorFormat/ColorRgba.cs
@@ -241,7 +241,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Converts the color to int-Rgba.
 		/// </summary>
-		/// <returns></returns>
 		public int ToIntRgba()
 		{
 			return ((int)this.R << 24) | ((int)this.G << 16) | ((int)this.B << 8) | ((int)this.A);
@@ -249,7 +248,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Converts the color to int-Argb.
 		/// </summary>
-		/// <returns></returns>
 		public int ToIntArgb()
 		{
 			return ((int)this.A << 24) | ((int)this.R << 16) | ((int)this.G << 8) | ((int)this.B);
@@ -257,7 +255,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Converts the color to Hsva.
 		/// </summary>
-		/// <returns></returns>
 		public ColorHsva ToHsva()
 		{
 			return ColorHsva.FromRgba(this);
@@ -298,7 +295,6 @@ namespace Duality.Drawing
 		/// Returns whether this color equals the specified one.
 		/// </summary>
 		/// <param name="other"></param>
-		/// <returns></returns>
 		public bool Equals(ColorRgba other)
 		{
 			return this.R == other.R && this.G == other.G && this.B == other.B && this.A == other.A;
@@ -323,7 +319,6 @@ namespace Duality.Drawing
 		/// Creates a new color based on an int-Rgba value.
 		/// </summary>
 		/// <param name="rgba"></param>
-		/// <returns></returns>
 		public static ColorRgba FromIntRgba(int rgba)
 		{
 			ColorRgba temp = new ColorRgba();
@@ -334,7 +329,6 @@ namespace Duality.Drawing
 		/// Creates a new color based on an int-Argb value.
 		/// </summary>
 		/// <param name="argb"></param>
-		/// <returns></returns>
 		public static ColorRgba FromIntArgb(int argb)
 		{
 			ColorRgba temp = new ColorRgba();
@@ -345,7 +339,6 @@ namespace Duality.Drawing
 		/// Creates a new color based on a Hsva value.
 		/// </summary>
 		/// <param name="hsva"></param>
-		/// <returns></returns>
 		public static ColorRgba FromHsva(ColorHsva hsva)
 		{
 			return hsva.ToRgba();
@@ -373,7 +366,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="left">The first color.</param>
 		/// <param name="right">The second color.</param>
-		/// <returns></returns>
 		public static bool operator ==(ColorRgba left, ColorRgba right)
 		{
 			return left.Equals(right);
@@ -383,7 +375,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="left">The first color.</param>
 		/// <param name="right">The second color.</param>
-		/// <returns></returns>
 		public static bool operator !=(ColorRgba left, ColorRgba right)
 		{
 			return !left.Equals(right);
@@ -393,7 +384,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="left">The first color.</param>
 		/// <param name="right">The second color.</param>
-		/// <returns></returns>
 		public static ColorRgba operator +(ColorRgba left, ColorRgba right)
 		{
 			return new ColorRgba(
@@ -407,7 +397,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="left">The first color.</param>
 		/// <param name="right">The second color.</param>
-		/// <returns></returns>
 		public static ColorRgba operator -(ColorRgba left, ColorRgba right)
 		{
 			return new ColorRgba(
@@ -421,7 +410,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="left">The first color.</param>
 		/// <param name="right">The second color.</param>
-		/// <returns></returns>
 		public static ColorRgba operator *(ColorRgba left, ColorRgba right)
 		{
 			return new ColorRgba(
@@ -435,7 +423,6 @@ namespace Duality.Drawing
 		/// </summary>
 		/// <param name="left">The color to scale.</param>
 		/// <param name="right">The scaling factor.</param>
-		/// <returns></returns>
 		public static ColorRgba operator *(ColorRgba left, float right)
 		{
 			return new ColorRgba(

--- a/Source/Core/Primitives/Drawing/ColorFormat/IColorData.cs
+++ b/Source/Core/Primitives/Drawing/ColorFormat/IColorData.cs
@@ -10,7 +10,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Converts the color to a <see cref="System.UInt32"/>-Rgba value.
 		/// </summary>
-		/// <returns></returns>
 		int ToIntRgba();
 		/// <summary>
 		/// Sets the color base ond a <see cref="System.UInt32"/>-Rgba value.
@@ -21,7 +20,6 @@ namespace Duality.Drawing
 		/// <summary>
 		/// Converts the color to a <see cref="System.UInt32"/>-Argb value.
 		/// </summary>
-		/// <returns></returns>
 		int ToIntArgb();
 		/// <summary>
 		/// Sets the color base ond a <see cref="System.UInt32"/>-Argb value.

--- a/Source/Core/Primitives/Math/Alignment.cs
+++ b/Source/Core/Primitives/Math/Alignment.cs
@@ -106,7 +106,6 @@
 		/// <param name="align"></param>
 		/// <param name="vec"></param>
 		/// <param name="size"></param>
-		/// <returns></returns>
 		public static Vector2 ApplyTo(this Alignment align, Vector2 vec, Vector2 size)
 		{
 			ApplyTo(align, ref vec, ref size);
@@ -140,7 +139,6 @@
 		/// <param name="y"></param>
 		/// <param name="width"></param>
 		/// <param name="height"></param>
-		/// <returns></returns>
 		public static Vector2 ApplyTo(this Alignment align, float x, float y, float width, float height)
 		{
 			Vector2 vec;

--- a/Source/Core/Primitives/Math/MathF.cs
+++ b/Source/Core/Primitives/Math/MathF.cs
@@ -82,7 +82,6 @@ namespace Duality
 		/// Converts the specified float value to decimal and clamps it if necessary.
 		/// </summary>
 		/// <param name="v"></param>
-		/// <returns></returns>
 		public static decimal SafeToDecimal(float v)
 		{
 			if (float.IsNaN(v))
@@ -497,7 +496,6 @@ namespace Duality
 		/// <param name="a">The first anchor value.</param>
 		/// <param name="b">The second anchor value.</param>
 		/// <param name="ratio">Ratio between first and second anchor. Zero will result in anchor a, one will result in anchor b.</param>
-		/// <returns></returns>
 		public static float Lerp(float a, float b, float ratio)
 		{
 			return a + ratio * (b - a);
@@ -509,7 +507,6 @@ namespace Duality
 		/// <param name="min">The first anchor value.</param>
 		/// <param name="max">The second anchor value.</param>
 		/// <param name="value">The value between both anchor values.</param>
-		/// <returns></returns>
 		public static float InvLerp(float min, float max, float value)
 		{
 			return (value - min) / (max - min);
@@ -521,7 +518,6 @@ namespace Duality
 		/// <param name="min">The first anchor value.</param>
 		/// <param name="max">The second anchor value.</param>
 		/// <param name="value">The value between both anchor values.</param>
-		/// <returns></returns>
 		public static float InvLerp(int min, int max, int value)
 		{
 			return (float) (value - min) / (max - min);
@@ -531,7 +527,6 @@ namespace Duality
 		/// Performs a SmoothStep interpolation between 0 and 1.
 		/// </summary>
 		/// <param name="value">The input value.</param>
-		/// <returns></returns>
 		public static float SmoothStep(float value)
 		{
 			value = Clamp01(value);
@@ -544,7 +539,6 @@ namespace Duality
 		/// <param name="min">The lower bound anchor value</param>
 		/// <param name="max">The upper bound anchor value</param>
 		/// <param name="value">The input value.</param>
-		/// <returns></returns>
 		public static float SmoothStep(float min, float max, float value)
 		{
 			value = Clamp01(InvLerp(min, max, value));
@@ -555,7 +549,6 @@ namespace Duality
 		/// Returns the specified power of <see cref="E"/>.
 		/// </summary>
 		/// <param name="v"></param>
-		/// <returns></returns>
 		public static float Exp(float v)
 		{
 			return (float)System.Math.Exp(v);
@@ -564,7 +557,6 @@ namespace Duality
 		/// Returns the natural logarithm of a value.
 		/// </summary>
 		/// <param name="v"></param>
-		/// <returns></returns>
 		public static float Log(float v)
 		{
 			return (float)System.Math.Log(v);
@@ -574,7 +566,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="v">The base value.</param>
 		/// <param name="e">Specifies the power to return.</param>
-		/// <returns></returns>
 		public static float Pow(float v, float e)
 		{
 			return (float)System.Math.Pow(v, e);
@@ -584,7 +575,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="v">The value whichs logarithm is to be calculated.</param>
 		/// <param name="newBase">The base of the logarithm.</param>
-		/// <returns></returns>
 		public static float Log(float v, float newBase)
 		{
 			return (float)System.Math.Log(v, newBase);
@@ -594,7 +584,6 @@ namespace Duality
 		/// Returns the sine value of the specified (radian) angle.
 		/// </summary>
 		/// <param name="angle">A radian angle.</param>
-		/// <returns></returns>
 		public static float Sin(float angle)
 		{
 			return (float)System.Math.Sin(angle);
@@ -603,7 +592,6 @@ namespace Duality
 		/// Returns the cosine value of the specified (radian) angle.
 		/// </summary>
 		/// <param name="angle">A radian angle.</param>
-		/// <returns></returns>
 		public static float Cos(float angle)
 		{
 			return (float)System.Math.Cos(angle);
@@ -612,7 +600,6 @@ namespace Duality
 		/// Returns the tangent value of the specified (radian) angle.
 		/// </summary>
 		/// <param name="angle">A radian angle.</param>
-		/// <returns></returns>
 		public static float Tan(float angle)
 		{
 			return (float)System.Math.Tan(angle);
@@ -621,7 +608,6 @@ namespace Duality
 		/// Returns the inverse sine value of the specified (radian) angle.
 		/// </summary>
 		/// <param name="sin">A radian angle.</param>
-		/// <returns></returns>
 		public static float Asin(float sin)
 		{
 			return (float)System.Math.Asin(sin);
@@ -630,7 +616,6 @@ namespace Duality
 		/// Returns the inverse cosine value of the specified (radian) angle.
 		/// </summary>
 		/// <param name="cos">A radian angle.</param>
-		/// <returns></returns>
 		public static float Acos(float cos)
 		{
 			return (float)System.Math.Acos(cos);
@@ -639,7 +624,6 @@ namespace Duality
 		/// Returns the inverse tangent value of the specified (radian) angle.
 		/// </summary>
 		/// <param name="tan">A radian angle.</param>
-		/// <returns></returns>
 		public static float Atan(float tan)
 		{
 			return (float)System.Math.Atan(tan);
@@ -649,7 +633,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="y">The y coordinate of a point. </param>
 		/// <param name="x">The x coordinate of a point. </param>
-		/// <returns></returns>
 		public static float Atan2(float y, float x)
 		{
 			return (float)System.Math.Atan2(y, x);
@@ -659,7 +642,6 @@ namespace Duality
 		/// Converts degrees  to radians.
 		/// </summary>
 		/// <param name="deg"></param>
-		/// <returns></returns>
 		public static float DegToRad(float deg)
 		{
 			const float factor = (float)System.Math.PI / 180.0f;
@@ -669,7 +651,6 @@ namespace Duality
 		/// Converts radians to degrees.
 		/// </summary>
 		/// <param name="rad"></param>
-		/// <returns></returns>
 		public static float RadToDeg(float rad)
 		{
 			const float factor = 180.0f / (float)System.Math.PI;
@@ -1234,7 +1215,6 @@ namespace Duality
 		/// Returns whether or not the specified polygon is convex.
 		/// </summary>
 		/// <param name="vertices"></param>
-		/// <returns></returns>
 		public static bool IsPolygonConvex(params Vector2[] vertices)
 		{
 			bool neg = false;
@@ -1289,7 +1269,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="baseHash"></param>
 		/// <param name="otherHash"></param>
-		/// <returns></returns>
 		public static void CombineHashCode(ref int baseHash, int otherHash)
 		{
 			unchecked { baseHash = baseHash * 23 + otherHash; }
@@ -1298,7 +1277,6 @@ namespace Duality
 		/// Combines any number of hash codes.
 		/// </summary>
 		/// <param name="hashes"></param>
-		/// <returns></returns>
 		public static int CombineHashCode(params int[] hashes)
 		{
 			int result = hashes[0];

--- a/Source/Core/Primitives/Math/Matrix4.cs
+++ b/Source/Core/Primitives/Math/Matrix4.cs
@@ -30,7 +30,6 @@ namespace Duality
 	/// <summary>
 	/// Represents a 4x4 matrix containing 3D rotation, scale, transform, and projection.
 	/// </summary>
-	/// <seealso cref="Matrix4d"/>
 	[StructLayout(LayoutKind.Sequential)]
 	public struct Matrix4 : IEquatable<Matrix4>
 	{

--- a/Source/Core/Primitives/Math/Point2.cs
+++ b/Source/Core/Primitives/Math/Point2.cs
@@ -88,7 +88,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="left"></param>
 		/// <param name="right"></param>
-		/// <returns></returns>
 		public static float Distance(Point2 left, Point2 right)
 		{
 			Point2 diff;
@@ -219,7 +218,6 @@ namespace Duality
 		/// <summary>
 		/// Returns a System.String that represents the current Point.
 		/// </summary>
-		/// <returns></returns>
 		public override string ToString()
 		{
 			return string.Format("({0}, {1})", this.X, this.Y);

--- a/Source/Core/Primitives/Math/Quaternion.cs
+++ b/Source/Core/Primitives/Math/Quaternion.cs
@@ -588,7 +588,6 @@ namespace Duality
 		/// <summary>
 		/// Returns a System.String that represents the current Quaternion.
 		/// </summary>
-		/// <returns></returns>
 		public override string ToString()
 		{
 			return string.Format("V: {0}, W: {1}", this.Xyz, this.W);

--- a/Source/Core/Primitives/Math/Rect.cs
+++ b/Source/Core/Primitives/Math/Rect.cs
@@ -355,7 +355,6 @@ namespace Duality
 		/// <summary>
 		/// Returns a normalized version of the rect, i.e. one with a positive width and height.
 		/// </summary>
-		/// <returns></returns>
 		public Rect Normalized()
 		{
 			Rect normalized = this;
@@ -478,7 +477,6 @@ namespace Duality
 		/// Tests if two Rects are equal.
 		/// </summary>
 		/// <param name="other"></param>
-		/// <returns></returns>
 		public bool Equals(Rect other)
 		{
 			return 
@@ -511,7 +509,6 @@ namespace Duality
 		/// <param name="y">The Rects y-Coordinate.</param>
 		/// <param name="w">The Rects width.</param>
 		/// <param name="h">The Rects height.</param>
-		/// <returns></returns>
 		public static Rect Align(Alignment align, float x, float y, float w, float h)
 		{
 			switch (align)
@@ -534,7 +531,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="left">The first Rect.</param>
 		/// <param name="right">The second Rect.</param>
-		/// <returns></returns>
 		public static bool operator ==(Rect left, Rect right)
 		{
 			return left.Equals(right);
@@ -544,7 +540,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="left">The first Rect.</param>
 		/// <param name="right">The second Rect.</param>
-		/// <returns></returns>
 		public static bool operator !=(Rect left, Rect right)
 		{
 			return !left.Equals(right);

--- a/Source/Core/Primitives/Math/Vector2.cs
+++ b/Source/Core/Primitives/Math/Vector2.cs
@@ -87,7 +87,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="angle"></param>
 		/// <param name="length"></param>
-		/// <returns></returns>
 		public static Vector2 FromAngleLength(float angle, float length)
 		{
 			return new Vector2((float)Math.Sin(angle) * length, (float)Math.Cos(angle) * -length);
@@ -424,7 +423,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="vec"></param>
 		/// <param name="mat"></param>
-		/// <returns></returns>
 		public static Vector2 Transform(Vector2 vec, Matrix4 mat)
 		{
 			Vector2 result;
@@ -437,7 +435,6 @@ namespace Duality
 		/// <param name="vec"></param>
 		/// <param name="mat"></param>
 		/// <param name="result"></param>
-		/// <returns></returns>
 		public static void Transform(ref Vector2 vec, ref Matrix4 mat, out Vector2 result)
 		{
 			Vector4 row0 = mat.Row0;
@@ -562,7 +559,6 @@ namespace Duality
 		/// <summary>
 		/// Returns a System.String that represents the current Vector2.
 		/// </summary>
-		/// <returns></returns>
 		public override string ToString()
 		{
 			return string.Format("({0:F}, {1:F})", this.X, this.Y);

--- a/Source/Core/Primitives/Math/Vector3.cs
+++ b/Source/Core/Primitives/Math/Vector3.cs
@@ -123,7 +123,6 @@ namespace Duality
 		/// <summary>
 		/// Gets the length (magnitude) of the vector.
 		/// </summary>
-		/// <see cref="LengthFast"/>
 		/// <seealso cref="LengthSquared"/>
 		public float Length
 		{
@@ -142,8 +141,7 @@ namespace Duality
 		/// This property avoids the costly square root operation required by the Length property. This makes it more suitable
 		/// for comparisons.
 		/// </remarks>
-		/// <see cref="Length"/>
-		/// <seealso cref="LengthFast"/>
+		/// <seealso cref="Length"/>
 		public float LengthSquared
 		{
 			get
@@ -383,7 +381,6 @@ namespace Duality
 		/// </summary>
 		/// <param name="left"></param>
 		/// <param name="right"></param>
-		/// <returns></returns>
 		public static float Distance(ref Vector3 left, ref Vector3 right)
 		{
 			Vector3 diff;
@@ -624,7 +621,6 @@ namespace Duality
 		/// <summary>
 		/// Returns a System.String that represents the current Vector3.
 		/// </summary>
-		/// <returns></returns>
 		public override string ToString()
 		{
 			return string.Format("({0}, {1}, {2})", this.X, this.Y, this.Z);

--- a/Source/Core/Primitives/Math/Vector4.cs
+++ b/Source/Core/Primitives/Math/Vector4.cs
@@ -624,7 +624,6 @@ namespace Duality
 		/// <summary>
 		/// Returns a System.String that represents the current Vector4.
 		/// </summary>
-		/// <returns></returns>
 		public override string ToString()
 		{
 			return string.Format("({0}, {1}, {2}, {3})", this.X, this.Y, this.Z, this.W);

--- a/Source/Editor/DualityEditor/AssetManagement/AssetInternalHelper.cs
+++ b/Source/Editor/DualityEditor/AssetManagement/AssetInternalHelper.cs
@@ -25,7 +25,6 @@ namespace Duality.Editor.AssetManagement
 		/// of that <see cref="Resource"/>.
 		/// </summary>
 		/// <param name="resource"></param>
-		/// <returns></returns>
 		public static string GetSourceMediaBaseDir(ContentRef<Resource> resource)
 		{
 			string resFullNameInData = PathHelper.MakeFilePathRelative(resource.FullName, DualityApp.DataDirectory);
@@ -41,7 +40,6 @@ namespace Duality.Editor.AssetManagement
 		/// <param name="resource"></param>
 		/// <param name="parameterName"></param>
 		/// <param name="value"></param>
-		/// <returns></returns>
 		public static bool GetAssetInfoCustomValue<T>(Resource resource, string parameterName, out T value)
 		{
 			// Otherwise, perform a defensive lookup

--- a/Source/Editor/DualityEditor/AssetManagement/AssetManager.cs
+++ b/Source/Editor/DualityEditor/AssetManagement/AssetManager.cs
@@ -73,7 +73,6 @@ namespace Duality.Editor.AssetManagement
 		/// The base directory of the previously specified input source files, 
 		/// which is mapped to the target base directory.
 		/// </param>
-		/// <returns></returns>
 		public static AssetImportOutput[] ImportAssets(IEnumerable<string> inputFiles, string targetBaseDir, string inputBaseDir)
 		{
 			return ImportAssets(inputFiles, targetBaseDir, inputBaseDir, false);
@@ -87,7 +86,6 @@ namespace Duality.Editor.AssetManagement
 		/// The base directory of the previously specified input source files, 
 		/// which is mapped to the target base directory.
 		/// </param>
-		/// <returns></returns>
 		public static AssetImportOutput[] SimulateImportAssets(IEnumerable<string> inputFiles, string targetBaseDir, string inputBaseDir)
 		{
 			return ImportAssets(inputFiles, targetBaseDir, inputBaseDir, true);
@@ -139,7 +137,6 @@ namespace Duality.Editor.AssetManagement
 		/// <param name="localInputFiles">
 		/// An enumerable of input source files that are already part of the local media source folder.
 		/// </param>
-		/// <returns></returns>
 		public static AssetImportOutput[] ReImportAssets(IEnumerable<string> localInputFiles)
 		{
 			return ReImportAssets(localInputFiles, false);
@@ -150,7 +147,6 @@ namespace Duality.Editor.AssetManagement
 		/// <param name="localInputFiles">
 		/// An enumerable of input source files that are already part of the local media source folder.
 		/// </param>
-		/// <returns></returns>
 		public static AssetImportOutput[] SimulateReImportAssets(IEnumerable<string> localInputFiles)
 		{
 			return ReImportAssets(localInputFiles, true);
@@ -189,7 +185,6 @@ namespace Duality.Editor.AssetManagement
 		/// </summary>
 		/// <param name="inputResource">The <see cref="Resource"/> to be exported.</param>
 		/// <param name="exportDir">The target directory that serves as a base for creating output source files.</param>
-		/// <returns></returns>
 		public static string[] ExportAssets(ContentRef<Resource> inputResource, string exportDir = null)
 		{
 			return ExportAssets(inputResource, exportDir, false);
@@ -199,7 +194,6 @@ namespace Duality.Editor.AssetManagement
 		/// </summary>
 		/// <param name="inputResource">The <see cref="Resource"/> to be exported.</param>
 		/// <param name="exportDir">The target directory that serves as a base for creating output source files.</param>
-		/// <returns></returns>
 		public static string[] SimulateExportAssets(ContentRef<Resource> inputResource, string exportDir = null)
 		{
 			return ExportAssets(inputResource, exportDir, true);
@@ -261,7 +255,6 @@ namespace Duality.Editor.AssetManagement
 		/// were used during the most recent import and can be re-used during export and re-import operations.
 		/// </summary>
 		/// <param name="resource"></param>
-		/// <returns></returns>
 		public static string[] GetAssetSourceFiles(ContentRef<Resource> resource)
 		{
 			// Early-out, if the input Resource isn't available

--- a/Source/Editor/DualityEditor/AssetManagement/Export/AssetExportOperation.cs
+++ b/Source/Editor/DualityEditor/AssetManagement/Export/AssetExportOperation.cs
@@ -90,7 +90,6 @@ namespace Duality.Editor.AssetManagement
 		/// <summary>
 		/// Performs the operation and returns whether it was successful.
 		/// </summary>
-		/// <returns></returns>
 		public bool Perform()
 		{
 			this.ResetWorkingData();
@@ -111,7 +110,6 @@ namespace Duality.Editor.AssetManagement
 		/// This can be used to determine which files would be affected when performing
 		/// the operation.
 		/// </summary>
-		/// <returns></returns>
 		public bool SimulatePerform()
 		{
 			this.ResetWorkingData();

--- a/Source/Editor/DualityEditor/AssetManagement/Import/AssetImportEnvironment.cs
+++ b/Source/Editor/DualityEditor/AssetManagement/Import/AssetImportEnvironment.cs
@@ -110,7 +110,6 @@ namespace Duality.Editor.AssetManagement
 		/// <summary>
 		/// Requests the specified input path to be handled by the current importer.
 		/// </summary>
-		/// <param name="inputPath"></param>
 		/// <returns>True, if the current importer is allowed to handle this input item, false if not.</returns>
 		public bool HandleInput(string filePath)
 		{
@@ -133,7 +132,6 @@ namespace Duality.Editor.AssetManagement
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="assetName">The name of the requested output <see cref="Duality.Resource"/> (see <see cref="AssetImportInput.AssetName"/>).</param>
-		/// <returns></returns>
 		public ContentRef<T> GetOutput<T>(string assetName) where T : Resource, new()
 		{
 			string targetResPath = this.GetTargetPath<T>(assetName);

--- a/Source/Editor/DualityEditor/AssetManagement/Import/IAssetImportEnvironment.cs
+++ b/Source/Editor/DualityEditor/AssetManagement/Import/IAssetImportEnvironment.cs
@@ -37,7 +37,6 @@ namespace Duality.Editor.AssetManagement
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="assetName">The name of the requested output <see cref="Duality.Resource"/> (see <see cref="AssetImportInput.AssetName"/>).</param>
-		/// <returns></returns>
 		ContentRef<T> GetOutput<T>(string assetName) where T : Resource, new();
 		/// <summary>
 		/// Specifies that the current importer will create or modify a <see cref="Duality.Resource"/> with 

--- a/Source/Editor/DualityEditor/Controls/PropertyEditors/PropertyEditorAssignmentAttribute.cs
+++ b/Source/Editor/DualityEditor/Controls/PropertyEditors/PropertyEditorAssignmentAttribute.cs
@@ -57,7 +57,6 @@ namespace Duality.Editor
 		/// </summary>
 		/// <param name="propertyType"></param>
 		/// <param name="context"></param>
-		/// <returns></returns>
 		public int MatchToProperty(Type propertyType, ProviderContext context)
 		{
 			if (this.dynamicAssign != null)

--- a/Source/Editor/DualityEditor/Controls/PropertyEditors/Provider.cs
+++ b/Source/Editor/DualityEditor/Controls/PropertyEditors/Provider.cs
@@ -33,7 +33,6 @@ namespace Duality.Editor.Controls.PropertyEditors
 		/// </summary>
 		/// <param name="baseType"></param>
 		/// <param name="context"></param>
-		/// <returns></returns>
 		public int IsResponsibleFor(Type baseType, ProviderContext context)
 		{
 			if (this.propertyEditorAssignments == null)
@@ -56,7 +55,6 @@ namespace Duality.Editor.Controls.PropertyEditors
 		/// </summary>
 		/// <param name="baseType"></param>
 		/// <param name="context"></param>
-		/// <returns></returns>
 		public PropertyEditor CreateEditor(Type baseType, ProviderContext context)
 		{
 			if (this.propertyEditorAssignments == null)

--- a/Source/Editor/DualityEditor/DualityEditorApp.cs
+++ b/Source/Editor/DualityEditor/DualityEditorApp.cs
@@ -404,7 +404,6 @@ namespace Duality.Editor
 		/// no such check is performed and all editor actions that match the other criteria are returned.
 		/// </param>
 		/// <param name="context">The context in which this action is performed.</param>
-		/// <returns></returns>
 		public static IEnumerable<IEditorAction> GetEditorActions(Type subjectType, IEnumerable<object> objects, string context = ActionContextMenu)
 		{
 			if (objects != null)

--- a/Source/Editor/DualityEditor/EditorPlugin.cs
+++ b/Source/Editor/DualityEditor/EditorPlugin.cs
@@ -37,7 +37,6 @@ namespace Duality.Editor
 		/// DockContent, a new an pre-setup instance or null as default.
 		/// </summary>
 		/// <param name="dockContentType"></param>
-		/// <returns></returns>
 		internal protected virtual IDockContent DeserializeDockContent(Type dockContentType) { return null; }
 	}
 }

--- a/Source/Editor/DualityEditor/EditorPluginManager.cs
+++ b/Source/Editor/DualityEditor/EditorPluginManager.cs
@@ -39,7 +39,6 @@ namespace Duality.Editor
 		/// Enumerates all currently loaded editor assemblies that are part of Duality, i.e. 
 		/// the editor Assembly itsself and all loaded plugins.
 		/// </summary>
-		/// <returns></returns>
 		public override IEnumerable<Assembly> GetAssemblies()
 		{
 			return this.editorAssemblies.Concat(base.GetAssemblies());
@@ -124,7 +123,6 @@ namespace Duality.Editor
 		/// a persistent type name to an instance of the desired type.
 		/// </summary>
 		/// <param name="typeName"></param>
-		/// <returns></returns>
 		public IDockContent DeserializeDockContent(string typeName)
 		{
 			// First ask plugins from the dock contents assembly for existing instances

--- a/Source/Editor/DualityEditor/Extensibility/DataConversion/ExtMethodsDataConverter.cs
+++ b/Source/Editor/DualityEditor/Extensibility/DataConversion/ExtMethodsDataConverter.cs
@@ -14,11 +14,6 @@ namespace Duality.Editor
 		/// Given a source <see cref="Resource"/> and matching function, this method finds an already existing
 		/// target <see cref="Resource"/> to be used in a <see cref="DataConverter"/> operation.
 		/// </summary>
-		/// <typeparam name="TTarget"></typeparam>
-		/// <typeparam name="TSource"></typeparam>
-		/// <param name="source"></param>
-		/// <param name="matchFunc"></param>
-		/// <returns></returns>
 		public static IEnumerable<TTarget> FindMatchingResources<TSource,TTarget>(this DataConverter conv, TSource source, Func<TSource,TTarget,bool> matchFunc) 
 			where TTarget : Resource 
 			where TSource : Resource

--- a/Source/Editor/DualityEditor/Extensibility/EditorActions/EditorAction.cs
+++ b/Source/Editor/DualityEditor/Extensibility/EditorActions/EditorAction.cs
@@ -87,7 +87,6 @@ namespace Duality.Editor
 		/// Returns whether the action matches the specified context.
 		/// </summary>
 		/// <param name="context"></param>
-		/// <returns></returns>
 		public virtual bool MatchesContext(string context)
 		{
 			return context == DualityEditorApp.ActionContextMenu;

--- a/Source/Editor/DualityEditor/Extensibility/EditorActions/EditorSingleAction.cs
+++ b/Source/Editor/DualityEditor/Extensibility/EditorActions/EditorSingleAction.cs
@@ -21,7 +21,6 @@ namespace Duality.Editor
 		/// Returns whether the action can be performed on the specified object.
 		/// </summary>
 		/// <param name="obj"></param>
-		/// <returns></returns>
 		public virtual bool CanPerformOn(T obj)
 		{
 			return true;

--- a/Source/Editor/DualityEditor/Extensibility/EditorActions/IEditorAction.cs
+++ b/Source/Editor/DualityEditor/Extensibility/EditorActions/IEditorAction.cs
@@ -43,7 +43,6 @@ namespace Duality.Editor
 		/// <summary>
 		/// Returns whether the action can be performed on the specified set of objects.
 		/// </summary>
-		/// <param name="objEnum"></param>
 		bool CanPerformOn(IEnumerable<object> obj);
 		/// <summary>
 		/// Returns whether or not this action matches the 

--- a/Source/Editor/DualityEditor/FileEventManager.cs
+++ b/Source/Editor/DualityEditor/FileEventManager.cs
@@ -222,7 +222,6 @@ namespace Duality.Editor
 		/// thus to be ignored when detecing file system changes.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		public static bool IsPathEditorModified(string path)
 		{
 			return editorModifiedFiles.Contains(Path.GetFullPath(path));

--- a/Source/Editor/DualityEditor/Forms/ReloadCorePluginDialog.cs
+++ b/Source/Editor/DualityEditor/Forms/ReloadCorePluginDialog.cs
@@ -496,7 +496,6 @@ namespace Duality.Editor.Forms
 		/// </summary>
 		/// <param name="pluginFilePath"></param>
 		/// <param name="assemblies"></param>
-		/// <returns></returns>
 		private static bool IsDependencyPlugin(string pluginFilePath, IEnumerable<Assembly> assemblies)
 		{
 			string asmName = Path.GetFileNameWithoutExtension(pluginFilePath);

--- a/Source/Editor/DualityEditor/PreviewProvider.cs
+++ b/Source/Editor/DualityEditor/PreviewProvider.cs
@@ -38,7 +38,6 @@ namespace Duality.Editor
 		/// <param name="desiredWidth">The desired width of the image</param>
 		/// <param name="desiredHeight">The desired height of the image</param>
 		/// <param name="mode">Determines how the image will be scaled or resized to match the given dimensions</param>
-		/// <returns></returns>
 		public static Bitmap GetPreviewImage(object obj, int desiredWidth, int desiredHeight, PreviewSizeMode mode = PreviewSizeMode.FixedNone)
 		{
 			if (desiredWidth <= 0) return null;
@@ -52,7 +51,6 @@ namespace Duality.Editor
 		/// Provides a suitable preview sound for the given object or null if none is available.
 		/// </summary>
 		/// <param name="obj">The object being previewed</param>
-		/// <returns></returns>
 		public static Sound GetPreviewSound(object obj)
 		{
 			PreviewSoundQuery query = new PreviewSoundQuery(obj);

--- a/Source/Editor/DualityEditor/UndoRedoManager.cs
+++ b/Source/Editor/DualityEditor/UndoRedoManager.cs
@@ -356,7 +356,6 @@ namespace Duality.Editor
 		/// Determines whether the specified action could be merged with this one.
 		/// </summary>
 		/// <param name="action"></param>
-		/// <returns></returns>
 		public virtual bool CanAppend(UndoRedoAction action)
 		{
 			return false;

--- a/Source/Editor/DualityEditor/Utility/EventArgs/FileSystemChangedEventArgs.cs
+++ b/Source/Editor/DualityEditor/Utility/EventArgs/FileSystemChangedEventArgs.cs
@@ -46,7 +46,6 @@ namespace Duality.Editor
 		/// multiple types, in which case any detected match will yield a "true" result.
 		/// </summary>
 		/// <param name="type"></param>
-		/// <returns></returns>
 		public bool Any(FileEventType type)
 		{
 			return 
@@ -60,7 +59,6 @@ namespace Duality.Editor
 		/// multiple types, in which case any detected match will yield a "true" result.
 		/// </summary>
 		/// <param name="type"></param>
-		/// <returns></returns>
 		public bool AnyFiles(FileEventType type)
 		{
 			return (this.fileEventTypes & type) != FileEventType.None;
@@ -72,7 +70,6 @@ namespace Duality.Editor
 		/// multiple types, in which case any detected match will yield a "true" result.
 		/// </summary>
 		/// <param name="type"></param>
-		/// <returns></returns>
 		public bool AnyDirectories(FileEventType type)
 		{
 			return (this.directoryEventTypes & type) != FileEventType.None;
@@ -86,7 +83,6 @@ namespace Duality.Editor
 		/// </summary>
 		/// <param name="type"></param>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		public bool Contains(FileEventType type, string path)
 		{
 			// Early-out to avoid iterating if we don't have anything of that type
@@ -109,7 +105,6 @@ namespace Duality.Editor
 		/// </summary>
 		/// <param name="type"></param>
 		/// <param name="paths"></param>
-		/// <returns></returns>
 		public bool Contains(FileEventType type, IEnumerable<string> paths)
 		{
 			// Early-out to avoid iterating if we don't have anything of that type

--- a/Source/Editor/DualityEditor/Utility/EventArgs/ObjectPropertyChangedEventArgs.cs
+++ b/Source/Editor/DualityEditor/Utility/EventArgs/ObjectPropertyChangedEventArgs.cs
@@ -65,7 +65,6 @@ namespace Duality.Editor
 		/// Determines whether the specified object has been modified.
 		/// </summary>
 		/// <param name="obj"></param>
-		/// <returns></returns>
 		public bool HasObject(object obj)
 		{
 			return this.obj.Contains(obj);
@@ -74,7 +73,6 @@ namespace Duality.Editor
 		/// Determines whether any of the specified objects has been modified.
 		/// </summary>
 		/// <param name="objEnum"></param>
-		/// <returns></returns>
 		public bool HasAnyObject(IEnumerable<object> objEnum)
 		{
 			return objEnum.Any(o => this.obj.Contains(o));
@@ -84,7 +82,6 @@ namespace Duality.Editor
 		/// Determines whether the specified property has been modified.
 		/// </summary>
 		/// <param name="info"></param>
-		/// <returns></returns>
 		public bool HasProperty(PropertyInfo info)
 		{
 			// If the property is mentioned explicitly, we have a match
@@ -103,7 +100,6 @@ namespace Duality.Editor
 		/// Determines whether any of the specified properties has been modified.
 		/// </summary>
 		/// <param name="info"></param>
-		/// <returns></returns>
 		public bool HasAnyProperty(params PropertyInfo[] info)
 		{
 			// If a property is mentioned explicitly, we have a match

--- a/Source/Editor/DualityEditor/Utility/EventArgs/ResourceFilesChangedEventArgs.cs
+++ b/Source/Editor/DualityEditor/Utility/EventArgs/ResourceFilesChangedEventArgs.cs
@@ -22,7 +22,6 @@ namespace Duality.Editor
 		/// </summary>
 		/// <param name="type"></param>
 		/// <param name="content"></param>
-		/// <returns></returns>
 		/// <seealso cref="FileSystemChangedEventArgs.Contains(FileEventType, string)"/>
 		public bool Contains(FileEventType type, Resource content)
 		{
@@ -34,7 +33,6 @@ namespace Duality.Editor
 		/// </summary>
 		/// <param name="type"></param>
 		/// <param name="content"></param>
-		/// <returns></returns>
 		/// <seealso cref="FileSystemChangedEventArgs.Contains(FileEventType, string)"/>
 		public bool Contains(FileEventType type, ContentRef<Resource> content)
 		{
@@ -45,7 +43,6 @@ namespace Duality.Editor
 		/// </summary>
 		/// <param name="type"></param>
 		/// <param name="content"></param>
-		/// <returns></returns>
 		/// <seealso cref="FileSystemChangedEventArgs.Contains(FileEventType, IEnumerable{string})"/>
 		public bool Contains(FileEventType type, IEnumerable<Resource> content)
 		{
@@ -64,7 +61,6 @@ namespace Duality.Editor
 		/// </summary>
 		/// <param name="type"></param>
 		/// <param name="content"></param>
-		/// <returns></returns>
 		/// <seealso cref="FileSystemChangedEventArgs.Contains(FileEventType, IEnumerable{string})"/>
 		public bool Contains(FileEventType type, IEnumerable<ContentRef<Resource>> content)
 		{
@@ -82,8 +78,6 @@ namespace Duality.Editor
 		/// Returns whether a change was made on a <see cref="Resource"/> of the specified type.
 		/// </summary>
 		/// <param name="type"></param>
-		/// <param name="content"></param>
-		/// <returns></returns>
 		/// <seealso cref="FileSystemChangedEventArgs.Contains(FileEventType, string)"/>
 		public bool Contains(FileEventType type, Type contentType)
 		{

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsBitmap.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsBitmap.cs
@@ -122,7 +122,6 @@ namespace Duality.Editor
 		/// <param name="w"></param>
 		/// <param name="h"></param>
 		/// <param name="mode"></param>
-		/// <returns></returns>
 		public static Bitmap ScaleToFit(this Bitmap bm, int w, int h, InterpolationMode mode = InterpolationMode.Bilinear)
 		{
 			Size imgSize = bm.Size;
@@ -157,7 +156,6 @@ namespace Duality.Editor
 		/// Measures the bounding rectangle of the opaque pixels in a Bitmap.
 		/// </summary>
 		/// <param name="bm"></param>
-		/// <returns></returns>
 		public static Rectangle OpaqueBounds(this Bitmap bm)
 		{
 			ColorRgba[] pixels = bm.GetPixelDataRgba();
@@ -182,7 +180,6 @@ namespace Duality.Editor
 		/// </summary>
 		/// <param name="bm"></param>
 		/// <param name="weightTransparent">If true, the alpha value weights a pixels color value. </param>
-		/// <returns></returns>
 		public static ColorRgba GetAverageColor(this Bitmap bm, bool weightTransparent = true)
 		{
 			float[] sum = new float[4];
@@ -231,7 +228,6 @@ namespace Duality.Editor
 		/// Extracts a Bitmaps pixel data.
 		/// </summary>
 		/// <param name="bm"></param>
-		/// <returns></returns>
 		public static ColorRgba[] GetPixelDataRgba(this Bitmap bm)
 		{
 			int[] argbValues = GetPixelDataIntArgb(bm);

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsControl.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsControl.cs
@@ -16,7 +16,6 @@ namespace Duality.Editor
 		/// <param name="control"></param>
 		/// <param name="globalPos"></param>
 		/// <param name="isOnActiveDropDown"></param>
-		/// <returns></returns>
 		public static ToolStripItem GetHoveredToolStripItem(this Control control, Point globalPos, out bool isOnActiveDropDown)
 		{
 			isOnActiveDropDown = false;

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsMemberInfoEditorHint.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsMemberInfoEditorHint.cs
@@ -13,7 +13,6 @@ namespace Duality.Editor
 		/// Returns the category tree which this Type prefers to be in.
 		/// </summary>
 		/// <param name="type"></param>
-		/// <returns></returns>
 		public static string[] GetEditorCategory(this Type type)
 		{
 			string[] tree = null;
@@ -29,7 +28,6 @@ namespace Duality.Editor
 		/// Return the preferred icon image representation of the specified Type.
 		/// </summary>
 		/// <param name="type"></param>
-		/// <returns></returns>
 		public static Image GetEditorImage(this Type type)
 		{
 			Image image = null;

--- a/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsToolStrip.cs
+++ b/Source/Editor/DualityEditor/Utility/Extensions/ExtMethodsToolStrip.cs
@@ -24,7 +24,6 @@ namespace Duality.Editor
 		/// Returns null, if no dropdown is active.
 		/// </summary>
 		/// <param name="toolstrip"></param>
-		/// <returns></returns>
 		public static ToolStripDropDownItem GetActiveDropDown(this ToolStrip toolstrip)
 		{
 			if (!toolstrip.Visible) return null;

--- a/Source/Editor/DualityEditor/Utility/PathHelper.cs
+++ b/Source/Editor/DualityEditor/Utility/PathHelper.cs
@@ -124,7 +124,6 @@ namespace Duality.Editor
 		/// </summary>
 		/// <param name="directoryPath"></param>
 		/// <param name="relativeToDir"></param>
-		/// <returns></returns>
 		public static string MakeDirectoryPathRelative(string directoryPath, string relativeToDir = ".")
 		{
 			string dummyFilePath = Path.Combine(directoryPath, "dummy.txt");
@@ -139,7 +138,6 @@ namespace Duality.Editor
 		/// Determines the mutual base directory of a set of paths.
 		/// </summary>
 		/// <param name="paths"></param>
-		/// <returns></returns>
 		public static string GetMutualBaseDirectory(IEnumerable<string> paths)
 		{
 			bool originalIsRooted = Path.IsPathRooted(paths.First());
@@ -162,7 +160,6 @@ namespace Duality.Editor
 		/// will be assumed that the path is visible.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		public static bool IsPathVisible(string path)
 		{
 			// First, check if the path contains an element that begins with a dot.
@@ -191,7 +188,6 @@ namespace Duality.Editor
 		/// be validly used to address one.
 		/// </summary>
 		/// <param name="path"></param>
-		/// <returns></returns>
 		[System.Diagnostics.DebuggerStepThrough]
 		public static bool IsPathValid(string path)
 		{
@@ -207,7 +203,6 @@ namespace Duality.Editor
 		/// <param name="targetPath"></param>
 		/// <param name="overwrite"></param>
 		/// <param name="filter"></param>
-		/// <returns></returns>
 		public static bool CopyDirectory(string sourcePath, string targetPath, bool overwrite = false, Predicate<string> filter = null)
 		{
 			if (!Directory.Exists(sourcePath)) return false;
@@ -252,7 +247,6 @@ namespace Duality.Editor
 		/// </summary>
 		/// <param name="filePathA"></param>
 		/// <param name="filePathB"></param>
-		/// <returns></returns>
 		public static bool FilesEqual(string filePathA, string filePathB)
 		{
 			filePathA = Path.GetFullPath(filePathA);

--- a/Source/Editor/DualityEditor/Utility/RecycleBin.cs
+++ b/Source/Editor/DualityEditor/Utility/RecycleBin.cs
@@ -21,7 +21,7 @@ namespace Duality.Editor
         /// <summary>
         /// Send file to recycle bin
         /// </summary>
-        /// <param name="path">Location of directory or file to recycle</param>
+        /// <param name="paths">Location of directory or file to recycle</param>
         /// <param name="flags">FileOperationFlags to add in addition to FOF_ALLOWUNDO</param>
         private static bool Send(IEnumerable<string> paths, NativeMethods.FileOperationFlags flags)
         {

--- a/Source/Platform/DefaultOpenTK/Backend/Audio/AudioBackend.cs
+++ b/Source/Platform/DefaultOpenTK/Backend/Audio/AudioBackend.cs
@@ -323,7 +323,6 @@ namespace Duality.Backend.DefaultOpenTK
 		/// <summary>
 		/// Checks for OpenAL errors using <see cref="CheckOpenALErrors"/> when both compiled in debug mode and a with an attached debugger.
 		/// </summary>
-		/// <returns></returns>
 		[System.Diagnostics.Conditional("DEBUG")]
 		public static void DebugCheckOpenALErrors([CallerMemberName] string callerInfoMember = null, [CallerFilePath] string callerInfoFile = null, [CallerLineNumber] int callerInfoLine = -1)
 		{

--- a/Source/Platform/DefaultOpenTK/Backend/Graphics/GraphicsBackend.cs
+++ b/Source/Platform/DefaultOpenTK/Backend/Graphics/GraphicsBackend.cs
@@ -941,7 +941,6 @@ namespace Duality.Backend.DefaultOpenTK
 		/// <summary>
 		/// Checks for OpenGL errors using <see cref="CheckOpenGLErrors"/> when both compiled in debug mode and a with an attached debugger.
 		/// </summary>
-		/// <returns></returns>
 		[System.Diagnostics.Conditional("DEBUG")]
 		public static void DebugCheckOpenGLErrors([CallerMemberName] string callerInfoMember = null, [CallerFilePath] string callerInfoFile = null, [CallerLineNumber] int callerInfoLine = -1)
 		{

--- a/Source/Platform/DefaultOpenTK/Backend/Graphics/GraphicsModeComparer.cs
+++ b/Source/Platform/DefaultOpenTK/Backend/Graphics/GraphicsModeComparer.cs
@@ -13,7 +13,6 @@ namespace Duality.Backend.DefaultOpenTK
 		/// </summary>
 		/// <param name="x"></param>
 		/// <param name="y"></param>
-		/// <returns></returns>
 		public bool Equals(GraphicsMode x, GraphicsMode y)
 		{
 			return 
@@ -29,7 +28,6 @@ namespace Duality.Backend.DefaultOpenTK
 		/// Returns the hash code of a GraphicsMode.
 		/// </summary>
 		/// <param name="obj"></param>
-		/// <returns></returns>
 		public int GetHashCode(GraphicsMode obj)
 		{
 			return 

--- a/Source/Platform/DefaultOpenTK/Backend/Graphics/NativeShaderProgram.cs
+++ b/Source/Platform/DefaultOpenTK/Backend/Graphics/NativeShaderProgram.cs
@@ -163,7 +163,6 @@ namespace Duality.Backend.DefaultOpenTK
 		/// Returns -1, if no match was found.
 		/// </summary>
 		/// <param name="element"></param>
-		/// <returns></returns>
 		public int SelectField(ref VertexElement element)
 		{
 			// Check for fields matching the elements preferred name

--- a/Source/Platform/DefaultOpenTK/Backend/Graphics/OpenTKGraphicsCapabilities.cs
+++ b/Source/Platform/DefaultOpenTK/Backend/Graphics/OpenTKGraphicsCapabilities.cs
@@ -160,7 +160,6 @@ namespace Duality.Backend.DefaultOpenTK
 		/// </summary>
 		/// <param name="versionString"></param>
 		/// <param name="version"></param>
-		/// <returns></returns>
 		protected bool TryParseVersionString(string versionString, out Version version)
 		{
 			version = new Version();

--- a/Source/Platform/DefaultOpenTKEditor/Backend/GraphicsModeComparer.cs
+++ b/Source/Platform/DefaultOpenTKEditor/Backend/GraphicsModeComparer.cs
@@ -13,7 +13,6 @@ namespace Duality.Editor.Backend.DefaultOpenTK
 		/// </summary>
 		/// <param name="x"></param>
 		/// <param name="y"></param>
-		/// <returns></returns>
 		public bool Equals(GraphicsMode x, GraphicsMode y)
 		{
 			return 
@@ -29,7 +28,6 @@ namespace Duality.Editor.Backend.DefaultOpenTK
 		/// Returns the hash code of a GraphicsMode.
 		/// </summary>
 		/// <param name="obj"></param>
-		/// <returns></returns>
 		public int GetHashCode(GraphicsMode obj)
 		{
 			return 

--- a/Source/Plugins/EditorBase/EditorActions/AudioDataToSound.cs
+++ b/Source/Plugins/EditorBase/EditorActions/AudioDataToSound.cs
@@ -36,7 +36,6 @@ namespace Duality.Editor.Plugins.Base.EditorActions
 		/// </summary>
 		/// <param name="baseRes"></param>
 		/// <param name="name"></param>
-		/// <returns></returns>
 		private static ContentRef<Sound> CreateFromAudioData(IEnumerable<ContentRef<AudioData>> baseRes, string name = null)
 		{
 			if (!baseRes.Any()) return null;
@@ -54,7 +53,6 @@ namespace Duality.Editor.Plugins.Base.EditorActions
 		/// The incoming AudioData is automatically grouped to the least number of Sounds, according to naming and path conventions.
 		/// </summary>
 		/// <param name="baseRes"></param>
-		/// <returns></returns>
 		public static List<ContentRef<Sound>> CreateMultipleFromAudioData(IEnumerable<ContentRef<AudioData>> baseRes)
 		{
 			char[] trimEndChars = new []{'0','1','2','3','4','5','6','7','8','9','_','-','.','#','~'};

--- a/Source/Plugins/EditorBase/Forms/PixmapSlicer/Utilities/PixmapSlicingUtility.cs
+++ b/Source/Plugins/EditorBase/Forms/PixmapSlicer/Utilities/PixmapSlicingUtility.cs
@@ -14,7 +14,6 @@ namespace Duality.Editor.Plugins.Base
 		/// <param name="columns"></param>
 		/// <param name="rows"></param>
 		/// <param name="frameBorder"></param>
-		/// <returns></returns>
 		public static List<Rect> SliceGrid(Pixmap pixmap, int columns, int rows, int frameBorder)
 		{
 			List<Rect> rects = new List<Rect>();

--- a/Source/Plugins/EditorBase/PropertyEditors/ResourceAssetPropertyEditor.cs
+++ b/Source/Plugins/EditorBase/PropertyEditors/ResourceAssetPropertyEditor.cs
@@ -253,7 +253,6 @@ namespace Duality.Editor.Plugins.Base.PropertyEditors
 		/// from the currently selected objects and with the given key.
 		/// </summary>
 		/// <param name="key"></param>
-		/// <returns></returns>
 		private Func<IEnumerable<object>> CreatePropertyValueGetter(string key)
 		{
 			return () =>
@@ -279,7 +278,6 @@ namespace Duality.Editor.Plugins.Base.PropertyEditors
 		/// from the currently selected objects and with the given key.
 		/// </summary>
 		/// <param name="key"></param>
-		/// <returns></returns>
 		private Action<IEnumerable<object>> CreatePropertyValueSetter(string key)
 		{
 			return delegate(IEnumerable<object> values)
@@ -311,7 +309,6 @@ namespace Duality.Editor.Plugins.Base.PropertyEditors
 		/// </summary>
 		/// <param name="localPos"></param>
 		/// <param name="captured"></param>
-		/// <returns></returns>
 		HelpInfo IHelpProvider.ProvideHoverHelp(Point localPos, ref bool captured)
 		{
 			return HelpInfo.FromMember(typeof(AssetInfo));

--- a/Source/Plugins/EditorBase/PropertyEditors/ResourceImportExportPropertyEditor.cs
+++ b/Source/Plugins/EditorBase/PropertyEditors/ResourceImportExportPropertyEditor.cs
@@ -281,7 +281,6 @@ namespace Duality.Editor.Plugins.Base.PropertyEditors
 		/// </summary>
 		/// <param name="localPos"></param>
 		/// <param name="captured"></param>
-		/// <returns></returns>
 		HelpInfo IHelpProvider.ProvideHoverHelp(Point localPos, ref bool captured)
 		{
 			HelpInfo result = null;

--- a/Source/Plugins/EditorModules/CamView/CamViewPlugin.cs
+++ b/Source/Plugins/EditorModules/CamView/CamViewPlugin.cs
@@ -85,8 +85,6 @@ namespace Duality.Editor.Plugins.CamView
 		/// Switches an existing <see cref="CamView"/> to the specified <see cref="CamViewState"/> type id,
 		/// or creates a new one, should none exist that is allowed to switch.
 		/// </summary>
-		/// <param name="camViewState"></param>
-		/// <returns></returns>
 		public CamView CreateOrSwitchCamView(string stateTypeId)
 		{
 			Type stateType = ReflectionHelper.ResolveType(stateTypeId) ?? typeof(CamViewStates.SceneEditorCamViewState);
@@ -97,7 +95,6 @@ namespace Duality.Editor.Plugins.CamView
 		/// or creates a new one, should none exist that is allowed to switch.
 		/// </summary>
 		/// <param name="camViewState"></param>
-		/// <returns></returns>
 		public CamView CreateOrSwitchCamView(Type camViewState)
 		{
 			// Search for existing cam views already using the requested state
@@ -122,7 +119,6 @@ namespace Duality.Editor.Plugins.CamView
 		/// Creates a new <see cref="CamView"/> and initializes it with the specified <see cref="CamViewState"/>.
 		/// </summary>
 		/// <param name="initStateTypeId"></param>
-		/// <returns></returns>
 		public CamView CreateCamView(string initStateTypeId = null)
 		{
 			CamView cam = new CamView(this.camViews.Count, initStateTypeId);

--- a/Source/Plugins/EditorModules/CamView/CamViewStates/ObjectEditor/ObjectEditorCamViewState.cs
+++ b/Source/Plugins/EditorModules/CamView/CamViewStates/ObjectEditor/ObjectEditorCamViewState.cs
@@ -253,7 +253,6 @@ namespace Duality.Editor.Plugins.CamView.CamViewStates
 		/// <param name="baseVec">The base vector without any locking in place.</param>
 		/// <param name="lockedVec">A reference vector that represents the base vector being locked to all axes at once.</param>
 		/// <param name="beginToTarget">The movement vector to evaluate in order to determine the axes to which the base vector will be locked.</param>
-		/// <returns></returns>
 		protected Vector3 ApplyAxisLock(Vector3 baseVec, Vector3 lockedVec, Vector3 beginToTarget)
 		{
 			bool shift = (Control.ModifierKeys & Keys.Shift) != Keys.None;

--- a/Source/Plugins/EditorModules/CamView/CamViewStates/RigidBodyEditor/IRigidBodyEditorToolEnvironment.cs
+++ b/Source/Plugins/EditorModules/CamView/CamViewStates/RigidBodyEditor/IRigidBodyEditorToolEnvironment.cs
@@ -12,7 +12,7 @@ namespace Duality.Editor.Plugins.CamView.CamViewStates
 {
 	/// <summary>
 	/// Provides an interface for <see cref="RigidBodyEditorTool"/> instances to access 
-	/// <see="RigidBodyEditorCamViewState"/> internals and perform editing operations.
+	/// <see cref="RigidBodyEditorCamViewState"/> internals and perform editing operations.
 	/// </summary>
 	public interface IRigidBodyEditorToolEnvironment
 	{
@@ -88,26 +88,22 @@ namespace Duality.Editor.Plugins.CamView.CamViewStates
 		/// </summary>
 		/// <param name="worldPos"></param>
 		/// <param name="radius"></param>
-		/// <returns></returns>
 		bool IsSphereInView(Vector3 worldPos, float radius = 1.0f);
 		/// <summary>
 		/// Determins the view scale at a given world space Z position.
 		/// </summary>
 		/// <param name="z"></param>
-		/// <returns></returns>
 		float GetScaleAtZ(float z);
 		/// <summary>
 		/// Determins the world space position of a given point in screen space.
 		/// The Z coordinate of that point will be evaluated as the assumed Z position.
 		/// </summary>
 		/// <param name="screenPos"></param>
-		/// <returns></returns>
 		Vector3 GetWorldPos(Vector3 screenPos);
 		/// <summary>
 		/// Determines the screen space position of a given point in world space.
 		/// </summary>
 		/// <param name="worldPos"></param>
-		/// <returns></returns>
 		Vector2 GetScreenPos(Vector3 worldPos);
 	}
 }

--- a/Source/Plugins/EditorModules/CamView/CamViewStates/RigidBodyEditor/RigidBodyEditorTool.cs
+++ b/Source/Plugins/EditorModules/CamView/CamViewStates/RigidBodyEditor/RigidBodyEditorTool.cs
@@ -109,7 +109,6 @@ namespace Duality.Editor.Plugins.CamView.CamViewStates
 		/// While performing a continuous operation, this method can provide an optional
 		/// action text that will be displayed in the status area of the <see cref="RigidBody"/> editor.
 		/// </summary>
-		/// <returns></returns>
 		public virtual string GetActionText()
 		{
 			return null;
@@ -118,7 +117,6 @@ namespace Duality.Editor.Plugins.CamView.CamViewStates
 		/// Checks whether this tool can start a continuous operation given the specified
 		/// user input and environment state.
 		/// </summary>
-		/// <returns></returns>
 		public virtual bool CanBeginAction(MouseButtons mouseButton)
 		{
 			return false;

--- a/Source/Plugins/EditorModules/CamView/Modules/EditingGuide.cs
+++ b/Source/Plugins/EditorModules/CamView/Modules/EditingGuide.cs
@@ -34,7 +34,6 @@ namespace Duality.Editor.Plugins.CamView
 		/// Snaps the specified world position to this editing guide.
 		/// </summary>
 		/// <param name="pos"></param>
-		/// <returns></returns>
 		public Vector3 SnapPosition(Vector3 pos)
 		{
 			Vector3 localPos = (pos - this.snapPosOrigin) / this.snapScaleOrigin;
@@ -51,7 +50,6 @@ namespace Duality.Editor.Plugins.CamView
 		/// Snaps the specified world position to this editing guide.
 		/// </summary>
 		/// <param name="pos"></param>
-		/// <returns></returns>
 		public Vector2 SnapPosition(Vector2 pos)
 		{
 			return this.SnapPosition(new Vector3(pos)).Xy;
@@ -61,7 +59,6 @@ namespace Duality.Editor.Plugins.CamView
 		/// Snaps the specified size value according to match this editing guide.
 		/// </summary>
 		/// <param name="size"></param>
-		/// <returns></returns>
 		public Vector3 SnapSize(Vector3 size)
 		{
 			size /= this.snapScaleOrigin;
@@ -74,7 +71,6 @@ namespace Duality.Editor.Plugins.CamView
 		/// Snaps the specified size value according to match this editing guide.
 		/// </summary>
 		/// <param name="size"></param>
-		/// <returns></returns>
 		public Vector2 SnapSize(Vector2 size)
 		{
 			return this.SnapSize(new Vector3(size)).Xy;
@@ -83,7 +79,6 @@ namespace Duality.Editor.Plugins.CamView
 		/// Snaps the specified size value according to match this editing guide.
 		/// </summary>
 		/// <param name="size"></param>
-		/// <returns></returns>
 		public float SnapSize(float size)
 		{
 			float snapOrigin = 1.0f;

--- a/Source/Plugins/EditorModules/CamView/Modules/GameObjectTypeFilter.cs
+++ b/Source/Plugins/EditorModules/CamView/Modules/GameObjectTypeFilter.cs
@@ -38,7 +38,6 @@ namespace Duality.Editor.Plugins.CamView
 		/// <see cref="Component"/> types, or if the filter is empty.
 		/// </summary>
 		/// <param name="obj"></param>
-		/// <returns></returns>
 		public bool Matches(GameObject obj)
 		{
 			if (this.typeIds.Count == 0) return true;
@@ -56,7 +55,6 @@ namespace Duality.Editor.Plugins.CamView
 		/// Returns true, if the specified <see cref="Type"/> is considered a match.
 		/// </summary>
 		/// <param name="type"></param>
-		/// <returns></returns>
 		public bool Matches(Type type)
 		{
 			this.UpdateTypeCache();
@@ -84,7 +82,6 @@ namespace Duality.Editor.Plugins.CamView
 		/// </summary>
 		/// <param name="objectType"></param>
 		/// <param name="isMatch"></param>
-		/// <returns></returns>
 		public bool SetTypeMatches(Type objectType, bool isMatch)
 		{
 			string objectTypeId = objectType.GetTypeId();

--- a/Source/Plugins/Tilemaps/Core/Tilemaps/Components/ICmpTilemapRenderer.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilemaps/Components/ICmpTilemapRenderer.cs
@@ -48,21 +48,18 @@ namespace Duality.Plugins.Tilemaps
 		/// </summary>
 		/// <param name="localPos"></param>
 		/// <param name="pickMode">Specifies the desired behavior when attempting to get a tile outside the rendered area.</param>
-		/// <returns></returns>
 		Point2 GetTileAtLocalPos(Vector2 localPos, TilePickMode pickMode);
 		/// <summary>
 		/// Gets the local position of the specified tile at the upper left corner.
 		/// The function does not check if the point is a valid tile position.
 		/// </summary>
 		/// <param name="tilePos">The index of the tile of which to calculate the local position.</param>
-		/// <returns></returns>
 		Vector2 GetLocalPosAtTile(Point2 tilePos);
 		/// <summary>
 		/// Determines the generated depth offset for the tile at the specified tile coordinates.
 		/// This also inclues the renderers overall depth offset.
 		/// </summary>
 		/// <param name="tilePos">The index of the tile of which to calculate the depth offset.</param>
-		/// <returns></returns>
 		float GetTileDepthOffsetAt(Point2 tilePos);
 	}
 }

--- a/Source/Plugins/Tilemaps/Core/Tilemaps/Components/TilemapRenderer.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilemaps/Components/TilemapRenderer.cs
@@ -179,7 +179,6 @@ namespace Duality.Plugins.Tilemaps
 		/// </summary>
 		/// <param name="localPos"></param>
 		/// <param name="pickMode">Specifies the desired behavior when attempting to get a tile outside the rendered area.</param>
-		/// <returns></returns>
 		public Point2 GetTileAtLocalPos(Vector2 localPos, TilePickMode pickMode)
 		{
 			// Early-out, if the specified local position is not within the tilemap rect
@@ -215,7 +214,6 @@ namespace Duality.Plugins.Tilemaps
 		/// The function does not check if the point is a valid tile position.
 		/// </summary>
 		/// <param name="tilePos">The index of the tile of which to calculate the local position.</param>
-		/// <returns></returns>
 		public Vector2 GetLocalPosAtTile(Point2 tilePos)
 		{
 			Rect localRect = this.LocalTilemapRect;
@@ -233,7 +231,6 @@ namespace Duality.Plugins.Tilemaps
 		/// is considered virtual and does not have to be within the valid tile position range.
 		/// </summary>
 		/// <param name="tilePos">The index of the tile of which to calculate the depth offset.</param>
-		/// <returns></returns>
 		public float GetTileDepthOffsetAt(Point2 tilePos)
 		{
 			if (this.tileDepthMode == TileDepthOffsetMode.Flat)

--- a/Source/Plugins/Tilemaps/Core/Tilemaps/Tile.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilemaps/Tile.cs
@@ -203,13 +203,6 @@ namespace Duality.Plugins.Tilemaps
 		/// <summary>
 		/// Resolves the <see cref="Index"/> values of the specified <see cref="Tile"/> grid area, given the grid's raw data block.
 		/// </summary>
-		/// <param name="tileGridData"></param>
-		/// <param name="beginX"></param>
-		/// <param name="beginY"></param>
-		/// <param name="width"></param>
-		/// <param name="height"></param>
-		/// <param name="stride"></param>
-		/// <param name="tilesetRes"></param>
 		public static void ResolveIndices(Tile[] tileGridData, int stride, int beginX, int beginY, int width, int height, ContentRef<Tileset> tileset)
 		{
 			if (tileset.Res == null) throw new ArgumentNullException("tileset");
@@ -250,13 +243,6 @@ namespace Duality.Plugins.Tilemaps
 		/// Updates the <see cref="AutoTileCon"/> state of an arbitrary region on the specified tile grid
 		/// based on its connectivity state with neighbouring tiles.
 		/// </summary>
-		/// <param name="tileGrid"></param>
-		/// <param name="updateMask"></param>
-		/// <param name="beginX"></param>
-		/// <param name="beginY"></param>
-		/// <param name="width"></param>
-		/// <param name="height"></param>
-		/// <param name="tilesetRes"></param>
 		public static void UpdateAutoTileCon(Grid<Tile> tileGrid, Grid<bool> updateMask, int beginX, int beginY, int width, int height, ContentRef<Tileset> tileset)
 		{
 			if (tileset.Res == null) throw new ArgumentNullException("tileset");

--- a/Source/Plugins/Tilemaps/Core/Tilemaps/TileEdgemap.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilemaps/TileEdgemap.cs
@@ -84,7 +84,6 @@ namespace Duality.Plugins.Tilemaps
 		/// </summary>
 		/// <param name="from"></param>
 		/// <param name="to"></param>
-		/// <returns></returns>
 		public bool HasEdge(Point2 from, Point2 to)
 		{
 			Connection con = GetConnection(new Point2(to.X - from.X, to.Y - from.Y));
@@ -96,7 +95,6 @@ namespace Duality.Plugins.Tilemaps
 		/// Returns (-1, -1) if no neighbour is connected.
 		/// </summary>
 		/// <param name="from"></param>
-		/// <returns></returns>
 		public Point2 GetClockwiseNextFrom(Point2 from)
 		{
 			Connection con = this.connections[from.X, from.Y];
@@ -116,7 +114,6 @@ namespace Duality.Plugins.Tilemaps
 		/// Finds the first node that is connected to any other node.
 		/// Returns (-1, -1) if no node is connected to any other.
 		/// </summary>
-		/// <returns></returns>
 		public Point2 FindNonEmpty()
 		{
 			return this.connections.FindIndex(c => c != Connection.None);

--- a/Source/Plugins/Tilemaps/Core/Tilemaps/TilemapCulling.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilemaps/TilemapCulling.cs
@@ -82,7 +82,6 @@ namespace Duality.Plugins.Tilemaps
 		/// </summary>
 		/// <param name="device"></param>
 		/// <param name="input"></param>
-		/// <returns></returns>
 		public static TileOutput GetVisibleTileRect(IDrawDevice device, TileInput input)
 		{
 			TileOutput output;

--- a/Source/Plugins/Tilemaps/Core/Tilesets/TileCollisionShapes.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilesets/TileCollisionShapes.cs
@@ -33,7 +33,6 @@ namespace Duality.Plugins.Tilemaps
 		/// [GET / SET] The collision shape on a given layer index from zero to (<see cref="LayerCount"/> - 1).
 		/// </summary>
 		/// <param name="layerIndex"></param>
-		/// <returns></returns>
 		public TileCollisionShape this[int layerIndex]
 		{
 			get
@@ -63,7 +62,6 @@ namespace Duality.Plugins.Tilemaps
 		/// [GET] The collision shape on the specified (set of) layer(s).
 		/// </summary>
 		/// <param name="layerMask"></param>
-		/// <returns></returns>
 		public TileCollisionShape this[TileCollisionLayer layerMask]
 		{
 			get

--- a/Source/Plugins/Tilemaps/Core/Tilesets/Tileset.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilesets/Tileset.cs
@@ -293,8 +293,6 @@ namespace Duality.Plugins.Tilemaps
 		/// Determines the <see cref="Compile"/>-relevant hash code of the specified <see cref="Tileset"/>.
 		/// This value is used internally to determine whether a <see cref="Tileset"/> needs to be recompiled.
 		/// </summary>
-		/// <param name="tileset"></param>
-		/// <returns></returns>
 		public int GetCompileHashCode()
 		{
 			int hash = 17;

--- a/Source/Plugins/Tilemaps/Core/Tilesets/TilesetAutoTileFallbackMap.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilesets/TilesetAutoTileFallbackMap.cs
@@ -52,7 +52,6 @@ namespace Duality.Plugins.Tilemaps
 		/// subtile quadrant of an AutoTile.
 		/// </summary>
 		/// <param name="quadrant"></param>
-		/// <returns></returns>
 		public TileConnection GetSubTileMask(TileQuadrant quadrant)
 		{
 			switch (quadrant)
@@ -76,7 +75,6 @@ namespace Duality.Plugins.Tilemaps
 		/// https://cloud.githubusercontent.com/assets/14859411/11279962/ccc1ac2e-8ef3-11e5-8e99-861b0d7a1c9a.png
 		/// </summary>
 		/// <param name="connection"></param>
-		/// <returns></returns>
 		public TileConnection GetBaseConnectivity(TileConnection connection)
 		{
 			return this.tileToBasePermutation[(int)connection];
@@ -87,7 +85,6 @@ namespace Duality.Plugins.Tilemaps
 		/// with the specified connectivity is available.
 		/// </summary>
 		/// <param name="connection"></param>
-		/// <returns></returns>
 		public IReadOnlyList<TileConnection> GetFallback(TileConnection connection)
 		{
 			return this.tileToFallbackList[(int)connection] ?? NoFallbacks;
@@ -244,7 +241,6 @@ namespace Duality.Plugins.Tilemaps
 		/// Generates a transitive fallback map where each item is a sorted list of all items in the items fallback chain.
 		/// </summary>
 		/// <param name="directMap"></param>
-		/// <returns></returns>
 		private static TileConnection[][] CreateTransitiveMap(TileConnection[] directMap)
 		{
 			TileConnection[][] transitiveMap = new TileConnection[StateCount][];

--- a/Source/Plugins/Tilemaps/Core/Tilesets/TilesetAutoTileInfo.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilesets/TilesetAutoTileInfo.cs
@@ -50,6 +50,7 @@ namespace Duality.Plugins.Tilemaps
 		/// of the border tile to use in this connectivity setup. This array is not copied. If you plan
 		/// to re-use it, pass a copy as a parameter.
 		/// </param>
+		/// <param name="tileInfo"></param>
 		public TilesetAutoTileInfo(int baseTile, int[] stateToTile, TilesetAutoTileItem[] tileInfo)
 		{
 			if (stateToTile == null) throw new ArgumentNullException("stateToTile");

--- a/Source/Plugins/Tilemaps/Core/Tilesets/TilesetCompiler.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilesets/TilesetCompiler.cs
@@ -218,7 +218,6 @@ namespace Duality.Plugins.Tilemaps
 		/// <param name="topRightIndex"></param>
 		/// <param name="bottomRightIndex"></param>
 		/// <param name="bottomLeftIndex"></param>
-		/// <returns></returns>
 		private int ScheduleGenerateTile(int baseTileIndex, int topLeftIndex, int topRightIndex, int bottomRightIndex, int bottomLeftIndex)
 		{
 			GeneratedQuadTile generatedTile = new GeneratedQuadTile
@@ -269,7 +268,6 @@ namespace Duality.Plugins.Tilemaps
 		/// while also collecting information on generated tiles and connectivity state mappings.
 		/// </summary>
 		/// <param name="autoTileConfig"></param>
-		/// <returns></returns>
 		private void GatherAutoTileData(IReadOnlyList<TilesetAutoTileInput> autoTileConfig)
 		{
 			for (int autoTileIndex = 0; autoTileIndex < autoTileConfig.Count; autoTileIndex++)
@@ -395,7 +393,6 @@ namespace Duality.Plugins.Tilemaps
 		/// </summary>
 		/// <param name="renderInput"></param>
 		/// <param name="layerData"></param>
-		/// <returns></returns>
 		private LayerGeometry CalculateLayerGeometry(TilesetRenderInput renderInput, PixelData layerData)
 		{
 			LayerGeometry geometry;
@@ -424,11 +421,6 @@ namespace Duality.Plugins.Tilemaps
 		/// <summary>
 		/// Composes pixel and atlas data for a single <see cref="Tileset"/> visual layer.
 		/// </summary>
-		/// <param name="renderInput"></param>
-		/// <param name="sourceData"></param>
-		/// <param name="geometry"></param>
-		/// <param name="tileData"></param>
-		/// <returns></returns>
 		private LayerPixelData ComposeLayerPixelData(TilesetRenderInput renderInput, PixelData sourceData, LayerGeometry geometry)
 		{
 			// Create a buffer for writing target pixel data
@@ -693,7 +685,6 @@ namespace Duality.Plugins.Tilemaps
 		/// <param name="data"></param>
 		/// <param name="pos"></param>
 		/// <param name="size"></param>
-		/// <returns></returns>
 		private static bool IsCompletelyTransparent(PixelData data, Point2 pos, Point2 size)
 		{
 			for (int y = pos.Y; y < pos.Y + size.Y; y++)
@@ -714,7 +705,6 @@ namespace Duality.Plugins.Tilemaps
 		/// <param name="quadrant"></param>
 		/// <param name="targetConnectivity"></param>
 		/// <param name="isStateAvailable"></param>
-		/// <returns></returns>
 		private static TileConnection FindGeneratedAutoTileBase(TileQuadrant quadrant, TileConnection targetConnectivity, bool[] isStateAvailable)
 		{
 			TileConnection mask = AutoTileFallbackMap.GetSubTileMask(quadrant);
@@ -757,7 +747,6 @@ namespace Duality.Plugins.Tilemaps
 		/// Counts the number of connected neighbours in the specified connectivity state.
 		/// </summary>
 		/// <param name="connectivity"></param>
-		/// <returns></returns>
 		private static int GetConnectedNeighbours(TileConnection connectivity)
 		{
 			// See here: https://stackoverflow.com/questions/12171584/what-is-the-fastest-way-to-count-set-bits-in-uint32

--- a/Source/Plugins/Tilemaps/Core/Tilesets/TilesetRenderInput.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilesets/TilesetRenderInput.cs
@@ -147,7 +147,6 @@ namespace Duality.Plugins.Tilemaps
 		/// </summary>
 		/// <param name="sourceImageWidth"></param>
 		/// <param name="sourceImageHeight"></param>
-		/// <returns></returns>
 		public Point2 GetSourceTileCount(int sourceImageWidth, int sourceImageHeight)
 		{
 			Point2 advance = this.SourceTileAdvance;

--- a/Source/Plugins/Tilemaps/Editor/EditorPlugin.cs
+++ b/Source/Plugins/Tilemaps/Editor/EditorPlugin.cs
@@ -165,7 +165,6 @@ namespace Duality.Editor.Plugins.Tilemaps
 		/// <summary>
 		/// Informs the system that a <see cref="TilemapToolSourcePalette"/> is required and creates one, if none is present yet.
 		/// </summary>
-		/// <returns></returns>
 		public TilemapToolSourcePalette PushTilePalette()
 		{
 			this.pendingLocalTilePalettes++;
@@ -239,7 +238,6 @@ namespace Duality.Editor.Plugins.Tilemaps
 		/// to account for potential changes.
 		/// </summary>
 		/// <param name="pixmapRef"></param>
-		/// <returns></returns>
 		private List<Tileset> GetRecompileTilesets(ContentRef<Pixmap> pixmapRef)
 		{
 			List<Tileset> recompileTilesets = new List<Tileset>();

--- a/Source/Plugins/Tilemaps/Editor/Modules/TilesetView.cs
+++ b/Source/Plugins/Tilemaps/Editor/Modules/TilesetView.cs
@@ -319,7 +319,6 @@ namespace Duality.Editor.Plugins.Tilemaps
 		/// <param name="y"></param>
 		/// <param name="scrolled"></param>
 		/// <param name="allowNearest"></param>
-		/// <returns></returns>
 		public int PickTileIndexAt(int x, int y, bool scrolled = true, bool allowNearest = false)
 		{
 			if (scrolled)
@@ -403,7 +402,6 @@ namespace Duality.Editor.Plugins.Tilemaps
 		/// </summary>
 		/// <param name="tileIndex"></param>
 		/// <param name="scrolled"></param>
-		/// <returns></returns>
 		public Point GetTileIndexLocation(int tileIndex, bool scrolled = true)
 		{
 			Point result = this.ClientRectangle.Location;
@@ -446,7 +444,6 @@ namespace Duality.Editor.Plugins.Tilemaps
 		/// </summary>
 		/// <param name="displayedTileX"></param>
 		/// <param name="displayedTileY"></param>
-		/// <returns></returns>
 		public Point GetTilesetTilePos(int displayedTileX, int displayedTileY)
 		{
 			int rowIndex = displayedTileY;
@@ -473,7 +470,6 @@ namespace Duality.Editor.Plugins.Tilemaps
 		/// </summary>
 		/// <param name="tilesetTileX"></param>
 		/// <param name="tilesetTileY"></param>
-		/// <returns></returns>
 		public Point GetDisplayedTilePos(int tilesetTileX, int tilesetTileY)
 		{
 			int rowIndex = tilesetTileY;
@@ -501,7 +497,6 @@ namespace Duality.Editor.Plugins.Tilemaps
 		/// </summary>
 		/// <param name="tileX"></param>
 		/// <param name="tileY"></param>
-		/// <returns></returns>
 		public int GetTileIndex(int tileX, int tileY)
 		{
 			return tileX + tileY * this.tileCount.X;
@@ -510,7 +505,6 @@ namespace Duality.Editor.Plugins.Tilemaps
 		/// Converts a tile index into a 2D tile (not pixel) coordinate, in tileset space.
 		/// </summary>
 		/// <param name="tileIndex"></param>
-		/// <returns></returns>
 		public Point GetTilePos(int tileIndex)
 		{
 			return new Point(

--- a/Source/Plugins/Tilemaps/Editor/Utility/TilemapsSetupUtility.cs
+++ b/Source/Plugins/Tilemaps/Editor/Utility/TilemapsSetupUtility.cs
@@ -21,7 +21,6 @@ namespace Duality.Editor.Plugins.Tilemaps
 		/// </summary>
 		/// <param name="tileset"></param>
 		/// <param name="isUpperLayer"></param>
-		/// <returns></returns>
 		public static int GetDefaultTileIndex(Tileset tileset, bool isUpperLayer)
 		{
 			if (tileset == null) return 0;

--- a/Test/Core/Testing/ExtMethodsIList.cs
+++ b/Test/Core/Testing/ExtMethodsIList.cs
@@ -21,7 +21,6 @@ namespace Duality.Tests
 		/// <param name="index"></param>
 		/// <param name="count"></param>
 		/// <param name="comparer"></param>
-		/// <returns></returns>
 		public static bool IsSorted<T>(this IList<T> values, int index, int count, Comparer<T> comparer = null)
 		{
 			if (comparer == null)
@@ -48,7 +47,6 @@ namespace Duality.Tests
 		/// <param name="count"></param>
 		/// <param name="valuesInOriginalOrder"></param>
 		/// <param name="comparer"></param>
-		/// <returns></returns>
 		public static bool IsStableOrder<T>(this IList<T> values, int index, int count, IList<T> valuesInOriginalOrder, Comparer<T> comparer = null)
 		{
 			if (comparer == null)

--- a/Tools/VisualStudio/DualityDebugging/ExtMethodsBitmap.cs
+++ b/Tools/VisualStudio/DualityDebugging/ExtMethodsBitmap.cs
@@ -17,7 +17,6 @@ namespace Duality.VisualStudio
 		/// </summary>
 		/// <param name="bm"></param>
 		/// <param name="weightTransparent">If true, the alpha value weights a pixels color value. </param>
-		/// <returns></returns>
 		public static ColorRgba GetAverageColor(this Bitmap bm, bool weightTransparent = true)
 		{
 			float[] sum = new float[4];
@@ -65,7 +64,6 @@ namespace Duality.VisualStudio
 		/// Extracts a Bitmaps pixel data.
 		/// </summary>
 		/// <param name="bm"></param>
-		/// <returns></returns>
 		public static ColorRgba[] GetPixelDataRgba(this Bitmap bm)
 		{
 			int[] argbValues = GetPixelDataIntArgb(bm);


### PR DESCRIPTION
Changes:
- Opted to ignore CS1591 as its simply generates too much warnings causing us to miss other more important warnings.
- Fixed param tags with wrong names. Either by removing the param if there are no comments or by adding the missing param tags if there are comments.
- Removed empty return tags

Solves #804