### PR TITLE
Fixed opentk Resolved file has a bad image warning

### DIFF
--- a/Build/NuGetPackageSpecs/DefaultOpenTKBackend.Core.nuspec
+++ b/Build/NuGetPackageSpecs/DefaultOpenTKBackend.Core.nuspec
@@ -25,7 +25,7 @@
   <files>
     <file src="..\Output\Plugins\DefaultOpenTK.Core.dll" target="lib\net472" />
     <file src="..\Output\Plugins\DefaultOpenTK.Core.pdb" target="lib\net472" />
-    <file src="..\Output\OpenALSoft32.dll" target="lib\net472" />
-    <file src="..\Output\OpenALSoft64.dll" target="lib\net472" />
+    <file src="..\Output\OpenALSoft32.dll" target="runtimes\any\native" />
+    <file src="..\Output\OpenALSoft64.dll" target="runtimes\any\native" />
   </files>
 </package>


### PR DESCRIPTION
Moved the openalsoft libraries to the runtimes\any\native folder in the nuget package

In the template I had to add `<RuntimeIdentifier>any</RuntimeIdentifier>` to the csproj so that it knows to pick up the any folder.

This solves the warning you otherwise get because it was trying to load the native dll's as a non native dll.

Solves #787 