### PR TITLE
Fix nuget pack warnings

### DIFF
--- a/Build/NuGetPackageSpecs/AudioHandling.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/AudioHandling.Sample.nuspec
@@ -20,7 +20,6 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="AdamsLair.Duality" version="4.0.0-alpha" />
-        <dependency id="AdamsLair.Duality.Editor" version="4.0.0-alpha" />
       </group>
     </dependencies>
   </metadata>

--- a/Build/NuGetPackageSpecs/AudioHandling.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/AudioHandling.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Audio Handling Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/AudioHandlingSample.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/AudioHandling</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Demonstrates how to handle Audio in Duality.</summary>
@@ -25,6 +25,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\AudioHandlingSample.png" target="\icon.png" />
     <file src="..\..\Samples\AudioHandling\Content\Plugins\netstandard2.0\AudioHandling.Sample.core.dll" target="lib\netstandard2.0" />
     <file src="..\..\Samples\AudioHandling\Content\Plugins\netstandard2.0\AudioHandling.Sample.core.xml" target="lib\netstandard2.0" />
     <file src="..\..\Samples\AudioHandling\Content\Data\**\*.res" target="contentFiles\any\any\Data" />

--- a/Build/NuGetPackageSpecs/Base.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/Base.Editor.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Editor Base Infrastructure</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/EditorBase.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Provides basic infrastructure for the Duality editor, such as PropertyEditors and Importers.</summary>
@@ -22,6 +22,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\EditorBase.png" target="\icon.png" />
     <file src="..\Output\Plugins\EditorBase.editor.dll" target="lib\net472" />
     <file src="..\Output\Plugins\EditorBase.editor.pdb" target="lib\net472" />
     <file src="..\Output\Plugins\EditorBase.editor.xml" target="lib\net472" />

--- a/Build/NuGetPackageSpecs/BasicMenu.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/BasicMenu.Sample.nuspec
@@ -20,7 +20,6 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="AdamsLair.Duality" version="4.0.0-alpha" />
-        <dependency id="AdamsLair.Duality.Editor" version="4.0.0-alpha" />
       </group>
     </dependencies>
   </metadata>

--- a/Build/NuGetPackageSpecs/BasicMenu.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/BasicMenu.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Pilati Alessandro</authors>
     <owners>Pilati Alessandro</owners>
     <title>Basic Menu Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/BasicMenuSample.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/BasicMenu</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Demonstrates a GameObject-based way to create a game menu.</summary>
@@ -25,6 +25,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\BasicMenuSample.png" target="\icon.png" />
     <file src="..\..\Samples\BasicMenu\Content\Plugins\netstandard2.0\BasicMenu.Sample.core.dll" target="lib\netstandard2.0" />
     <file src="..\..\Samples\BasicMenu\Content\Plugins\netstandard2.0\BasicMenu.Sample.core.xml" target="lib\netstandard2.0" />
     <file src="..\..\Samples\BasicMenu\Content\Data\**\*.res" target="contentFiles\any\any\Data" />

--- a/Build/NuGetPackageSpecs/BasicShaders.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/BasicShaders.Sample.nuspec
@@ -20,7 +20,6 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="AdamsLair.Duality" version="4.0.0-alpha" />
-        <dependency id="AdamsLair.Duality.Editor" version="4.0.0-alpha" />
       </group>
     </dependencies>
   </metadata>

--- a/Build/NuGetPackageSpecs/BasicShaders.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/BasicShaders.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Pilati Alessandro, Fedja Adam</authors>
     <owners>Pilati Alessandro, Fedja Adam</owners>
     <title>Basic Shaders Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/BasicShadersSample.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/BasicShaders</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Demonstrates how to use shaders in Duality.</summary>
@@ -25,6 +25,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\BasicShadersSample.png" target="\icon.png" />
     <file src="..\..\Samples\BasicShaders\Content\Data\**\*.res" target="contentFiles\any\any\Data" />
   </files>
 </package>

--- a/Build/NuGetPackageSpecs/Benchmarks.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/Benchmarks.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Benchmarks Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/BenchmarksSample.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/Benchmarks</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Implements a set of benchmarks for profiling Duality.</summary>
@@ -25,6 +25,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\BenchmarksSample.png" target="\icon.png" />
     <file src="..\..\Samples\Benchmarks\Content\Plugins\netstandard2.0\Benchmarks.Sample.core.dll" target="lib\netstandard2.0" />
     <file src="..\..\Samples\Benchmarks\Content\Plugins\netstandard2.0\Benchmarks.Sample.core.xml" target="lib\netstandard2.0" />
     <file src="..\..\Samples\Benchmarks\Content\Data\**\*.res" target="contentFiles\any\any\Data" />

--- a/Build/NuGetPackageSpecs/Benchmarks.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/Benchmarks.Sample.nuspec
@@ -20,7 +20,6 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="AdamsLair.Duality" version="4.0.0-alpha" />
-        <dependency id="AdamsLair.Duality.Editor" version="4.0.0-alpha" />
       </group>
     </dependencies>
   </metadata>

--- a/Build/NuGetPackageSpecs/Benchmarks.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/Benchmarks.Sample.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>AdamsLair.Duality.Samples.Benchmarks</id>
-    <version>2.0.4</version>
+    <version>4.0.0-alpha</version>
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Benchmarks Sample</title>

--- a/Build/NuGetPackageSpecs/CamView.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/CamView.Editor.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Camera View</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/CameraView.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>A basic Camera View editor module.</summary>
@@ -22,6 +22,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\CameraView.png" target="\icon.png" />
     <file src="..\Output\Plugins\CamView.editor.dll" target="lib\net472" />
     <file src="..\Output\Plugins\CamView.editor.pdb" target="lib\net472" />
   </files>

--- a/Build/NuGetPackageSpecs/CameraController.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/CameraController.Sample.nuspec
@@ -20,7 +20,6 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="AdamsLair.Duality" version="4.0.0-alpha" />
-        <dependency id="AdamsLair.Duality.Editor" version="4.0.0-alpha" />
       </group>
     </dependencies>
   </metadata>

--- a/Build/NuGetPackageSpecs/CameraController.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/CameraController.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Camera Controller Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/CameraControllerSample.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/CameraController</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Demonstrates various camera controller Components.</summary>
@@ -25,6 +25,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\CameraControllerSample.png" target="\icon.png" />
     <file src="..\..\Samples\CameraController\Content\Plugins\netstandard2.0\CameraController.Sample.core.dll" target="lib\netstandard2.0" />
     <file src="..\..\Samples\CameraController\Content\Plugins\netstandard2.0\CameraController.Sample.core.xml" target="lib\netstandard2.0" />
     <file src="..\..\Samples\CameraController\Content\Data\**\*.res" target="contentFiles\any\any\Data" />

--- a/Build/NuGetPackageSpecs/Compatibility.Core.nuspec
+++ b/Build/NuGetPackageSpecs/Compatibility.Core.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Backwards Compatibility</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/Compatibility.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Defines helper classes to retain backwards compatibility with older Duality versions.</summary>
@@ -21,6 +21,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\Compatibility.png" target="\icon.png" />
     <file src="..\Output\Plugins\Compatibility.core.dll" target="lib\netstandard2.0" />
     <file src="..\Output\Plugins\Compatibility.core.pdb" target="lib\netstandard2.0" />
   </files>

--- a/Build/NuGetPackageSpecs/CustomRenderingSetup.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/CustomRenderingSetup.Sample.nuspec
@@ -20,7 +20,6 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="AdamsLair.Duality" version="4.0.0-alpha" />
-        <dependency id="AdamsLair.Duality.Editor" version="4.0.0-alpha" />
       </group>
     </dependencies>
   </metadata>

--- a/Build/NuGetPackageSpecs/CustomRenderingSetup.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/CustomRenderingSetup.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Custom Rendering Setup Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/CustomRenderingSetup.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/CustomRenderingSetup</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Demonstrates various custom rendering setups for post-processing or fixed-resolution rendering.</summary>
@@ -25,6 +25,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\CustomRenderingSetup.png" target="\icon.png" />
     <file src="..\..\Samples\CustomRenderingSetup\Content\Plugins\netstandard2.0\CustomRenderingSetup.Sample.core.dll" target="lib\netstandard2.0" />
     <file src="..\..\Samples\CustomRenderingSetup\Content\Plugins\netstandard2.0\CustomRenderingSetup.Sample.core.xml" target="lib\netstandard2.0" />
     <file src="..\..\Samples\CustomRenderingSetup\Content\Data\**\*.res" target="contentFiles\any\any\Data" />

--- a/Build/NuGetPackageSpecs/DefaultOpenTKBackend.Core.nuspec
+++ b/Build/NuGetPackageSpecs/DefaultOpenTKBackend.Core.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>OpenTK Backend</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/DefaultOpenTKBackend.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>The default audiovisual backend layer for Duality.</summary>
@@ -23,6 +23,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\DefaultOpenTKBackend.png" target="\icon.png" />
     <file src="..\Output\Plugins\DefaultOpenTK.Core.dll" target="lib\net472" />
     <file src="..\Output\Plugins\DefaultOpenTK.Core.pdb" target="lib\net472" />
     <file src="..\Output\OpenALSoft32.dll" target="runtimes\any\native" />

--- a/Build/NuGetPackageSpecs/DefaultOpenTKBackend.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/DefaultOpenTKBackend.Editor.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>OpenTK Editor Backend</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/DefaultOpenTKBackend.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>The default editor backend layer for Duality.</summary>
@@ -25,6 +25,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\DefaultOpenTKBackend.png" target="\icon.png" />
     <file src="..\Output\Plugins\DefaultOpenTK.Editor.dll" target="lib\net472" />
     <file src="..\Output\Plugins\DefaultOpenTK.Editor.pdb" target="lib\net472" />
   </files>

--- a/Build/NuGetPackageSpecs/DotNetFrameworkBackend.Core.nuspec
+++ b/Build/NuGetPackageSpecs/DotNetFrameworkBackend.Core.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>DotNetFramework Backend</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/DotNetFrameworkBackend.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>The default system backend layer for Duality.</summary>
@@ -21,6 +21,7 @@
     <releaseNotes>Patch Version Update</releaseNotes>
   </metadata>
   <files>
+    <file src="Icons\DotNetFrameworkBackend.png" target="\icon.png" />
     <file src="..\Output\Plugins\DotNetFramework.Core.dll" target="lib\net472" />
     <file src="..\Output\Plugins\DotNetFramework.Core.pdb" target="lib\net472" />
   </files>

--- a/Build/NuGetPackageSpecs/DualStickSpaceShooter.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/DualStickSpaceShooter.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Dual Stick Space Shooter Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/Game.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/DualStickSpaceShooter</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>A small dual stick space shooter made with Duality.</summary>
@@ -25,6 +25,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\Physics.png" target="\Game.png" />
     <file src="..\..\Samples\DualStickSpaceShooter\Content\Plugins\netstandard2.0\DualStickSpaceShooter.Sample.core.dll" target="lib\netstandard2.0" />
     <file src="..\..\Samples\DualStickSpaceShooter\Content\Plugins\netstandard2.0\DualStickSpaceShooter.Sample.core.xml" target="lib\netstandard2.0" />
     <file src="..\..\Samples\DualStickSpaceShooter\Content\Data\**\*.res" target="contentFiles\any\any\Data" />

--- a/Build/NuGetPackageSpecs/DualStickSpaceShooter.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/DualStickSpaceShooter.Sample.nuspec
@@ -20,7 +20,6 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="AdamsLair.Duality" version="4.0.0-alpha" />
-        <dependency id="AdamsLair.Duality.Editor" version="4.0.0-alpha" />
       </group>
     </dependencies>
   </metadata>

--- a/Build/NuGetPackageSpecs/DualStickSpaceShooter.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/DualStickSpaceShooter.Sample.nuspec
@@ -25,7 +25,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Icons\Physics.png" target="\Game.png" />
+    <file src="Icons\Game.png" target="\icon.png" />
     <file src="..\..\Samples\DualStickSpaceShooter\Content\Plugins\netstandard2.0\DualStickSpaceShooter.Sample.core.dll" target="lib\netstandard2.0" />
     <file src="..\..\Samples\DualStickSpaceShooter\Content\Plugins\netstandard2.0\DualStickSpaceShooter.Sample.core.xml" target="lib\netstandard2.0" />
     <file src="..\..\Samples\DualStickSpaceShooter\Content\Data\**\*.res" target="contentFiles\any\any\Data" />

--- a/Build/NuGetPackageSpecs/Duality.Docs.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.Docs.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Duality Documentation</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/Docs.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Contains the external Duality API documentation help files.</summary>
@@ -22,6 +22,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\Docs.png" target="\icon.png" />
     <file src="..\Documentation\Help\DDoc.chm" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/Build/NuGetPackageSpecs/Duality.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.Editor.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Duality Editor</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/Duality.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>The Duality editor.</summary>
@@ -23,11 +23,9 @@
         <dependency id="AdamsLair.WinForms.PopupControl" version="1.0.1" />
       </group>
     </dependencies>
-    <references>
-      <reference file="DualityEditor.exe" />
-    </references>
   </metadata>
   <files>
+    <file src="Icons\duality.png" target="\icon.png" />
     <file src="..\Output\DualityEditor.exe" target="lib\net472" />
     <file src="..\Output\DualityEditor.exe.config" target="lib\net472" />
     <file src="..\Output\DualityEditor.pdb" target="lib\net472" />

--- a/Build/NuGetPackageSpecs/Duality.Launcher.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.Launcher.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Duality Launcher</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/Duality.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>The default launcher application for Duality games.</summary>
@@ -21,6 +21,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\Duality.png" target="\icon.png" />
     <file src="..\Output\DualityLauncher.exe" target="lib\net472" />
     <file src="..\Output\DualityLauncher.exe.config" target="lib\net472" />
     <file src="..\Output\DualityLauncher.pdb" target="lib\net472" />

--- a/Build/NuGetPackageSpecs/Duality.Physics.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.Physics.nuspec
@@ -12,10 +12,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A custom version of Farseer Physics for being used with the Duality framework. Forked from https://farseerphysics.codeplex.com/</description>
     <tags></tags>
-    <references>
-      <reference file="DualityPhysics.dll" />
-    </references>
     <releaseNotes>Patch Version Update</releaseNotes>
+    <dependencies>
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
   </metadata>
   <files>
     <file src="Icons\Physics.png" target="\icon.png" />

--- a/Build/NuGetPackageSpecs/Duality.Physics.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.Physics.nuspec
@@ -6,8 +6,8 @@
     <authors>See original project authors</authors>
     <owners>Fedja Adam</owners>
     <title>Duality Physics</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/Physics.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A custom version of Farseer Physics for being used with the Duality framework. Forked from https://farseerphysics.codeplex.com/</description>
@@ -18,6 +18,7 @@
     <releaseNotes>Patch Version Update</releaseNotes>
   </metadata>
   <files>
+    <file src="Icons\Physics.png" target="\icon.png" />
     <file src="..\Output\DualityPhysics.dll" target="lib\netstandard2.0" />
     <file src="..\Output\DualityPhysics.xml" target="lib\netstandard2.0" />
     <file src="..\Output\DualityPhysics.pdb" target="lib\netstandard2.0" />

--- a/Build/NuGetPackageSpecs/Duality.Primitives.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.Primitives.nuspec
@@ -13,11 +13,10 @@
     <summary>A set of primitive classes that are used by Duality.</summary>
     <description>A set of primitive classes that are used by Duality and some of its dependencies.</description>
     <tags></tags>
-    <references>
-      <reference file="DualityPrimitives.dll" />
-    </references>
-    <releaseNotes>Patch Version Update
-</releaseNotes>
+    <releaseNotes>Patch Version Update</releaseNotes>
+    <dependencies>
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
   </metadata>
   <files>
     <file src="Icons\Primitives.png" target="\icon.png" />

--- a/Build/NuGetPackageSpecs/Duality.Primitives.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.Primitives.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Duality Primitives</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/Primitives.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>A set of primitive classes that are used by Duality.</summary>
@@ -20,6 +20,7 @@
 </releaseNotes>
   </metadata>
   <files>
+    <file src="Icons\Primitives.png" target="\icon.png" />
     <file src="..\Output\DualityPrimitives.dll" target="lib\netstandard2.0" />
     <file src="..\Output\DualityPrimitives.pdb" target="lib\netstandard2.0" />
     <file src="..\Output\DualityPrimitives.xml" target="lib\netstandard2.0" />

--- a/Build/NuGetPackageSpecs/Duality.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.nuspec
@@ -21,9 +21,6 @@
         <dependency id="AdamsLair.Duality.Physics" version="4.0.0-alpha" />
       </group>
     </dependencies>
-    <references>
-      <reference file="Duality.dll" />
-    </references>
   </metadata>
   <files>
     <file src="Icons\Duality.png" target="\icon.png" />

--- a/Build/NuGetPackageSpecs/Duality.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Duality Core</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/Duality.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>The Duality engine core.</summary>
@@ -26,6 +26,7 @@
     </references>
   </metadata>
   <files>
+    <file src="Icons\Duality.png" target="\icon.png" />
     <file src="..\Output\Duality.dll" target="lib\netstandard2.0" />
     <file src="..\Output\Duality.pdb" target="lib\netstandard2.0" />
     <file src="..\Output\Duality.xml" target="lib\netstandard2.0" />

--- a/Build/NuGetPackageSpecs/DynamicLighting.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/DynamicLighting.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>DynamicLighting Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/DynamicLighting.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/DynamicLighting</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Introduces a naive implementation of dynamic lighting Components.</summary>
@@ -25,6 +25,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\DynamicLighting.png" target="\icon.png" />
     <file src="..\..\Samples\DynamicLighting\Content\Data\**\*.res" target="contentFiles\any\any\Data" />
     <file src="..\..\Samples\DynamicLighting\Core\Content\Plugins\netstandard2.0\DynamicLighting.Sample.core.dll" target="lib\net472" />
     <file src="..\..\Samples\DynamicLighting\Core\Content\Plugins\netstandard2.0\DynamicLighting.Sample.core.xml" target="lib\net472" />

--- a/Build/NuGetPackageSpecs/FlapOrDie.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/FlapOrDie.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Pilati Alessandro</authors>
     <owners>Pilati Alessandro</owners>
     <title>Flap-Or-Die Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/Game.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/FlapOrDie</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>A clone of a commonly known casual game in Duality.</summary>
@@ -25,6 +25,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\Game.png" target="\icon.png" />
     <file src="..\..\Samples\FlapOrDie\Content\Plugins\netstandard2.0\FlapOrDie.Sample.core.dll" target="lib\netstandard2.0" />
     <file src="..\..\Samples\FlapOrDie\Content\Plugins\netstandard2.0\FlapOrDie.Sample.core.xml" target="lib\netstandard2.0" />
     <file src="..\..\Samples\FlapOrDie\Content\Data\**\*.res" target="contentFiles\any\any\Data" />

--- a/Build/NuGetPackageSpecs/FlapOrDie.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/FlapOrDie.Sample.nuspec
@@ -20,7 +20,6 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="AdamsLair.Duality" version="4.0.0-alpha" />
-        <dependency id="AdamsLair.Duality.Editor" version="4.0.0-alpha" />
       </group>
     </dependencies>
   </metadata>

--- a/Build/NuGetPackageSpecs/HelpAdvisor.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/HelpAdvisor.Editor.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Help Advisor</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/Advisor.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>The Help Advisor editor module provides mouseover information on documented topics.</summary>
@@ -22,6 +22,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\Advisor.png" target="\icon.png" />
     <file src="..\Output\Plugins\HelpAdvisor.editor.dll" target="lib\net472" />
     <file src="..\Output\Plugins\HelpAdvisor.editor.pdb" target="lib\net472" />
   </files>

--- a/Build/NuGetPackageSpecs/InputHandling.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/InputHandling.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Input Handling Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/InputHandlingSample.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/InputHandling</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Demonstrates how to access user input in Duality.</summary>
@@ -25,6 +25,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\InputHandlingSample.png" target="\icon.png" />
     <file src="..\..\Samples\InputHandling\Content\Plugins\netstandard2.0\InputHandling.Sample.core.dll" target="lib\netstandard2.0" />
     <file src="..\..\Samples\InputHandling\Content\Plugins\netstandard2.0\InputHandling.Sample.core.xml" target="lib\netstandard2.0" />
     <file src="..\..\Samples\InputHandling\Content\Data\**\*.res" target="contentFiles\any\any\Data" />

--- a/Build/NuGetPackageSpecs/InputHandling.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/InputHandling.Sample.nuspec
@@ -20,7 +20,6 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="AdamsLair.Duality" version="4.0.0-alpha" />
-        <dependency id="AdamsLair.Duality.Editor" version="4.0.0-alpha" />
       </group>
     </dependencies>
   </metadata>

--- a/Build/NuGetPackageSpecs/LogView.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/LogView.Editor.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Log View</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/LogView.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Displays the content of the primary text logs of Duality.</summary>
@@ -22,6 +22,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\LogView.png" target="\icon.png" />
     <file src="..\Output\Plugins\LogView.editor.dll" target="lib\net472" />
     <file src="..\Output\Plugins\LogView.editor.pdb" target="lib\net472" />
   </files>

--- a/Build/NuGetPackageSpecs/ObjectInspector.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/ObjectInspector.Editor.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Object Inspector</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/ObjectInspector.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Allows editing the properties of selected objects.</summary>
@@ -23,6 +23,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\ObjectInspector.png" target="\icon.png" />
     <file src="..\Output\Plugins\ObjectInspector.editor.dll" target="lib\net472" />
     <file src="..\Output\Plugins\ObjectInspector.editor.pdb" target="lib\net472" />
   </files>

--- a/Build/NuGetPackageSpecs/ParticleSystem.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/ParticleSystem.Sample.nuspec
@@ -20,7 +20,6 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="AdamsLair.Duality" version="4.0.0-alpha" />
-        <dependency id="AdamsLair.Duality.Editor" version="4.0.0-alpha" />
       </group>
     </dependencies>
   </metadata>

--- a/Build/NuGetPackageSpecs/ParticleSystem.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/ParticleSystem.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Custom ParticleSystem Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/ParticleSystemSample.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/ParticleSystem</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Implements and showcases a custom Particle System in Duality.</summary>
@@ -25,6 +25,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\ParticleSystemSample.png" target="\icon.png" />
     <file src="..\..\Samples\ParticleSystem\Content\Plugins\netstandard2.0\ParticleSystem.Sample.core.dll" target="lib\netstandard2.0" />
     <file src="..\..\Samples\ParticleSystem\Content\Plugins\netstandard2.0\ParticleSystem.Sample.core.xml" target="lib\netstandard2.0" />
     <file src="..\..\Samples\ParticleSystem\Content\Data\**\*.res" target="contentFiles\any\any\Data" />

--- a/Build/NuGetPackageSpecs/Physics.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/Physics.Sample.nuspec
@@ -20,7 +20,6 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="AdamsLair.Duality" version="4.0.0-alpha" />
-        <dependency id="AdamsLair.Duality.Editor" version="4.0.0-alpha" />
       </group>
     </dependencies>
   </metadata>

--- a/Build/NuGetPackageSpecs/Physics.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/Physics.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Physics Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/PhysicsSample.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/Physics</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Demonstrates how to use physics simulation in Duality.</summary>
@@ -25,6 +25,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\PhysicsSample.png" target="\icon.png" />
     <file src="..\..\Samples\Physics\Content\Plugins\netstandard2.0\Physics.Sample.core.dll" target="lib\netstandard2.0" />
     <file src="..\..\Samples\Physics\Content\Plugins\netstandard2.0\Physics.Sample.core.xml" target="lib\netstandard2.0" />
     <file src="..\..\Samples\Physics\Content\Data\**\*.res" target="contentFiles\any\any\Data" />

--- a/Build/NuGetPackageSpecs/ProjectView.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/ProjectView.Editor.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Project View</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/ProjectView.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Provides an overview of project Resources and allows importing new Assets.</summary>
@@ -22,6 +22,7 @@
     </dependencies>
   </metadata>
   <files>
+     <file src="Icons\ProjectView.png" target="\icon.png" />
     <file src="..\Output\Plugins\ProjectView.editor.dll" target="lib\net472" />
     <file src="..\Output\Plugins\ProjectView.editor.pdb" target="lib\net472" />
   </files>

--- a/Build/NuGetPackageSpecs/SceneView.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/SceneView.Editor.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Scene View</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/SceneView.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Displays the contents of the current Scene hierarchically and allows editing the Scene graph.</summary>
@@ -22,6 +22,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\SceneView.png" target="\icon.png" />
     <file src="..\Output\Plugins\SceneView.editor.dll" target="lib\net472" />
     <file src="..\Output\Plugins\SceneView.editor.pdb" target="lib\net472" />
   </files>

--- a/Build/NuGetPackageSpecs/SmoothAnimation.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/SmoothAnimation.Sample.nuspec
@@ -20,7 +20,6 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="AdamsLair.Duality" version="4.0.0-alpha" />
-        <dependency id="AdamsLair.Duality.Editor" version="4.0.0-alpha" />
       </group>
     </dependencies>
   </metadata>

--- a/Build/NuGetPackageSpecs/SmoothAnimation.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/SmoothAnimation.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Smooth Sprite Animation Blending Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/SmoothAnimationSample.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/SmoothAnimation</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Demonstrates a smooth blending technique for sprite animations.</summary>
@@ -25,6 +25,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\SmoothAnimationSample.png" target="\icon.png" />
     <file src="..\..\Samples\SmoothAnimation\Content\Plugins\netstandard2.0\SmoothAnimation.Sample.core.dll" target="lib\netstandard2.0" />
     <file src="..\..\Samples\SmoothAnimation\Content\Plugins\netstandard2.0\SmoothAnimation.Sample.core.xml" target="lib\netstandard2.0" />
     <file src="..\..\Samples\SmoothAnimation\Content\Data\**\*.res" target="contentFiles\any\any\Data" />

--- a/Build/NuGetPackageSpecs/Steering.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/Steering.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Daniel Herb, Fedja Adam</authors>
     <owners>Daniel Herb, Fedja Adam</owners>
     <title>Steering Behaviours Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/Steering.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/Steering</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Introduces a Steering Agent Component that allows for objects to evade each other.</summary>
@@ -24,6 +24,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\Steering.png" target="\icon.png" />
     <file src="..\..\Samples\Steering\Content\Plugins\netstandard2.0\Steering.Sample.core.dll" target="lib\netstandard2.0" />
     <file src="..\..\Samples\Steering\Content\Plugins\netstandard2.0\Steering.Sample.core.xml" target="lib\netstandard2.0" />
     <file src="..\..\Samples\Steering\Content\Data\**\*.res" target="contentFiles\any\any\Data" />

--- a/Build/NuGetPackageSpecs/Tilemaps.Core.nuspec
+++ b/Build/NuGetPackageSpecs/Tilemaps.Core.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Tilemaps (Core)</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/Tilemaps.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Defines core Resources and Components for using tilemaps with Duality.</summary>
@@ -22,6 +22,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\Tilemaps.png" target="\icon.png" />
     <file src="..\Output\Plugins\Tilemaps.core.dll" target="lib\netstandard2.0" />
     <file src="..\Output\Plugins\Tilemaps.core.pdb" target="lib\netstandard2.0" />
     <file src="..\Output\Plugins\Tilemaps.core.xml" target="lib\netstandard2.0" />

--- a/Build/NuGetPackageSpecs/Tilemaps.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/Tilemaps.Editor.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Tilemaps (Editor)</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/Tilemaps.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Defines the editor integration of the dependent core tilemap plugin.</summary>
@@ -24,6 +24,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\Tilemaps.png" target="\icon.png" />
     <file src="..\Output\Plugins\Tilemaps.editor.dll" target="lib\net472" />
     <file src="..\Output\Plugins\Tilemaps.editor.pdb" target="lib\net472" />
     <file src="..\Output\Plugins\Tilemaps.editor.xml" target="lib\net472" />

--- a/Build/NuGetPackageSpecs/Tilemaps.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/Tilemaps.Sample.nuspec
@@ -6,8 +6,8 @@
     <authors>Fedja Adam</authors>
     <owners>Fedja Adam</owners>
     <title>Tilemaps Sample</title>
-    <iconUrl>https://github.com/AdamsLair/duality/raw/release/Build/NuGetPackageSpecs/Icons/Tilemaps.png</iconUrl>
-    <licenseUrl>https://github.com/AdamsLair/duality/raw/release/LICENSE</licenseUrl>
+    <icon>icon.png</icon>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/AdamsLair/duality/tree/master/Samples/Tilemaps</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>A sample project to show how to use Tilemaps.</summary>
@@ -27,6 +27,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Icons\Tilemaps.png" target="\icon.png" />
     <file src="..\..\Samples\Tilemaps\Content\Plugins\netstandard2.0\Tilemaps.Sample.core.dll" target="lib\netstandard2.0" />
     <file src="..\..\Samples\Tilemaps\Content\Plugins\netstandard2.0\Tilemaps.Sample.core.xml" target="lib\netstandard2.0" />
     <file src="..\..\Samples\Tilemaps\Content\Data\**\*.res" target="contentFiles\any\any\Data" />


### PR DESCRIPTION
This should fix any warnings you get when running nuget pack and bring our nuget packages up to the updated spec.

Changes:
- Replaced `licenseUrl` with `license`, it now uses a license expression instead of a link.
- Replaced `PackageIconUrl` with `PackageIcon`, the icon is now included in the package itself
- Removed `references` elements as these are not needed (and actually caused warnings).