### PR TITLE
revised project structure with dualityeditor still at the root

### DIFF
--- a/Source/Editor/DualityEditor/AssetManagement/AssetInternalHelper.cs
+++ b/Source/Editor/DualityEditor/AssetManagement/AssetInternalHelper.cs
@@ -29,7 +29,7 @@ namespace Duality.Editor.AssetManagement
 		{
 			string resFullNameInData = PathHelper.MakeFilePathRelative(resource.FullName, DualityApp.DataDirectory);
 			string resDirInData = Path.GetDirectoryName(resFullNameInData);
-			string sourceMediaDir = Path.Combine(EditorHelper.SourceMediaDirectory, resDirInData);
+			string sourceMediaDir = Path.Combine(EditorHelper.ImportDirectory, resDirInData);
 			return sourceMediaDir;
 		}
 		

--- a/Source/Editor/DualityEditor/AssetManagement/Import/AssetFirstImportOperation.cs
+++ b/Source/Editor/DualityEditor/AssetManagement/Import/AssetFirstImportOperation.cs
@@ -44,13 +44,13 @@ namespace Duality.Editor.AssetManagement
 			if (PathOp.ArePathsEqual(targetBaseDir, DualityApp.DataDirectory))
 			{
 				this.targetDir = DualityApp.DataDirectory;
-				this.sourceDir = EditorHelper.SourceMediaDirectory;
+				this.sourceDir = EditorHelper.ImportDirectory;
 			}
 			else
 			{
 				string baseDir = PathHelper.MakeFilePathRelative(targetBaseDir, DualityApp.DataDirectory);
 				this.targetDir = Path.Combine(DualityApp.DataDirectory, baseDir);
-				this.sourceDir = Path.Combine(EditorHelper.SourceMediaDirectory, baseDir);
+				this.sourceDir = Path.Combine(EditorHelper.ImportDirectory, baseDir);
 			}
 
 			string[] inputFileArray = inputFiles.ToArray();

--- a/Source/Editor/DualityEditor/AssetManagement/Import/AssetReImportOperation.cs
+++ b/Source/Editor/DualityEditor/AssetManagement/Import/AssetReImportOperation.cs
@@ -12,10 +12,10 @@ namespace Duality.Editor.AssetManagement
 	{
 		public AssetReImportOperation(IEnumerable<string> inputFiles)
 		{
-			if (inputFiles.Any(file => !PathOp.IsPathLocatedIn(file, EditorHelper.SourceMediaDirectory)))
+			if (inputFiles.Any(file => !PathOp.IsPathLocatedIn(file, EditorHelper.ImportDirectory)))
 			{
 				throw new ArgumentException(
-					string.Format("Can't re-import Assets using source files that are located outside the Duality '{0}' direcctory", EditorHelper.SourceMediaDirectory),
+					string.Format("Can't re-import Assets using source files that are located outside the Duality '{0}' directory", EditorHelper.ImportDirectory),
 					"inputFiles");
 			}
 
@@ -23,7 +23,7 @@ namespace Duality.Editor.AssetManagement
 			this.input = new AssetImportInput[inputFileArray.Length];
 			for (int i = 0; i < this.input.Length; i++)
 			{
-				this.input[i] = new AssetImportInput(inputFileArray[i], EditorHelper.SourceMediaDirectory);
+				this.input[i] = new AssetImportInput(inputFileArray[i], EditorHelper.ImportDirectory);
 			}
 		}
 
@@ -46,8 +46,8 @@ namespace Duality.Editor.AssetManagement
 		private bool DetermineImportInputMapping()
 		{
 			AssetImportEnvironment prepareEnv = new AssetImportEnvironment(
-				DualityApp.DataDirectory, 
-				EditorHelper.SourceMediaDirectory, 
+				DualityApp.DataDirectory,
+				EditorHelper.ImportDirectory, 
 				this.input);
 			prepareEnv.IsPrepareStep = true;
 			prepareEnv.IsReImport = true;
@@ -81,8 +81,8 @@ namespace Duality.Editor.AssetManagement
 			{
 				ImportInputAssignment assignment = this.inputMapping.Data[assignmentIndex];
 				AssetImportEnvironment importEnv = new AssetImportEnvironment(
-					DualityApp.DataDirectory, 
-					EditorHelper.SourceMediaDirectory, 
+					DualityApp.DataDirectory,
+					EditorHelper.ImportDirectory, 
 					assignment.HandledInputInSourceMedia);
 				importEnv.IsReImport = true;
 				

--- a/Source/Editor/DualityEditor/DualityEditorApp.cs
+++ b/Source/Editor/DualityEditor/DualityEditorApp.cs
@@ -210,10 +210,10 @@ namespace Duality.Editor
 				FileInfo fileInfoIcon = new FileInfo(Path.Combine(DualityApp.DataDirectory, "WorkingFolderIcon.ico"));
 				fileInfoIcon.Attributes |= FileAttributes.Hidden;
 			}
-			if (!Directory.Exists(DualityApp.PluginDirectory)) Directory.CreateDirectory(DualityApp.PluginDirectory);
-			if (!Directory.Exists(EditorHelper.SourceDirectory)) Directory.CreateDirectory(EditorHelper.SourceDirectory);
-			if (!Directory.Exists(EditorHelper.SourceMediaDirectory)) Directory.CreateDirectory(EditorHelper.SourceMediaDirectory);
-			if (!Directory.Exists(EditorHelper.SourceCodeDirectory)) Directory.CreateDirectory(EditorHelper.SourceCodeDirectory);
+
+			Directory.CreateDirectory(DualityApp.PluginDirectory);
+			Directory.CreateDirectory(EditorHelper.ImportDirectory);
+			Directory.CreateDirectory(EditorHelper.SourceDirectory);
 
 			// Initialize Duality
 			EditorHintImageAttribute.ImageResolvers += EditorHintImageResolver;

--- a/Source/Editor/DualityEditor/DualityEditorApp.cs
+++ b/Source/Editor/DualityEditor/DualityEditorApp.cs
@@ -213,7 +213,6 @@ namespace Duality.Editor
 
 			Directory.CreateDirectory(DualityApp.PluginDirectory);
 			Directory.CreateDirectory(EditorHelper.ImportDirectory);
-			Directory.CreateDirectory(EditorHelper.SourceDirectory);
 
 			// Initialize Duality
 			EditorHintImageAttribute.ImageResolvers += EditorHintImageResolver;

--- a/Source/Editor/DualityEditor/FileEventManager.cs
+++ b/Source/Editor/DualityEditor/FileEventManager.cs
@@ -29,6 +29,7 @@ namespace Duality.Editor
 		private static FileSystemWatcher dataDirWatcherFile      = null;
 		private static FileSystemWatcher dataDirWatcherDirectory = null;
 		private static FileSystemWatcher sourceDirWatcher        = null;
+		private static FileSystemWatcher importDirWatcher        = null;
 		private static HashSet<string>   reimportSchedule        = new HashSet<string>();
 		private static HashSet<string>   editorModifiedFiles     = new HashSet<string>();
 		private static HashSet<string>   editorModifiedFilesLast = new HashSet<string>();
@@ -117,6 +118,17 @@ namespace Duality.Editor
 			sourceDirWatcher.Deleted += fileSystemWatcher_ForwardSource;
 			sourceDirWatcher.Renamed += fileSystemWatcher_ForwardSource;
 			sourceDirWatcher.EnableRaisingEvents = true;
+
+			importDirWatcher = new FileSystemWatcher();
+			importDirWatcher.SynchronizingObject = DualityEditorApp.MainForm;
+			importDirWatcher.EnableRaisingEvents = false;
+			importDirWatcher.IncludeSubdirectories = true;
+			importDirWatcher.Path = EditorHelper.ImportDirectory;
+			importDirWatcher.Created += fileSystemWatcher_ForwardSource;
+			importDirWatcher.Changed += fileSystemWatcher_ForwardSource;
+			importDirWatcher.Deleted += fileSystemWatcher_ForwardSource;
+			importDirWatcher.Renamed += fileSystemWatcher_ForwardSource;
+			importDirWatcher.EnableRaisingEvents = true;
 
 			// Register events
 			DualityEditorApp.EditorIdling += DualityEditorApp_EditorIdling;
@@ -487,7 +499,7 @@ namespace Duality.Editor
 				// Mind modified source files for re-import
 				if (fileEvent.Type == FileEventType.Changed)
 				{
-					if (File.Exists(fileEvent.Path) && PathOp.IsPathLocatedIn(fileEvent.Path, EditorHelper.SourceMediaDirectory)) 
+					if (File.Exists(fileEvent.Path) && PathOp.IsPathLocatedIn(fileEvent.Path, EditorHelper.ImportDirectory)) 
 						reimportSchedule.Add(fileEvent.Path);
 				}
 			}
@@ -529,7 +541,7 @@ namespace Duality.Editor
 			else
 			{
 				string mediaPath = Path.Combine(
-					EditorHelper.SourceMediaDirectory, 
+					EditorHelper.ImportDirectory, 
 					PathHelper.MakeFilePathRelative(deleteEvent.Path, DualityApp.DataDirectory));
 				if (Directory.Exists(mediaPath))
 				{
@@ -582,12 +594,12 @@ namespace Duality.Editor
 			{
 				// Determine which source/media directory we're going to move
 				string oldMediaPath = Path.Combine(
-					EditorHelper.SourceMediaDirectory, 
+					EditorHelper.ImportDirectory, 
 					PathHelper.MakeFilePathRelative(renameEvent.OldPath, DualityApp.DataDirectory));
 
 				// Determine where that old source/media directory needs to be moved
 				string newMediaPath = Path.Combine(
-					EditorHelper.SourceMediaDirectory, 
+					EditorHelper.ImportDirectory, 
 					PathHelper.MakeFilePathRelative(renameEvent.Path, DualityApp.DataDirectory));
 
 				// Move the media directory to mirror the data directories movement

--- a/Source/Editor/DualityEditor/FileEventManager.cs
+++ b/Source/Editor/DualityEditor/FileEventManager.cs
@@ -107,17 +107,20 @@ namespace Duality.Editor
 			dataDirWatcherDirectory.Deleted += fileSystemWatcher_ForwardData;
 			dataDirWatcherDirectory.Renamed += fileSystemWatcher_ForwardData;
 			dataDirWatcherDirectory.EnableRaisingEvents = true;
-			
-			sourceDirWatcher = new FileSystemWatcher();
-			sourceDirWatcher.SynchronizingObject = DualityEditorApp.MainForm;
-			sourceDirWatcher.EnableRaisingEvents = false;
-			sourceDirWatcher.IncludeSubdirectories = true;
-			sourceDirWatcher.Path = EditorHelper.SourceDirectory;
-			sourceDirWatcher.Created += fileSystemWatcher_ForwardSource;
-			sourceDirWatcher.Changed += fileSystemWatcher_ForwardSource;
-			sourceDirWatcher.Deleted += fileSystemWatcher_ForwardSource;
-			sourceDirWatcher.Renamed += fileSystemWatcher_ForwardSource;
-			sourceDirWatcher.EnableRaisingEvents = true;
+
+			if (Directory.Exists(EditorHelper.SourceDirectory))
+			{
+				sourceDirWatcher = new FileSystemWatcher();
+				sourceDirWatcher.SynchronizingObject = DualityEditorApp.MainForm;
+				sourceDirWatcher.EnableRaisingEvents = false;
+				sourceDirWatcher.IncludeSubdirectories = true;
+				sourceDirWatcher.Path = EditorHelper.SourceDirectory;
+				sourceDirWatcher.Created += fileSystemWatcher_ForwardSource;
+				sourceDirWatcher.Changed += fileSystemWatcher_ForwardSource;
+				sourceDirWatcher.Deleted += fileSystemWatcher_ForwardSource;
+				sourceDirWatcher.Renamed += fileSystemWatcher_ForwardSource;
+				sourceDirWatcher.EnableRaisingEvents = true;
+			}
 
 			importDirWatcher = new FileSystemWatcher();
 			importDirWatcher.SynchronizingObject = DualityEditorApp.MainForm;
@@ -166,14 +169,17 @@ namespace Duality.Editor
 			dataDirWatcherDirectory.Dispose();
 			dataDirWatcherDirectory = null;
 
-			sourceDirWatcher.EnableRaisingEvents = false;
-			sourceDirWatcher.Created -= fileSystemWatcher_ForwardSource;
-			sourceDirWatcher.Changed -= fileSystemWatcher_ForwardSource;
-			sourceDirWatcher.Deleted -= fileSystemWatcher_ForwardSource;
-			sourceDirWatcher.Renamed -= fileSystemWatcher_ForwardSource;
-			sourceDirWatcher.SynchronizingObject = null;
-			sourceDirWatcher.Dispose();
-			sourceDirWatcher = null;
+			if (sourceDirWatcher != null)
+			{
+				sourceDirWatcher.EnableRaisingEvents = false;
+				sourceDirWatcher.Created -= fileSystemWatcher_ForwardSource;
+				sourceDirWatcher.Changed -= fileSystemWatcher_ForwardSource;
+				sourceDirWatcher.Deleted -= fileSystemWatcher_ForwardSource;
+				sourceDirWatcher.Renamed -= fileSystemWatcher_ForwardSource;
+				sourceDirWatcher.SynchronizingObject = null;
+				sourceDirWatcher.Dispose();
+				sourceDirWatcher = null;
+			}
 		}
 
 		/// <summary>

--- a/Source/Editor/DualityEditor/Forms/PublishGameDialog.cs
+++ b/Source/Editor/DualityEditor/Forms/PublishGameDialog.cs
@@ -22,15 +22,15 @@ namespace Duality.Editor.Forms
 			@"*\.svn",
 			@".\Backup",
 			@".\Temp",
-			@".\Source\Media",
-			@".\Source\Packages",
+			$@".\{EditorHelper.ImportDirectory}",
 			@".\logfile*",
 			@".\perflog*",
 			@"*.vshost.*",
 			@".\OpenAL32.dll" };
 		private static readonly string[] SourcePathBlacklist = new string[] {
-			@".\Source",
+			$@".\{EditorHelper.SourceDirectory}",
 			@"*.pdb",
+			@"*.sln",
 			@".\FarseerDuality.xml",
 			@".\NVorbis.xml" };
 		private static readonly string[] EditorPathBlacklist = new string[] {
@@ -52,8 +52,7 @@ namespace Duality.Editor.Forms
 			@".\DualityUpdater.*",
 			@".\NuGet.Core.*",
 			@".\Ionic.Zip.*",
-			@".\Plugins\OpenTK.GLControl.*",
-			@".\PackageConfig.xml" };
+			@".\Plugins\OpenTK.GLControl.*"};
 		private static readonly Regex[] RegExTemporaryProjectFiles = TemporaryProjectFiles.Select(w => PathWildcardToRegex(w)).ToArray();
 		private static readonly Regex[] RegExSourcePathBlacklist = SourcePathBlacklist.Select(w => PathWildcardToRegex(w)).ToArray();
 		private static readonly Regex[] RegExEditorPathBlacklist = EditorPathBlacklist.Select(w => PathWildcardToRegex(w)).ToArray();

--- a/Source/Editor/DualityEditor/Utility/EditorHelper.cs
+++ b/Source/Editor/DualityEditor/Utility/EditorHelper.cs
@@ -1,33 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.IO;
-using System.IO.Compression;
-using System.Xml.Linq;
 using System.Windows.Forms;
-using System.Runtime.InteropServices;
 using System.Drawing;
-using System.Reflection;
-using Microsoft.Win32;
-
-using Duality;
-using Duality.IO;
-using Duality.Serialization;
 
 namespace Duality.Editor
 {
 	public static class EditorHelper
 	{
-		public static readonly string DualityLauncherExecFile			= "DualityLauncher.exe";
-		public static readonly string BackupDirectory					= "Backup";
-		public static readonly string SourceDirectory					= "Source";
-
-		public static readonly string SourceMediaDirectory				= Path.Combine(SourceDirectory, "Media");
-		public static readonly string SourceCodeDirectory				= Path.Combine(SourceDirectory, "Code");
+		public static readonly string DualityLauncherExecFile = "DualityLauncher.exe";
+		public static readonly string BackupDirectory = "Backup";
 
 		public static readonly string GlobalUserDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Duality");
 
+		public static readonly string ImportDirectory = "Import";
+		public static readonly string SourceDirectory = "Source";
 
 		/// <summary>
 		/// The path to the *.sln solution file. Will throw a <see cref="FileNotFoundException"/> if the solution file cannot be found.
@@ -37,15 +25,16 @@ namespace Duality.Editor
 			get
 			{
 				string sourceCodeSolutionFilePath = null;
-				if (Directory.Exists(SourceCodeDirectory))
+				string sourcePath = EditorHelper.SourceDirectory;
+				if (Directory.Exists(sourcePath))
 				{
 					sourceCodeSolutionFilePath = Directory.EnumerateFiles(
-						SourceCodeDirectory, 
-						"*.sln", 
+							sourcePath,
+						"*.sln",
 						SearchOption.AllDirectories)
 						.FirstOrDefault();
 				}
-				return sourceCodeSolutionFilePath ?? throw new FileNotFoundException($"Could not find a solution file in {SourceCodeDirectory}");
+				return sourceCodeSolutionFilePath ?? throw new FileNotFoundException($"Could not find a solution file in {sourcePath}");
 			}
 		}
 		public static string CurrentProjectName
@@ -106,7 +95,7 @@ namespace Duality.Editor
 					// that isn't a Form will just return null. In other cases, will throw an exception.
 				}
 			}
-			
+
 			return result;
 		}
 		public static Control GetFocusedControl()
@@ -125,7 +114,7 @@ namespace Duality.Editor
 		private class ImageOverlaySet
 		{
 			private Image baseImage;
-			private Dictionary<Image,Image> overlayDict;
+			private Dictionary<Image, Image> overlayDict;
 
 			public Image Base
 			{
@@ -135,7 +124,7 @@ namespace Duality.Editor
 			public ImageOverlaySet(Image baseImage)
 			{
 				this.baseImage = baseImage;
-				this.overlayDict = new Dictionary<Image,Image>();;
+				this.overlayDict = new Dictionary<Image, Image>(); ;
 			}
 			public Image GetOverlay(Image overlayImage)
 			{
@@ -152,7 +141,7 @@ namespace Duality.Editor
 				return baseWithOverlay;
 			}
 		}
-		private static Dictionary<Image,ImageOverlaySet> overlayCache = new Dictionary<Image,ImageOverlaySet>();
+		private static Dictionary<Image, ImageOverlaySet> overlayCache = new Dictionary<Image, ImageOverlaySet>();
 		public static Image GetImageWithOverlay(Image baseImage, Image overlayImage)
 		{
 			ImageOverlaySet overlaySet;


### PR DESCRIPTION
Revision of #823

Decided to keep DualityEditor/DualityLauncher in the root for now as that doesn't require much changes in duality:
```
[Project Folder]
|
+- [Project].sln
|
+- DualityEditor.exe
+- Data
+- Plugins
+- all the other project files and binaries
|
+- Import
|
+- Source
   +- Launchers
      +- GameLauncher
      +- GameEditor
   +- Plugins
      +- GamePlugin
```