### PR TITLE
Fixed compiler errors when any Content folder contains source code

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <NoWarn>1701;1702;CS1591;CS0419</NoWarn>
+    <DefaultItemExcludes>$(DefaultItemExcludes);Content\**</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>


### PR DESCRIPTION
If one of the `Content` folders, either in any of the sample projects `Content` working directories contains source code of a custom game plugin, the build of the solution will fail due to it being included in the build by accident.

This PR fixes the issue by adding a global msbuild ignore for files in `Content` folder hierarchies.