### PR TITLE
Improved RawList API, Implementation and Tests

### DIFF
--- a/Source/Core/Duality/Utility/RawList.cs
+++ b/Source/Core/Duality/Utility/RawList.cs
@@ -135,7 +135,9 @@ namespace Duality
 		/// <param name="item"></param>
 		public void Add(T item)
 		{
-			this.Insert(this.count, item);
+			this.Reserve(this.count + 1);
+			this.data[this.count] = item;
+			this.count++;
 		}
 		/// <summary>
 		/// Adds a range of new items to the list.
@@ -381,7 +383,7 @@ namespace Duality
 		public void Reserve(int capacity)
 		{
 			if (this.data.Length >= capacity) return;
-			Array.Resize(ref this.data, MathF.Max(this.data.Length * 2, capacity, BaseCapacity));
+			Array.Resize(ref this.data, Math.Max(Math.Max(this.data.Length * 2, capacity), BaseCapacity));
 		}
 		/// <summary>
 		/// Moves a range of elements by a certain value and resets the indices that now remain empty.

--- a/Source/Core/Duality/Utility/RawList.cs
+++ b/Source/Core/Duality/Utility/RawList.cs
@@ -65,21 +65,17 @@ namespace Duality
 		}
 
 		/// <summary>
-		/// [GET / SET] A safety-checked index accessor to the lists internal array. Will throw an <see cref="System.IndexOutOfRangeException"/>
+		/// [GET / SET] A safety-checked by-ref index accessor to the lists internal array. Will throw an <see cref="System.IndexOutOfRangeException"/>
 		/// when attempting to access indices exceeding <see cref="Count"/>.
 		/// </summary>
 		/// <param name="index"></param>
-		public T this[int index]
+		/// <returns></returns>
+		public ref T this[int index]
 		{
 			get
 			{
 				if (index >= this.count) ThrowIndexOutOfRangeException();
-				return this.data[index];
-			}
-			set
-			{
-				if (index >= this.count) ThrowIndexOutOfRangeException();
-				this.data[index] = value;
+				return ref this.data[index];
 			}
 		}
 
@@ -537,6 +533,27 @@ namespace Duality
 		{
 			get { return this[index]; }
 			set { this[index] = (T)value; }
+		}
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)] T IList<T>.this[int index]
+		{
+			get
+			{
+				if (index >= this.count) ThrowIndexOutOfRangeException();
+				return this.data[index];
+			}
+			set
+			{
+				if (index >= this.count) ThrowIndexOutOfRangeException();
+				this.data[index] = value;
+			}
+		}
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)] T IReadOnlyList<T>.this[int index]
+		{
+			get
+			{
+				if (index >= this.count) ThrowIndexOutOfRangeException();
+				return this.data[index];
+			}
 		}
 
 		IEnumerator IEnumerable.GetEnumerator()

--- a/Source/Core/Duality/Utility/RawList.cs
+++ b/Source/Core/Duality/Utility/RawList.cs
@@ -90,11 +90,6 @@ namespace Duality
 		/// <param name="capacity"></param>
 		public RawList(int capacity) : this(new T[capacity], 0) {}
 		/// <summary>
-		/// Creates a new list with the specified contents.
-		/// </summary>
-		/// <param name="data"></param>
-		public RawList(IEnumerable<T> data) : this(data.ToArray()) {}
-		/// <summary>
 		/// Creates a new list that is a copy of the specified source list.
 		/// </summary>
 		/// <param name="source"></param>
@@ -151,14 +146,6 @@ namespace Duality
 			this.InsertRange(this.count, items);
 		}
 		/// <summary>
-		/// Adds a range of new items to the list.
-		/// </summary>
-		/// <param name="items"></param>
-		public void AddRange(IEnumerable<T> items)
-		{
-			this.InsertRange(this.count, items);
-		}
-		/// <summary>
 		/// Inserts a new item at a specified index.
 		/// </summary>
 		/// <param name="targetIndex">The index at which to insert the new items.</param>
@@ -173,15 +160,6 @@ namespace Duality
 			}
 			this.data[targetIndex] = item;
 			this.count++;
-		}
-		/// <summary>
-		/// Inserts a range of new items at a specified index.
-		/// </summary>
-		/// <param name="targetIndex">The index at which to insert the new items.</param>
-		/// <param name="items">The source enumerable to copy items from.</param>
-		public void InsertRange(int targetIndex, IEnumerable<T> items)
-		{
-			this.InsertRange(targetIndex, items.ToArray());
 		}
 		/// <summary>
 		/// Inserts a range of new items at a specified index.

--- a/Source/Core/Duality/Utility/RawList.cs
+++ b/Source/Core/Duality/Utility/RawList.cs
@@ -25,8 +25,9 @@ namespace Duality
 		private const int BaseCapacity = 8;
 
 
-		private	T[]	data;
-		private	int	count;
+		private T[] data;
+		private int count;
+
 
 		/// <summary>
 		/// [GET / SET] The lists internal array for data storage. Assigning an array that is shorter than <see cref="Count"/> will
@@ -83,22 +84,22 @@ namespace Duality
 		/// <summary>
 		/// Creates a new, empty list.
 		/// </summary>
-		public RawList() : this(new T[BaseCapacity], 0) {}
+		public RawList() : this(new T[BaseCapacity], 0) { }
 		/// <summary>
 		/// Creates a new list with the specified capacity.
 		/// </summary>
 		/// <param name="capacity"></param>
-		public RawList(int capacity) : this(new T[capacity], 0) {}
+		public RawList(int capacity) : this(new T[capacity], 0) { }
 		/// <summary>
 		/// Creates a new list that is a copy of the specified source list.
 		/// </summary>
 		/// <param name="source"></param>
-		public RawList(RawList<T> source) : this(source.Data.Clone() as T[], source.Count) {}
+		public RawList(RawList<T> source) : this((T[])source.Data.Clone(), source.Count) { }
 		/// <summary>
 		/// Creates a new list that wraps the specified array. Does not copy the array.
 		/// </summary>
 		/// <param name="wrapAround"></param>
-		public RawList(T[] wrapAround) : this(wrapAround, wrapAround.Length) {}
+		public RawList(T[] wrapAround) : this(wrapAround, wrapAround.Length) { }
 		/// <summary>
 		/// Creates a new list that wraps the specified array. Does not copy the array.
 		/// </summary>
@@ -116,6 +117,7 @@ namespace Duality
 		/// Returns the first index of the specified item within the used range of the internal array. Returns -1, if not found.
 		/// </summary>
 		/// <param name="item"></param>
+		/// <returns></returns>
 		public int IndexOf(T item)
 		{
 			return Array.IndexOf(this.data, item, 0, this.count);
@@ -124,6 +126,7 @@ namespace Duality
 		/// Returns whether the specified item is contained within the used range of the internal array.
 		/// </summary>
 		/// <param name="item"></param>
+		/// <returns></returns>
 		public bool Contains(T item)
 		{
 			return Array.IndexOf(this.data, item, 0, this.count) >= 0;
@@ -147,6 +150,7 @@ namespace Duality
 		{
 			this.InsertRange(this.count, items);
 		}
+
 		/// <summary>
 		/// Inserts a new item at a specified index.
 		/// </summary>
@@ -190,10 +194,12 @@ namespace Duality
 			Array.Copy(items, sourceIndex, this.data, targetIndex, count);
 			this.count += count;
 		}
+
 		/// <summary>
 		/// Removes the first matching item from the list.
 		/// </summary>
 		/// <param name="item"></param>
+		/// <returns></returns>
 		public bool Remove(T item)
 		{
 			int index = this.IndexOf(item);
@@ -316,6 +322,7 @@ namespace Duality
 		/// Removes all matching items from the list.
 		/// </summary>
 		/// <param name="predicate"></param>
+		/// <returns></returns>
 		public int RemoveAll(Predicate<T> predicate)
 		{
 			// Iterate over the internal array with two indices:
@@ -362,6 +369,7 @@ namespace Duality
 
 			return 0;
 		}
+
 		/// <summary>
 		/// Clears the entire list of its contents and resets its size to zero.
 		/// </summary>
@@ -374,7 +382,6 @@ namespace Duality
 			this.count = 0;
 		}
 
-		
 		/// <summary>
 		/// Sorts the entire list.
 		/// </summary>
@@ -467,7 +474,7 @@ namespace Duality
 		{
 			this.MoveInternal(index, count, moveBy, true);
 		}
-		
+
 		/// <summary>
 		/// Copies the contents of this collection to the specified array.
 		/// </summary>
@@ -507,19 +514,21 @@ namespace Duality
 
 		private void MoveInternal(int index, int count, int moveBy, bool resetToDefault)
 		{
-			if (count < 0)									throw new ArgumentException("Parameter 'count' may not be negative.", "count");
-			if (index < 0 || index >= this.data.Length)		throw new IndexOutOfRangeException("Parameter 'index' is out of range.");
-			if (index + count > this.data.Length)			throw new IndexOutOfRangeException("'index + count' is out of range.");
-			if (index + moveBy < 0)							throw new IndexOutOfRangeException("'index + moveBy' is out of range.");
-			if (index + moveBy + count > this.data.Length)	throw new IndexOutOfRangeException("'index + moveBy + count' is out of range.");
+			if (count < 0)                                 throw new ArgumentException("Parameter 'count' may not be negative.", "count");
+			if (index < 0 || index >= this.data.Length)    throw new IndexOutOfRangeException("Parameter 'index' is out of range.");
+			if (index + count > this.data.Length)          throw new IndexOutOfRangeException("'index + count' is out of range.");
+			if (index + moveBy < 0)                        throw new IndexOutOfRangeException("'index + moveBy' is out of range.");
+			if (index + moveBy + count > this.data.Length) throw new IndexOutOfRangeException("'index + moveBy + count' is out of range.");
 
 			int baseIndex = index + moveBy;
 			if (moveBy > 0)
 			{
+				// Non-overlapping move
 				if (moveBy >= count)
 				{
 					Array.Copy(this.data, index, this.data, index + moveBy, count);
 				}
+				// Source and target range within the array are overlapping
 				else
 				{
 					for (int i = baseIndex + count - 1; i >= baseIndex; i--)
@@ -527,6 +536,7 @@ namespace Duality
 						this.data[i] = this.data[i - moveBy];
 					}
 				}
+
 				if (resetToDefault)
 				{
 					int clearCount = Math.Min(moveBy, count);
@@ -535,10 +545,12 @@ namespace Duality
 			}
 			else
 			{
+				// Non-overlapping move
 				if (-moveBy >= count)
 				{
 					Array.Copy(this.data, index, this.data, index + moveBy, count);
 				}
+				// Source and target range within the array are overlapping
 				else
 				{
 					for (int i = baseIndex; i < baseIndex + count; i++)
@@ -546,6 +558,7 @@ namespace Duality
 						this.data[i] = this.data[i - moveBy];
 					}
 				}
+
 				if (resetToDefault)
 				{
 					int clearCount = Math.Min(-moveBy, count);

--- a/Source/Core/Duality/Utility/RawList.cs
+++ b/Source/Core/Duality/Utility/RawList.cs
@@ -594,12 +594,13 @@ namespace Duality
 		{
 			get { return this.data; }
 		}
-		[DebuggerBrowsable(DebuggerBrowsableState.Never)] object IList.this[int index]
+
+		object IList.this[int index]
 		{
 			get { return this[index]; }
 			set { this[index] = (T)value; }
 		}
-		[DebuggerBrowsable(DebuggerBrowsableState.Never)] T IList<T>.this[int index]
+		T IList<T>.this[int index]
 		{
 			get
 			{
@@ -612,7 +613,7 @@ namespace Duality
 				this.data[index] = value;
 			}
 		}
-		[DebuggerBrowsable(DebuggerBrowsableState.Never)] T IReadOnlyList<T>.this[int index]
+		T IReadOnlyList<T>.this[int index]
 		{
 			get
 			{

--- a/Source/Core/Duality/Utility/RawList.cs
+++ b/Source/Core/Duality/Utility/RawList.cs
@@ -437,7 +437,7 @@ namespace Duality
 			if (index < 0 || index >= this.count) throw new IndexOutOfRangeException("Parameter 'index' is out of range.");
 			if (index + count > this.count)       throw new IndexOutOfRangeException("'index + count' is out of range.");
 
-			Array.Sort(this.data, index, count, new FunctorComparer(comparison));
+			Array.Sort(this.data, index, count, Comparer<T>.Create(comparison));
 		}
 
 		/// <summary>
@@ -640,18 +640,6 @@ namespace Duality
 		#endregion
 
 
-		internal sealed class FunctorComparer : IComparer<T>
-		{
-			private Comparison<T> comparison;
-			public FunctorComparer(Comparison<T> comparison)
-			{
-				this.comparison = comparison;
-			}
-			public int Compare(T x, T y)
-			{
-				return this.comparison(x, y);
-			}
-		}
 		internal sealed class DebuggerTypeProxy
 		{
 			private RawList<T> rawList;

--- a/Test/Core/Utility/RawListTest.cs
+++ b/Test/Core/Utility/RawListTest.cs
@@ -121,28 +121,28 @@ namespace Duality.Tests.Utility
 		{
 			// Remove nothing
 			{
-				RawList<int> list = new RawList<int>(Enumerable.Range(0, 10));
+				RawList<int> list = new RawList<int>(Enumerable.Range(0, 10).ToArray());
 				list.RemoveAll(i => false);
 				CollectionAssert.AreEqual(Enumerable.Range(0, 10), list);
 			}
 
 			// Remove everything
 			{
-				RawList<int> list = new RawList<int>(Enumerable.Range(0, 10));
+				RawList<int> list = new RawList<int>(Enumerable.Range(0, 10).ToArray());
 				list.RemoveAll(i => true);
 				CollectionAssert.AreEqual(new int[0], list);
 			}
 
 			// Remove all even numbers
 			{
-				RawList<int> list = new RawList<int>(Enumerable.Range(0, 10));
+				RawList<int> list = new RawList<int>(Enumerable.Range(0, 10).ToArray());
 				list.RemoveAll(i => i % 2 == 0);
 				CollectionAssert.AreEqual(new int[] { 1, 3, 5, 7, 9 }, list);
 			}
 
 			// Remove numbers that are in a second list with no regularity
 			{
-				RawList<int> list = new RawList<int>(Enumerable.Range(0, 10));
+				RawList<int> list = new RawList<int>(Enumerable.Range(0, 10).ToArray());
 				RawList<int> removeList = new RawList<int>(new int[] { 1, 2, 4, 5, 6, 9 });
 				list.RemoveAll(i => removeList.Contains(i));
 				CollectionAssert.AreEqual(new int[] { 0, 3, 7, 8 }, list);
@@ -150,7 +150,10 @@ namespace Duality.Tests.Utility
 		}
 		[Test] public void RemoveResetsReferenceTypesToDefault()
 		{
-			RawList<string> list = new RawList<string>(Enumerable.Range(0, 10).Select(i => i.ToString()));
+			RawList<string> list = new RawList<string>(
+				Enumerable.Range(0, 10)
+				.Select(i => i.ToString())
+				.ToArray());
 
 			// Is the internal array empty if not assigned otherwise?
 			if (list.Capacity > list.Count)

--- a/Test/Core/Utility/RawListTest.cs
+++ b/Test/Core/Utility/RawListTest.cs
@@ -46,9 +46,17 @@ namespace Duality.Tests.Utility
 			CollectionAssert.AreEqual(new int[] { 10, 150, 200, 250, 300, 17, 94 }, intList);
 			CollectionAssert.AreEqual(new int[] { 10, 150, 200, 250, 300, 17, 94 }, intList.Data.Take(intList.Count));
 
+			intList.RemoveLast();
+			CollectionAssert.AreEqual(new int[] { 10, 150, 200, 250, 300, 17 }, intList);
+			CollectionAssert.AreEqual(new int[] { 10, 150, 200, 250, 300, 17 }, intList.Data.Take(intList.Count));
+
+			intList.RemoveLast(4);
+			CollectionAssert.AreEqual(new int[] { 10, 150 }, intList);
+			CollectionAssert.AreEqual(new int[] { 10, 150 }, intList.Data.Take(intList.Count));
+
 			intList.Clear();
 			Assert.AreEqual(0, intList.Count);
-			Assert.IsTrue(!intList.Contains(94));
+			Assert.IsTrue(!intList.Contains(10));
 		}
 		[Test] public void Move()
 		{
@@ -147,6 +155,48 @@ namespace Duality.Tests.Utility
 				list.RemoveAll(i => removeList.Contains(i));
 				CollectionAssert.AreEqual(new int[] { 0, 3, 7, 8 }, list);
 			}
+		}
+		[Test] public void RemoveAtFast()
+		{
+			RawList<int> list = new RawList<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+			list.RemoveAtFast(9);
+			CollectionAssert.AreEqual(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 }, list);
+
+			list.RemoveAtFast(0);
+			CollectionAssert.AreEqual(new int[] { 8, 1, 2, 3, 4, 5, 6, 7 }, list);
+
+			list.RemoveAtFast(3);
+			CollectionAssert.AreEqual(new int[] { 8, 1, 2, 7, 4, 5, 6 }, list);
+
+			list.RemoveAtFast(6);
+			list.RemoveAtFast(5);
+			list.RemoveAtFast(4);
+			list.RemoveAtFast(3);
+			CollectionAssert.AreEqual(new int[] { 8, 1, 2 }, list);
+
+			list.RemoveAtFast(0);
+			list.RemoveAtFast(0);
+			CollectionAssert.AreEqual(new int[] { 1 }, list);
+
+			list.RemoveAtFast(0);
+			CollectionAssert.AreEqual(new int[0], list);
+		}
+		[Test] public void RemoveRangeFast()
+		{
+			RawList<int> list = new RawList<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+			list.RemoveRangeFast(7, 3);
+			CollectionAssert.AreEqual(new int[] { 0, 1, 2, 3, 4, 5, 6 }, list);
+
+			list.RemoveRangeFast(0, 3);
+			CollectionAssert.AreEqual(new int[] { 6, 5, 4, 3 }, list);
+
+			list.RemoveRangeFast(1, 3);
+			CollectionAssert.AreEqual(new int[] { 6 }, list);
+
+			list.RemoveRangeFast(0, 1);
+			CollectionAssert.AreEqual(new int[0], list);
 		}
 		[Test] public void RemoveResetsReferenceTypesToDefault()
 		{


### PR DESCRIPTION
As noted in #820, the `RawList<T>` class can benefit from newly available ref-returns in C# 7.3 for its indexer implementation. Since this is a breaking change for v4.0, it also was a good opportunity to rework and extend some of its API to better address its core use case.

This PR adds several small improvements, as well as a by-ref indexer for `RawList<T>`. For a detailed list, see the individual commits, which have been structured so each one represents a group of changes.