### PR TITLE
Updated copyright note in license info

### DIFF
--- a/Build/NuGetPackageSpecs/AudioHandling.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/AudioHandling.Sample.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Samples.AudioHandling</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Audio Handling Sample</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/Base.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/Base.Editor.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Editor.Plugins.Base</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Editor Base Infrastructure</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/BasicShaders.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/BasicShaders.Sample.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Samples.BasicShaders</id>
     <version>4.0.0-alpha0</version>
-    <authors>Pilati Alessandro, Fedja Adam</authors>
-    <owners>Pilati Alessandro, Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Basic Shaders Sample</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/Benchmarks.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/Benchmarks.Sample.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Samples.Benchmarks</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Benchmarks Sample</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/CamView.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/CamView.Editor.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Editor.Plugins.CamView</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Camera View</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/CameraController.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/CameraController.Sample.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Samples.CameraController</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Camera Controller Sample</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/Compatibility.Core.nuspec
+++ b/Build/NuGetPackageSpecs/Compatibility.Core.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Plugins.Compatibility</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Backwards Compatibility</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/CustomRenderingSetup.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/CustomRenderingSetup.Sample.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Samples.CustomRenderingSetup</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Custom Rendering Setup Sample</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/DefaultOpenTKBackend.Core.nuspec
+++ b/Build/NuGetPackageSpecs/DefaultOpenTKBackend.Core.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Backend.DefaultOpenTK</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>OpenTK Backend</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/DefaultOpenTKBackend.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/DefaultOpenTKBackend.Editor.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Editor.Backend.DefaultOpenTK</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>OpenTK Editor Backend</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/DotNetFrameworkBackend.Core.nuspec
+++ b/Build/NuGetPackageSpecs/DotNetFrameworkBackend.Core.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Backend.DotNetFramework</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>DotNetFramework Backend</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/DualStickSpaceShooter.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/DualStickSpaceShooter.Sample.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Samples.DualStickSpaceShooter</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Dual Stick Space Shooter Sample</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/Duality.Docs.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.Docs.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Docs</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Duality Documentation</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/Duality.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.Editor.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Editor</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Duality Editor</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/Duality.Launcher.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.Launcher.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Launcher</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Duality Launcher</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/Duality.Physics.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.Physics.nuspec
@@ -4,7 +4,7 @@
     <id>AdamsLair.Duality.Physics</id>
     <version>4.0.0-alpha0</version>
     <authors>See original project authors</authors>
-    <owners>Fedja Adam</owners>
+    <owners>Duality Core Team</owners>
     <title>Duality Physics</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/Duality.Primitives.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.Primitives.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Primitives</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Duality Primitives</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/Duality.nuspec
+++ b/Build/NuGetPackageSpecs/Duality.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Duality Core</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/DynamicLighting.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/DynamicLighting.Sample.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Samples.DynamicLighting</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>DynamicLighting Sample</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/HelpAdvisor.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/HelpAdvisor.Editor.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Editor.Plugins.HelpAdvisor</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Help Advisor</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/InputHandling.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/InputHandling.Sample.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Samples.InputHandling</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Input Handling Sample</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/LogView.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/LogView.Editor.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Editor.Plugins.LogView</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Log View</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/ObjectInspector.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/ObjectInspector.Editor.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Editor.Plugins.ObjectInspector</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Object Inspector</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/ParticleSystem.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/ParticleSystem.Sample.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Samples.ParticleSystem</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Custom ParticleSystem Sample</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/Physics.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/Physics.Sample.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Samples.Physics</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Physics Sample</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/ProjectView.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/ProjectView.Editor.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Editor.Plugins.ProjectView</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Project View</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/SceneView.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/SceneView.Editor.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Editor.Plugins.SceneView</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Scene View</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/SmoothAnimation.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/SmoothAnimation.Sample.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Samples.SmoothAnimation</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Smooth Sprite Animation Blending Sample</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/Steering.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/Steering.Sample.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Samples.Steering</id>
     <version>4.0.0-alpha0</version>
-    <authors>Daniel Herb, Fedja Adam</authors>
-    <owners>Daniel Herb, Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Steering Behaviours Sample</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/Tilemaps.Core.nuspec
+++ b/Build/NuGetPackageSpecs/Tilemaps.Core.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Plugins.Tilemaps</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Tilemaps (Core)</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/Tilemaps.Editor.nuspec
+++ b/Build/NuGetPackageSpecs/Tilemaps.Editor.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Editor.Plugins.Tilemaps</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Tilemaps (Editor)</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/Build/NuGetPackageSpecs/Tilemaps.Sample.nuspec
+++ b/Build/NuGetPackageSpecs/Tilemaps.Sample.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>AdamsLair.Duality.Samples.Tilemaps</id>
     <version>4.0.0-alpha0</version>
-    <authors>Fedja Adam</authors>
-    <owners>Fedja Adam</owners>
+    <authors>Duality Core Team</authors>
+    <owners>Duality Core Team</owners>
     <title>Tilemaps Sample</title>
     <icon>icon.png</icon>
     <license type="expression">MIT</license>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Fedja Adam
+Copyright (c) 2020 The Duality Core Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/Samples/DynamicLighting/Core/DynamicLighting.Sample.Core.csproj
+++ b/Samples/DynamicLighting/Core/DynamicLighting.Sample.Core.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>4.0.0-alpha0</Version>
-		<Copyright>Copyright © Fedja Adam 2012</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<OutputPath>Content\Plugins\</OutputPath>
 	</PropertyGroup>
 

--- a/Samples/DynamicLighting/Editor/DynamicLighting.Sample.Editor.csproj
+++ b/Samples/DynamicLighting/Editor/DynamicLighting.Sample.Editor.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>4.0.0-alpha0</Version>
-		<Copyright>Copyright © Fedja Adam 2012</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>
 		<OutputPath>Content\Plugins\</OutputPath>
 	</PropertyGroup>

--- a/Source/Core/Duality/Duality.csproj
+++ b/Source/Core/Duality/Duality.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>4.0.0-alpha0</Version>
-		<Copyright>Copyright © Fedja Adam 2012</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Source/Core/Physics/DualityPhysics.csproj
+++ b/Source/Core/Physics/DualityPhysics.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>4.0.0-alpha0</Version>
-		<Copyright>Copyright © Fedja Adam 2018</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<NeutralLanguage>en</NeutralLanguage>
 	</PropertyGroup>
 	

--- a/Source/Core/Primitives/DualityPrimitives.csproj
+++ b/Source/Core/Primitives/DualityPrimitives.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>4.0.0-alpha0</Version>
-		<Copyright>Copyright © Fedja Adam 2015</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<NeutralLanguage>en</NeutralLanguage>
 	</PropertyGroup>
 

--- a/Source/Editor/DualityEditor/DualityEditor.csproj
+++ b/Source/Editor/DualityEditor/DualityEditor.csproj
@@ -5,7 +5,7 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<LangVersion>7.3</LangVersion>
 		<OutputPath>$(SolutionDir)Build\Output\</OutputPath>
-		<Copyright>Copyright © Fedja Adam 2012</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<RootNamespace>Duality.Editor</RootNamespace>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<OutputType>WinExe</OutputType>

--- a/Source/Editor/Updater/DualityUpdater.csproj
+++ b/Source/Editor/Updater/DualityUpdater.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<LangVersion>7.3</LangVersion>
 		<OutputPath>$(SolutionDir)Build\Output\</OutputPath>
-		<Copyright>Copyright © Fedja Adam 2014</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<RootNamespace>Duality.Updater</RootNamespace>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<OutputType>Exe</OutputType>

--- a/Source/Launcher/DualityLauncher.csproj
+++ b/Source/Launcher/DualityLauncher.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<LangVersion>7.3</LangVersion>
 		<OutputPath>$(SolutionDir)Build\Output\</OutputPath>
-		<Copyright>Copyright © Fedja Adam 2012</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<RootNamespace>Duality.Launcher</RootNamespace>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<ApplicationIcon>DualityIcon.ico</ApplicationIcon>

--- a/Source/Platform/DefaultOpenTK/DefaultOpenTK.Core.csproj
+++ b/Source/Platform/DefaultOpenTK/DefaultOpenTK.Core.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net472</TargetFramework>
 		<LangVersion>7.3</LangVersion>
-		<Copyright>Copyright © Fedja Adam 2015</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<RootNamespace>Duality.Backend.DefaultOpenTK</RootNamespace>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<Version>4.0.0-alpha0</Version>

--- a/Source/Platform/DefaultOpenTKEditor/DefaultOpenTK.Editor.csproj
+++ b/Source/Platform/DefaultOpenTKEditor/DefaultOpenTK.Editor.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net472</TargetFramework>
 		<LangVersion>7.3</LangVersion>
-		<Copyright>Copyright © Fedja Adam 2015</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<RootNamespace>Duality.Editor.Backend.DefaultOpenTK</RootNamespace>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<Version>4.0.0-alpha0</Version>

--- a/Source/Platform/DotNetFramework/DotNetFramework.Core.csproj
+++ b/Source/Platform/DotNetFramework/DotNetFramework.Core.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net472</TargetFramework>
 		<LangVersion>7.3</LangVersion>
-		<Copyright>Copyright © Fedja Adam 2015</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<RootNamespace>Duality.Backend.DotNetFramework</RootNamespace>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<Version>4.0.0-alpha0</Version>

--- a/Source/Plugins/EditorBase/EditorBase.Editor.csproj
+++ b/Source/Plugins/EditorBase/EditorBase.Editor.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>4.0.0-alpha0</Version>
-		<Copyright>Copyright © Fedja Adam 2012</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<RootNamespace>Duality.Editor.Plugins.Base</RootNamespace>
 		<UseWindowsForms>true</UseWindowsForms>
 		<EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>

--- a/Source/Plugins/EditorModules/CamView/CamView.Editor.csproj
+++ b/Source/Plugins/EditorModules/CamView/CamView.Editor.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>4.0.0-alpha0</Version>
-		<Copyright>Copyright © Fedja Adam 2012</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<RootNamespace>Duality.Editor.Plugins.CamView</RootNamespace>
 		<UseWindowsForms>true</UseWindowsForms>
 		<EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>

--- a/Source/Plugins/EditorModules/HelpAdvisor/HelpAdvisor.Editor.csproj
+++ b/Source/Plugins/EditorModules/HelpAdvisor/HelpAdvisor.Editor.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>4.0.0-alpha0</Version>
-		<Copyright>Copyright © Fedja Adam 2012</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<RootNamespace>Duality.Editor.Plugins.HelpAdvisor</RootNamespace>
 		<UseWindowsForms>true</UseWindowsForms>
 		<EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>

--- a/Source/Plugins/EditorModules/LogView/LogView.Editor.csproj
+++ b/Source/Plugins/EditorModules/LogView/LogView.Editor.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>4.0.0-alpha0</Version>
-		<Copyright>Copyright © Fedja Adam 2012</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<RootNamespace>Duality.Editor.Plugins.LogView</RootNamespace>
 		<UseWindowsForms>true</UseWindowsForms>
 		<EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>

--- a/Source/Plugins/EditorModules/ObjectInspector/ObjectInspector.Editor.csproj
+++ b/Source/Plugins/EditorModules/ObjectInspector/ObjectInspector.Editor.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>4.0.0-alpha0</Version>
-		<Copyright>Copyright © Fedja Adam 2012</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<RootNamespace>Duality.Editor.Plugins.ObjectInspector</RootNamespace>
 		<UseWindowsForms>true</UseWindowsForms>
 		<EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>

--- a/Source/Plugins/EditorModules/ProjectView/ProjectView.Editor.csproj
+++ b/Source/Plugins/EditorModules/ProjectView/ProjectView.Editor.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>4.0.0-alpha0</Version>
-		<Copyright>Copyright © Fedja Adam 2012</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<RootNamespace>Duality.Editor.Plugins.ProjectView</RootNamespace>
 		<UseWindowsForms>true</UseWindowsForms>
 		<EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>

--- a/Source/Plugins/EditorModules/SceneView/SceneView.Editor.csproj
+++ b/Source/Plugins/EditorModules/SceneView/SceneView.Editor.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>4.0.0-alpha0</Version>
-		<Copyright>Copyright © Fedja Adam 2012</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<RootNamespace>Duality.Editor.Plugins.SceneView</RootNamespace>
 		<UseWindowsForms>true</UseWindowsForms>
 		<EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>

--- a/Source/Plugins/Tilemaps/Core/Tilemaps.Core.csproj
+++ b/Source/Plugins/Tilemaps/Core/Tilemaps.Core.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>4.0.0-alpha0</Version>
-		<Copyright>Copyright © Fedja Adam 2015</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\Core\Primitives\DualityPrimitives.csproj">

--- a/Source/Plugins/Tilemaps/Editor/Tilemaps.Editor.csproj
+++ b/Source/Plugins/Tilemaps/Editor/Tilemaps.Editor.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>4.0.0-alpha0</Version>
-		<Copyright>Copyright © Fedja Adam 2015</Copyright>
+		<Copyright>Copyright © Duality Core Team 2020</Copyright>
 		<RootNamespace>Duality.Editor.Plugins.Tilemaps</RootNamespace>
 		<UseWindowsForms>true</UseWindowsForms>
 		<EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>


### PR DESCRIPTION
The LICENSE note still stated I had the copyright on Duality, dated 2017. I'd like to remove my name from this entirely, replacing it with a reference to the core team and an updated timestamp.