### PR TITLE
Migrate performance benchmarks in unit tests to benchmarkdotnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ Build/NUnit/nunit-project-loader.dll
 Build/NUnit/Mono.Cecil.dll
 Build/NUnit/nunit3-console.exe
 Samples/**/Content/Plugins
+Benchmarks/DualityBenchmarks/BenchmarkDotNet.Artifacts

--- a/Benchmarks/DualityBenchmarks/CloneProviderBenchmarks.cs
+++ b/Benchmarks/DualityBenchmarks/CloneProviderBenchmarks.cs
@@ -9,33 +9,25 @@ namespace DualityBenchmarks
 	public class CloneProviderBenchmarks
 	{
 		private Random rnd;
-		private TestObject[] results;
 		private TestObject data;
 
 		[GlobalSetup]
 		public void Setup()
 		{
 			this.rnd = new Random(0);
-			this.results = new TestObject[200];
 			this.data = new TestObject(this.rnd, 5);
 		}
 
 		[Benchmark]
-		public void CloneTestObjectGraph()
+		public TestObject CloneTestObjectGraph()
 		{
-			for (int i = 0; i < this.results.Length; i++)
-			{
-				this.results[i] = this.data.DeepClone();
-			}
+			return this.data.DeepClone();
 		}
 
 		[Benchmark(Baseline = true)]
-		public void CreateWithoutClone()
+		public TestObject CreateWithoutClone()
 		{
-			for (int i = 0; i < this.results.Length; i++)
-			{
-				this.results[i] = new TestObject(this.rnd, 5);
-			}
+			return new TestObject(this.rnd, 5);
 		}
 	}
 }

--- a/Benchmarks/DualityBenchmarks/CloneProviderBenchmarks.cs
+++ b/Benchmarks/DualityBenchmarks/CloneProviderBenchmarks.cs
@@ -5,6 +5,7 @@ using Duality.Tests.Serialization;
 
 namespace DualityBenchmarks
 {
+	[MemoryDiagnoser]
 	public class CloneProviderBenchmarks
 	{
 		private Random rnd;

--- a/Benchmarks/DualityBenchmarks/CloneProviderBenchmarks.cs
+++ b/Benchmarks/DualityBenchmarks/CloneProviderBenchmarks.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using Duality.Cloning;
+using Duality.Tests.Serialization;
+
+namespace DualityBenchmarks
+{
+	public class CloneProviderBenchmarks
+	{
+		[Benchmark]
+		public void CloneTestObjectGraph()
+		{
+			Random rnd = new Random(0);
+			TestObject data = new TestObject(rnd, 5);
+			TestObject[] results = new TestObject[200];
+
+			for (int i = 0; i < results.Length; i++)
+			{
+				results[i] = data.DeepClone();
+			}
+		}
+
+		[Benchmark(Baseline = true)]
+		public void CreateWithoutClone()
+		{
+			Random rnd = new Random(0);
+			TestObject[] results = new TestObject[200];
+			for (int i = 0; i < results.Length; i++)
+			{
+				results[i] = new TestObject(rnd, 5);
+			}
+		}
+	}
+}

--- a/Benchmarks/DualityBenchmarks/CloneProviderBenchmarks.cs
+++ b/Benchmarks/DualityBenchmarks/CloneProviderBenchmarks.cs
@@ -7,27 +7,33 @@ namespace DualityBenchmarks
 {
 	public class CloneProviderBenchmarks
 	{
+		private Random rnd;
+		private TestObject[] results;
+		private TestObject data;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			this.rnd = new Random(0);
+			this.results = new TestObject[200];
+			this.data = new TestObject(this.rnd, 5);
+		}
+
 		[Benchmark]
 		public void CloneTestObjectGraph()
 		{
-			Random rnd = new Random(0);
-			TestObject data = new TestObject(rnd, 5);
-			TestObject[] results = new TestObject[200];
-
-			for (int i = 0; i < results.Length; i++)
+			for (int i = 0; i < this.results.Length; i++)
 			{
-				results[i] = data.DeepClone();
+				this.results[i] = this.data.DeepClone();
 			}
 		}
 
 		[Benchmark(Baseline = true)]
 		public void CreateWithoutClone()
 		{
-			Random rnd = new Random(0);
-			TestObject[] results = new TestObject[200];
-			for (int i = 0; i < results.Length; i++)
+			for (int i = 0; i < this.results.Length; i++)
 			{
-				results[i] = new TestObject(rnd, 5);
+				this.results[i] = new TestObject(this.rnd, 5);
 			}
 		}
 	}

--- a/Benchmarks/DualityBenchmarks/DualityBenchmarks.csproj
+++ b/Benchmarks/DualityBenchmarks/DualityBenchmarks.csproj
@@ -6,6 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="BenchmarkDotNet.Artifacts\**" />
+    <EmbeddedResource Remove="BenchmarkDotNet.Artifacts\**" />
+    <None Remove="BenchmarkDotNet.Artifacts\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>
 

--- a/Benchmarks/DualityBenchmarks/DualityBenchmarks.csproj
+++ b/Benchmarks/DualityBenchmarks/DualityBenchmarks.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Source\Core\Duality\Duality.csproj" />
+    <ProjectReference Include="..\..\Test\Core\DualityTests.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Benchmarks/DualityBenchmarks/PrefabBenchmarks.cs
+++ b/Benchmarks/DualityBenchmarks/PrefabBenchmarks.cs
@@ -10,31 +10,23 @@ namespace DualityBenchmarks
 	public class PrefabBenchmarks
 	{
 		private Prefab prefab;
-		private GameObject[] results;
 
 		[GlobalSetup]
 		public void Setup()
 		{
 			this.prefab = new Prefab(this.CreateSimpleGameObject());
-			this.results = new GameObject[1000];
 		}
 
 		[Benchmark(Baseline = true)]
-		public void CreateWithoutPrefabs()
+		public GameObject CreateWithoutPrefabs()
 		{
-			for (int i = 0; i < this.results.Length; i++)
-			{
-				this.CreateSimpleGameObject();
-			}
+			return this.CreateSimpleGameObject();
 		}
 
 		[Benchmark]
-		public void Instantiate()
+		public GameObject Instantiate()
 		{
-			for (int i = 0; i < this.results.Length; i++)
-			{
-				this.results[i] = this.prefab.Instantiate();
-			}
+			return this.prefab.Instantiate();
 		}
 
 		private GameObject CreateSimpleGameObject(GameObject parent = null)

--- a/Benchmarks/DualityBenchmarks/PrefabBenchmarks.cs
+++ b/Benchmarks/DualityBenchmarks/PrefabBenchmarks.cs
@@ -1,0 +1,48 @@
+﻿using BenchmarkDotNet.Attributes;
+using Duality.Resources;
+using Duality;
+using Duality.Components;
+using Duality.Components.Renderers;
+
+namespace DualityBenchmarks
+{
+	[MemoryDiagnoser]
+	public class PrefabBenchmarks
+	{
+		private Prefab prefab;
+		private GameObject[] results;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			this.prefab = new Prefab(this.CreateSimpleGameObject());
+			this.results = new GameObject[1000];
+		}
+
+		[Benchmark(Baseline = true)]
+		public void CreateWithoutPrefabs()
+		{
+			for (int i = 0; i < this.results.Length; i++)
+			{
+				this.CreateSimpleGameObject();
+			}
+		}
+
+		[Benchmark]
+		public void Instantiate()
+		{
+			for (int i = 0; i < this.results.Length; i++)
+			{
+				this.results[i] = this.prefab.Instantiate();
+			}
+		}
+
+		private GameObject CreateSimpleGameObject(GameObject parent = null)
+		{
+			GameObject obj = new GameObject("SimpleObject", parent);
+			obj.AddComponent<Transform>();
+			obj.AddComponent<SpriteRenderer>();
+			return obj;
+		}
+	}
+}

--- a/Benchmarks/DualityBenchmarks/Program.cs
+++ b/Benchmarks/DualityBenchmarks/Program.cs
@@ -10,13 +10,6 @@ namespace DualityBenchmarks
     {
         static void Main(string[] args)
         {
-			// Initialize Duality
-			DualityApp.Init(
-				DualityApp.ExecutionEnvironment.Launcher,
-				DualityApp.ExecutionContext.Game,
-				new DefaultAssemblyLoader(),
-				null);
-
 			if (Debugger.IsAttached)
 			{
 				BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new DebugInProcessConfig());

--- a/Benchmarks/DualityBenchmarks/Program.cs
+++ b/Benchmarks/DualityBenchmarks/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Diagnostics;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 using Duality;
@@ -6,7 +6,7 @@ using Duality.Backend;
 
 namespace DualityBenchmarks
 {
-    class Program
+	class Program
     {
         static void Main(string[] args)
         {
@@ -17,7 +17,13 @@ namespace DualityBenchmarks
 				new DefaultAssemblyLoader(),
 				null);
 
-			BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new DebugInProcessConfig());
+			if (Debugger.IsAttached)
+			{
+				BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new DebugInProcessConfig());
+			}
+			else {
+				BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+			}			
 		}
     }
 }

--- a/Benchmarks/DualityBenchmarks/Program.cs
+++ b/Benchmarks/DualityBenchmarks/Program.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using BenchmarkDotNet.Running;
+
+namespace DualityBenchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+			BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+		}
+    }
+}

--- a/Benchmarks/DualityBenchmarks/Program.cs
+++ b/Benchmarks/DualityBenchmarks/Program.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
+using Duality;
+using Duality.Backend;
 
 namespace DualityBenchmarks
 {
@@ -7,7 +10,14 @@ namespace DualityBenchmarks
     {
         static void Main(string[] args)
         {
-			BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+			// Initialize Duality
+			DualityApp.Init(
+				DualityApp.ExecutionEnvironment.Launcher,
+				DualityApp.ExecutionContext.Game,
+				new DefaultAssemblyLoader(),
+				null);
+
+			BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new DebugInProcessConfig());
 		}
     }
 }

--- a/Benchmarks/DualityBenchmarks/SerializerBenchmarks.cs
+++ b/Benchmarks/DualityBenchmarks/SerializerBenchmarks.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.IO;
+using Duality.Tests.Serialization;
+using Duality.Serialization;
+using BenchmarkDotNet.Attributes;
+
+namespace DualityBenchmarks
+{
+	[MemoryDiagnoser]
+	public class SerializerBenchmarks
+	{
+		[Params(typeof(XmlSerializer), typeof(BinarySerializer))]
+		public Type type;
+		private Random rnd;
+		private TestObject[] results;
+		private byte[] readData;
+		private TestObject data;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			this.rnd = new Random(0);
+			this.results = new TestObject[50];
+			this.data = new TestObject(this.rnd, 5);
+
+			using (MemoryStream stream = new MemoryStream())
+			{
+				for (int i = 0; i < this.results.Length; i++)
+				{
+					using (Serializer formatterWrite = Serializer.Create(stream, this.type))
+					{
+						formatterWrite.WriteObject(this.data);
+					}
+				}
+				this.readData = stream.GetBuffer();
+			}
+		}
+
+		[Benchmark]
+		public void Write()
+		{
+			using (MemoryStream stream = new MemoryStream())
+			{
+				for (int i = 0; i < this.results.Length; i++)
+				{
+					using (Serializer formatterWrite = Serializer.Create(stream, this.type))
+					{
+						formatterWrite.WriteObject(this.data);
+					}
+				}
+			}
+		}
+
+		[Benchmark]
+		public void Read()
+		{
+			using (MemoryStream stream = new MemoryStream(this.readData))
+			{
+				for (int i = 0; i < this.results.Length; i++)
+				{
+					using (Serializer formatterRead = Serializer.Create(stream))
+					{
+						this.results[i] = formatterRead.ReadObject<TestObject>();
+					}
+				}
+			}
+		}
+	}
+}

--- a/Benchmarks/DualityBenchmarks/SpecificCloningBenchmarks.cs
+++ b/Benchmarks/DualityBenchmarks/SpecificCloningBenchmarks.cs
@@ -1,0 +1,49 @@
+﻿using BenchmarkDotNet.Attributes;
+using Duality;
+using Duality.Components;
+using Duality.Components.Renderers;
+using Duality.Cloning;
+using Duality.Components.Physics;
+
+namespace DualityBenchmarks
+{
+	[MemoryDiagnoser]
+	public class SpecificCloningBenchmarks
+	{
+		private GameObject data;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			this.data = new GameObject("CloneRoot");
+			for (int i = 0; i < 1000; i++)
+			{
+				GameObject child = new GameObject("Child", this.data);
+				child.AddComponent<Transform>();
+				if (i % 3 != 0) child.AddComponent<SpriteRenderer>();
+				if (i % 3 == 0) child.AddComponent<RigidBody>();
+				if (i % 7 == 0) child.AddComponent<TextRenderer>();
+			}
+		}
+
+		[Benchmark]
+		public void CreateWithoutClone()
+		{
+			var data = new GameObject("CloneRoot");
+			for (int i = 0; i < 1000; i++)
+			{
+				GameObject child = new GameObject("Child", data);
+				child.AddComponent<Transform>();
+				if (i % 3 != 0) child.AddComponent<SpriteRenderer>();
+				if (i % 3 == 0) child.AddComponent<RigidBody>();
+				if (i % 7 == 0) child.AddComponent<TextRenderer>();
+			}
+		}
+
+		[Benchmark]
+		public GameObject CloneGameObjectGraph()
+		{
+			return this.data.DeepClone();
+		}
+	}
+}

--- a/Duality.sln
+++ b/Duality.sln
@@ -102,6 +102,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DualityPhysics", "Source\Co
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DualityTemplates", "Source\DualityTemplates\DualityTemplates.csproj", "{3AB26D57-70D9-40DE-B12D-6B1489035805}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DualityBenchmarks", "Benchmarks\DualityBenchmarks\DualityBenchmarks.csproj", "{20985018-3635-478D-BA4F-6AF1E278C0AB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -260,6 +262,10 @@ Global
 		{3AB26D57-70D9-40DE-B12D-6B1489035805}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3AB26D57-70D9-40DE-B12D-6B1489035805}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3AB26D57-70D9-40DE-B12D-6B1489035805}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20985018-3635-478D-BA4F-6AF1E278C0AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20985018-3635-478D-BA4F-6AF1E278C0AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20985018-3635-478D-BA4F-6AF1E278C0AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20985018-3635-478D-BA4F-6AF1E278C0AB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -305,6 +311,7 @@ Global
 		{D220795D-8A59-432F-A8EC-CE9143DD07D5} = {9D215950-8E34-4070-914F-7B7D8A54ED6C}
 		{165D83B8-EAE8-4CDC-9003-E595D4225B8F} = {9D215950-8E34-4070-914F-7B7D8A54ED6C}
 		{5CA66347-C3DA-47DA-B07B-E2B89E6E712A} = {FC08D0D6-612E-4AD2-950C-8E9BA895D5D1}
+		{20985018-3635-478D-BA4F-6AF1E278C0AB} = {FC08D0D6-612E-4AD2-950C-8E9BA895D5D1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {74E2A280-F2F3-400D-9CC2-7A91D6D3D15C}

--- a/Source/Core/Duality/Serialization/Serializer.cs
+++ b/Source/Core/Duality/Serialization/Serializer.cs
@@ -317,10 +317,16 @@ namespace Duality.Serialization
 		public object ReadObject()
 		{
 			if (!this.CanRead) throw new InvalidOperationException("Can't read object from a write-only serializer!");
-			this.BeginReadOperation();
-			object result = this.ReadObjectData();
-			this.EndReadOperation();
-			return result;
+
+			try
+			{
+				this.BeginReadOperation();
+				return this.ReadObjectData();
+			}
+			finally
+			{
+				this.EndReadOperation();
+			}
 		}
 		/// <summary>
 		/// Reads a single object, casts it to the specified Type and returns it.
@@ -349,9 +355,16 @@ namespace Duality.Serialization
 		public void WriteObject(object obj)
 		{
 			if (!this.CanWrite) throw new InvalidOperationException("Can't write object to a read-only serializer!");
-			this.BeginWriteOperation();
-			this.WriteObjectData(obj);
-			this.EndWriteOperation();
+
+			try
+			{
+				this.BeginWriteOperation();
+				this.WriteObjectData(obj);
+			}
+			finally
+			{
+				this.EndWriteOperation();
+			}
 		}
 		/// <summary>
 		/// Writes a single object.

--- a/Test/Core/Cloning/CloneProviderTest.cs
+++ b/Test/Core/Cloning/CloneProviderTest.cs
@@ -511,37 +511,5 @@ namespace Duality.Tests.Cloning
 			provider.ClearCachedMapping();
 			Assert.DoesNotThrow(() => provider.CloneObject(targetStatic3, true));
 		}
-		[Test] public void PerformanceTest()
-		{
-			Random rnd = new Random(0);
-			TestObject data = new TestObject(rnd, 5);
-			TestObject[] results = new TestObject[200];
-
-			GC.Collect();
-
-			var watch = new System.Diagnostics.Stopwatch();
-			watch.Start();
-			for (int i = 0; i < results.Length; i++)
-			{
-				results[i] = data.DeepClone();
-			}
-			watch.Stop();
-			TestHelper.LogNumericTestResult(this, "CloneTestObjectGraph", watch.Elapsed.TotalMilliseconds, "ms");
-
-			GC.Collect();
-
-			var watch2 = new System.Diagnostics.Stopwatch();
-			watch2.Start();
-			for (int i = 0; i < results.Length; i++)
-			{
-				results[i] = new TestObject(rnd, 5);
-			}
-			watch2.Stop();
-			TestHelper.LogNumericTestResult(this, "CreateWithoutClone", watch2.Elapsed.TotalMilliseconds, "ms");
-			TestHelper.LogNumericTestResult(this, "CloneVersusRaw", watch.Elapsed.TotalMilliseconds / watch2.Elapsed.TotalMilliseconds, null);
-
-			GC.Collect();
-			Assert.Pass();
-		}
 	}
 }

--- a/Test/Core/Cloning/SpecificCloningTest.cs
+++ b/Test/Core/Cloning/SpecificCloningTest.cs
@@ -490,55 +490,5 @@ namespace Duality.Tests.Cloning
 			Assert.IsNull(isolatedTargetShape.Parent);
 			Assert.AreEqual(1, sourceBody.Shapes.Count());
 		}
-		[Test] public void RealWorldPerformanceTest()
-		{
-
-			Random rnd = new Random(0);
-			GameObject data = new GameObject("CloneRoot");
-			for (int i = 0; i < 1000; i++)
-			{
-				GameObject child = new GameObject("Child", data);
-				child.AddComponent<Transform>();
-				if (i % 3 != 0) child.AddComponent<SpriteRenderer>();
-				if (i % 3 == 0) child.AddComponent<RigidBody>();
-				if (i % 7 == 0) child.AddComponent<TextRenderer>();
-			}
-			GameObject[] results = new GameObject[25];
-
-			GC.Collect();
-
-			Stopwatch watch = new System.Diagnostics.Stopwatch();
-			watch.Start();
-			for (int i = 0; i < results.Length; i++)
-			{
-				results[i] = data.DeepClone();
-			}
-			watch.Stop();
-			TestHelper.LogNumericTestResult(this, "CloneGameObjectGraph", watch.Elapsed.TotalMilliseconds, "ms");
-
-			GC.Collect();
-
-			Stopwatch watch2 = new System.Diagnostics.Stopwatch();
-			watch2.Start();
-			for (int j = 0; j < results.Length; j++)
-			{
-				GameObject obj = new GameObject("CloneRoot");
-				for (int i = 0; i < 1000; i++)
-				{
-					GameObject child = new GameObject("Child", data);
-					child.AddComponent<Transform>();
-					if (i % 3 != 0) child.AddComponent<SpriteRenderer>();
-					if (i % 3 == 0) child.AddComponent<RigidBody>();
-					if (i % 7 == 0) child.AddComponent<TextRenderer>();
-				}
-				results[j] = data;
-			}
-			watch2.Stop();
-			TestHelper.LogNumericTestResult(this, "CreateWithoutClone", watch2.Elapsed.TotalMilliseconds, "ms");
-			TestHelper.LogNumericTestResult(this, "CloneVersusRaw", watch.Elapsed.TotalMilliseconds / watch2.Elapsed.TotalMilliseconds, null);
-
-			GC.Collect();
-			Assert.Pass();
-		}
 	}
 }

--- a/Test/Core/InitDualityAttribute.cs
+++ b/Test/Core/InitDualityAttribute.cs
@@ -1,11 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.IO;
-
-using Duality;
-using Duality.Serialization;
 using Duality.Backend;
 
 using NUnit.Framework;
@@ -63,9 +57,6 @@ namespace Duality.Tests
 				this.dummyWindow = DualityApp.OpenWindow(options);
 			}
 
-			// Load local testing memory
-			TestHelper.LocalTestMemory = Serializer.TryReadObject<TestMemory>(TestHelper.LocalTestMemoryFilePath, typeof(XmlSerializer));
-
 			Console.WriteLine("----- Duality environment setup complete -----");
 		}
 		public void AfterTest(ITest details)
@@ -81,13 +72,6 @@ namespace Duality.Tests
 				ContentProvider.ClearContent();
 			    this.dummyWindow.Dispose();
 			    this.dummyWindow = null;
-			}
-
-			// Save local testing memory. As this uses Duality serializers, 
-			// it needs to be done before terminating Duality.
-			if (TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Passed && !System.Diagnostics.Debugger.IsAttached)
-			{
-				Serializer.WriteObject(TestHelper.LocalTestMemory, TestHelper.LocalTestMemoryFilePath, typeof(XmlSerializer));
 			}
 
 			DualityApp.Terminate();

--- a/Test/Core/Resources/PrefabTest.cs
+++ b/Test/Core/Resources/PrefabTest.cs
@@ -184,37 +184,7 @@ namespace Duality.Tests.Resources
 
 			Assert.AreEqual(ColorRgba.Green, childSprite.ColorTint);
 		}
-		[Test] public void InstantiatePerformance()
-		{
-			Prefab prefab = new Prefab(this.CreateSimpleGameObject());
-			GameObject[] results = new GameObject[1000];
 
-			GC.Collect();
-			
-			var watch = new System.Diagnostics.Stopwatch();
-			watch.Restart();
-			for (int i = 0; i < results.Length; i++)
-			{
-				results[i] = prefab.Instantiate();
-			}
-			watch.Stop();
-			TestHelper.LogNumericTestResult(this, "Instantiate", watch.Elapsed.TotalMilliseconds, "ms");
-
-			GC.Collect();
-
-			var watch2 = new System.Diagnostics.Stopwatch();
-			watch2.Restart();
-			for (int i = 0; i < results.Length; i++)
-			{
-				results[i] = this.CreateSimpleGameObject();
-			}
-			watch2.Stop();
-			TestHelper.LogNumericTestResult(this, "CreateWithoutPrefabs", watch2.Elapsed.TotalMilliseconds, "ms");
-			TestHelper.LogNumericTestResult(this, "PrefabVersusRaw", watch.Elapsed.TotalMilliseconds / watch2.Elapsed.TotalMilliseconds, null);
-
-			GC.Collect();
-			Assert.Pass();
-		}
 		[Test] public void SameNamePropertyChanges()
 		{
 			var gameObj = this.CreateSimpleGameObject();

--- a/Test/Core/Serialization/SerializerTest.cs
+++ b/Test/Core/Serialization/SerializerTest.cs
@@ -416,45 +416,7 @@ namespace Duality.Tests.Serialization
 			// Test Data last updated 2014-03-11
 			// this.CreateReferenceFile("Old", obj, this.PrimaryFormat);
 		}
-		[Test] public void PerformanceTest()
-		{
-			System.Diagnostics.Stopwatch watch = new System.Diagnostics.Stopwatch();
-			
-			Random rnd = new Random(0);
-			TestObject data = new TestObject(rnd, 5);
-			TestObject[] results = new TestObject[50];
-			
-			watch.Start();
-			long memUsage;
-			using (MemoryStream stream = new MemoryStream())
-			{
-				// Write
-				for (int i = 0; i < results.Length; i++)
-				{
-					using (Serializer formatterWrite = Serializer.Create(stream, this.format))
-					{
-						formatterWrite.WriteObject(data);
-					}
-				}
 
-				memUsage = stream.Length / 1024;
-				stream.Position = 0;
-
-				// Read
-				for (int i = 0; i < results.Length; i++)
-				{
-					using (Serializer formatterRead = Serializer.Create(stream))
-					{
-						results[i] = formatterRead.ReadObject<TestObject>();
-					}
-				}
-			}
-			watch.Stop();
-			TestHelper.LogNumericTestResult(this, "ReadWritePerformance" + this.format.ToString(), watch.Elapsed.TotalMilliseconds, "ms");
-			TestHelper.LogNumericTestResult(this, "MemoryUsage" + this.format.ToString(), memUsage, "Kb");
-
-			Assert.Pass();
-		}
 		[Test] public void CleanupAfterDisposedStream()
 		{
 			Random rnd = new Random();

--- a/Test/Core/Testing/TestHelper.cs
+++ b/Test/Core/Testing/TestHelper.cs
@@ -1,144 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.IO;
-using System.Text;
+﻿using System.IO;
 
 namespace Duality.Tests
 {
 	public static class TestHelper
 	{
-		private static TestMemory localTestMemory = null;
-
 		public static string EmbeddedResourcesDir
 		{
 			get { return Path.Combine("..", "..", "Test", "Core", "EmbeddedResources"); }
-		}
-		public static string LocalTestMemoryFilePath
-		{
-			get
-			{
-				string appDataDir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-				string testingDir = Path.Combine(appDataDir, "Duality", "UnitTesting");
-				string testingFile = "DualityTests";
-#if DEBUG
-				testingFile += "Debug";
-#else
-				testingFile += "Release";
-#endif
-				testingFile += ".dat";
-				return Path.Combine(testingDir, testingFile);
-			}
-		}
-		public static TestMemory LocalTestMemory
-		{
-			get { return localTestMemory; }
-			internal set { localTestMemory = value ?? new TestMemory(); }
 		}
 
 		public static string GetEmbeddedResourcePath(string resName, string resEnding)
 		{
 			return Path.Combine(TestHelper.EmbeddedResourcesDir, resName + resEnding);
-		}
-		public static void LogNumericTestResult(object testFixture, string testName, long resultValue, string unit)
-		{
-			if (!string.IsNullOrEmpty(unit)) unit = " " + unit;
-			
-			List<long> lastValueList;
-			if (!TestHelper.LocalTestMemory.GetValue(testFixture, testName, out lastValueList))
-			{
-				lastValueList = new List<long>();
-			}
-			lastValueList.Add(resultValue);
-			if (lastValueList.Count > 10) lastValueList.RemoveAt(0);
-			TestHelper.LocalTestMemory.SetValue(testFixture, testName, lastValueList);
-
-			long localAverage = (long)lastValueList.Average();
-
-			string nameStr = (testFixture.GetType().Name + "." + testName);
-			string newValueStr = string.Format("{0}{1}", resultValue, unit);
-			string lastValueStr = string.Format("{0}{1}", localAverage, unit);
-
-			double relativeChange = ((double)resultValue - (double)localAverage) / (double)localAverage;
-			LogNumericTestResult(nameStr, newValueStr, lastValueStr, relativeChange);
-		}
-		public static void LogNumericTestResult(object testFixture, string testName, double resultValue, string unit)
-		{
-			if (!string.IsNullOrEmpty(unit)) unit = " " + unit;
-
-			List<double> lastValueList;
-			if (!TestHelper.LocalTestMemory.GetValue(testFixture, testName, out lastValueList))
-			{
-				lastValueList = new List<double>();
-			}
-			lastValueList.Add(resultValue);
-			if (lastValueList.Count > 10) lastValueList.RemoveAt(0);
-			TestHelper.LocalTestMemory.SetValue(testFixture, testName, lastValueList);
-
-			double localAverage = lastValueList.Average();
-
-			string nameStr = (testFixture.GetType().Name + "." + testName);
-			string newValueStr = string.Format("{0:F}{1}", resultValue, unit);
-			string lastValueStr = string.Format("{0:F}{1}", localAverage, unit);
-
-			double relativeChange = ((double)resultValue - (double)localAverage) / (double)localAverage;
-			LogNumericTestResult(nameStr, newValueStr, lastValueStr, relativeChange);
-		}
-		private static void LogNumericTestResult(string nameStr, string newValueStr, string lastValueStr, double relativeChange)
-		{
-			if (Math.Abs(relativeChange) > 0.03)
-			{
-				Console.WriteLine(string.Format("{0}: {2} --> {1} Changed by {3}%", 
-					nameStr.PadRight(50),
-					newValueStr.PadRight(12), 
-					lastValueStr.PadRight(12),
-					(int)Math.Round(100.0d * relativeChange)));
-			}
-			else
-			{
-				Console.WriteLine(string.Format("{0}: {1}", 
-					nameStr.PadRight(50),
-					newValueStr));
-			}
-		}
-	}
-
-	public class TestMemory
-	{
-		private Dictionary<string,object> data = new Dictionary<string,object>();
-
-		public bool SwitchValue<T>(object testFixture, string key, out T oldValue, T newValue)
-		{
-			bool result = this.GetValue(testFixture, key, out oldValue);
-			this.SetValue(testFixture, key, newValue);
-			return result;
-		}
-		public void SetValue<T>(object testFixture, string key, T value)
-		{
-			if (testFixture != null)
-			{
-				key = testFixture.GetType().Name + "_" + key;
-			}
-			this.data[key] = value;
-		}
-		public bool GetValue<T>(object testFixture, string key, out T value)
-		{
-			if (testFixture != null)
-			{
-				key = testFixture.GetType().Name + "_" + key;
-			}
-			object valueObj;
-			if (this.data.TryGetValue(key, out valueObj) && valueObj is T)
-			{
-				value = (T)valueObj;
-				return true;
-			}
-			else
-			{
-				value = default(T);
-				return false;
-			}
 		}
 	}
 }


### PR DESCRIPTION
Moved all our benchmarks in our unit tests to a separate benchmarkdotnet project.

How to use:
- cd to Benchmarks\DualityBenchmarks
- Run `dotnet run -c Release --list tree` to view the available benchmarks
- Run `dotnet run -c Release --filter CloneProviderBenchmarks` to run the CloneProviderBenchmarks

TODO:
- Some benchmarks are running alot of itterations. This is a leftover of the setup in the unit tests and is usually not needed unless you are interested in how something scales. Change this to only run once or if scaling is important parameterize it so its easier to see the scaling (for example do 3 runs with the first run only 1 itteration, the second one 10 itterations etc). DONE

Rebased on https://github.com/AdamsLair/duality/pull/842