### PR TITLE
Fixed VS Debug / Run for launchers in Duality project template

### DIFF
--- a/Source/DualityTemplates/Templates/SolutionTemplate/Source/Launchers/GameEditor/Properties/launchSettings.json
+++ b/Source/DualityTemplates/Templates/SolutionTemplate/Source/Launchers/GameEditor/Properties/launchSettings.json
@@ -1,9 +1,9 @@
 {
   "profiles": {
-    "GameEditor": {
+    "Debug Editor": {
       "commandName": "Executable",
       "executablePath": ".\\DualityEditor.exe",
-      "workingDirectory": ".\\..\\..\\..\\.."
+      "workingDirectory": ".\\..\\..\\.."
     }
   }
 }

--- a/Source/DualityTemplates/Templates/SolutionTemplate/Source/Launchers/GameLauncher/Properties/launchSettings.json
+++ b/Source/DualityTemplates/Templates/SolutionTemplate/Source/Launchers/GameLauncher/Properties/launchSettings.json
@@ -1,9 +1,9 @@
 {
   "profiles": {
-    "GameLauncher": {
+    "Debug Game": {
       "commandName": "Executable",
       "executablePath": ".\\DualityLauncher.exe",
-      "workingDirectory": ".\\..\\..\\..\\.."
+      "workingDirectory": ".\\..\\..\\.."
     }
   }
 }


### PR DESCRIPTION
## Summary

In the current alpha2 release, the run / debug buttons for `GameLauncher` and `GameEditor` in Visual Studio are broken, as their working directory is off by one - probably a regression due to recent folder structure changes.

This PR fixes the launch settings and also provides more descriptive names for the "Run" button / debug profile.
