### PR TITLE
Added a duality test launcher for use in unit tests/benchmarks etc

### DIFF
--- a/Benchmarks/DualityBenchmarks/DualityBenchmarks.csproj
+++ b/Benchmarks/DualityBenchmarks/DualityBenchmarks.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net472</TargetFramework>
+    <OutputPath>$(RootFolder)Build\Output\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Benchmarks/DualityBenchmarks/Program.cs
+++ b/Benchmarks/DualityBenchmarks/Program.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
 
 namespace DualityBenchmarks
 {
@@ -14,7 +15,7 @@ namespace DualityBenchmarks
 				Console.ForegroundColor = ConsoleColor.Yellow;
 				Console.WriteLine($"[WARNING] Running with debugger attached, using {nameof(DebugInProcessConfig)} this might affect benchmark results!");
 				Console.ResetColor();
-				BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new DebugInProcessConfig());
+				BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new DebugInProcessConfig().AddValidator(ExecutionValidator.FailOnError));
 			}
 			else {
 				BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/Benchmarks/DualityBenchmarks/SerializerBenchmarks.cs
+++ b/Benchmarks/DualityBenchmarks/SerializerBenchmarks.cs
@@ -3,9 +3,8 @@ using System.IO;
 using Duality.Tests.Serialization;
 using Duality.Serialization;
 using BenchmarkDotNet.Attributes;
-using Duality;
-using Duality.Backend;
 using Duality.Launcher;
+using Duality.Tests;
 
 namespace DualityBenchmarks
 {
@@ -21,14 +20,12 @@ namespace DualityBenchmarks
 		private byte[] readData;
 		private TestObject data;
 
+		private DualityTestLauncher launcher;
+
 		[GlobalSetup]
 		public void Setup()
 		{
-			DualityApp.Init(
-				DualityApp.ExecutionEnvironment.Launcher,
-				DualityApp.ExecutionContext.Game,
-				new DefaultAssemblyLoader(),
-				new LauncherArgs());
+			this.launcher = new DualityTestLauncher();
 
 			this.results = new TestObject[this.N];
 			this.data = new TestObject(new Random(0), 5);
@@ -39,7 +36,7 @@ namespace DualityBenchmarks
 		[GlobalCleanup]
 		public void Cleanup()
 		{
-			DualityApp.Terminate();
+			this.launcher.Dispose();
 		}
 
 		[Benchmark]

--- a/Test/Core/DualityTestLauncher.cs
+++ b/Test/Core/DualityTestLauncher.cs
@@ -4,12 +4,18 @@ using System.IO;
 
 namespace Duality.Tests
 {
+	/// <summary>
+	/// Launcher for duality for a test environment (such as unit tests, benchmarks etc).
+	/// </summary>
 	public class DualityTestLauncher : IDisposable
 	{
 		public string CodeBasePath { get; }
 		private string oldEnvDir;
 		private DualityLauncher launcher;
 
+		/// <summary>
+		/// Setups duality for testing.
+		/// </summary>
 		public DualityTestLauncher()
 		{
 			// Set environment directory to Duality binary directory

--- a/Test/Core/DualityTestLauncher.cs
+++ b/Test/Core/DualityTestLauncher.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Duality.Launcher;
+using System.IO;
+
+namespace Duality.Tests
+{
+	public class DualityTestLauncher : IDisposable
+	{
+		public string CodeBasePath { get; }
+		private string oldEnvDir;
+		private DualityLauncher launcher;
+
+		public DualityTestLauncher()
+		{
+			// Set environment directory to Duality binary directory
+			this.oldEnvDir = Environment.CurrentDirectory;
+			string codeBaseURI = typeof(DualityApp).Assembly.CodeBase;
+			this.CodeBasePath = (codeBaseURI.StartsWith("file:") ? codeBaseURI.Remove(0, "file:".Length) : codeBaseURI).TrimStart('/');
+			Console.WriteLine("Testing Core Assembly: {0}", this.CodeBasePath);
+			Environment.CurrentDirectory = Path.GetDirectoryName(this.CodeBasePath);
+
+			this.launcher = new DualityLauncher();
+		}
+
+		public void Dispose()
+		{
+			this.launcher.Dispose();
+
+			Environment.CurrentDirectory = this.oldEnvDir;
+		}
+	}
+}

--- a/Test/Core/InitDualityAttribute.cs
+++ b/Test/Core/InitDualityAttribute.cs
@@ -1,45 +1,37 @@
 ﻿using System;
-using System.IO;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
-using Duality.Launcher;
 
 namespace Duality.Tests
 {
+
 	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
 	public class InitDualityAttribute : Attribute, ITestAction
 	{
-		private	string				oldEnvDir			= null;
-		private	CorePlugin			unitTestPlugin		= null;
+		private DualityTestLauncher launcher;
+		private CorePlugin unitTestPlugin = null;
 
 		public ActionTargets Targets
 		{
 			get { return ActionTargets.Suite; }
 		}
 
-		private DualityLauncher launcher;
-		public InitDualityAttribute() {}
+		public InitDualityAttribute() { }
+
+
 		public void BeforeTest(ITest details)
 		{
 			Console.WriteLine("----- Beginning Duality environment setup -----");
 
-			// Set environment directory to Duality binary directory
-			this.oldEnvDir = Environment.CurrentDirectory;
-			string codeBaseURI = typeof(DualityApp).Assembly.CodeBase;
-			string codeBasePath = codeBaseURI.StartsWith("file:") ? codeBaseURI.Remove(0, "file:".Length) : codeBaseURI;
-			codeBasePath = codeBasePath.TrimStart('/');
-			Console.WriteLine("Testing Core Assembly: {0}", codeBasePath);
-			Environment.CurrentDirectory = Path.GetDirectoryName(codeBasePath);
-
 			if (this.launcher == null)
 			{
-				this.launcher = new DualityLauncher();
+				this.launcher = new DualityTestLauncher();
 			}
-			
+
 			// Manually register pseudo-plugin for the Unit Testing Assembly
 			this.unitTestPlugin = DualityApp.PluginManager.LoadPlugin(
-				typeof(DualityTestsPlugin).Assembly, 
-				codeBasePath);
+				typeof(DualityTestsPlugin).Assembly,
+				this.launcher.CodeBasePath);
 
 			Console.WriteLine("----- Duality environment setup complete -----");
 		}
@@ -51,8 +43,6 @@ namespace Duality.Tests
 			{
 				this.launcher.Dispose();
 			}
-
-			Environment.CurrentDirectory = this.oldEnvDir;
 
 			Console.WriteLine("----- Duality environment teardown complete -----");
 		}


### PR DESCRIPTION
After making debugging benchmarks a bit easier and more strict I found out that we actually get a exception in the cleanup of the serialization benchmark.

Changes
- Adds a DualityTestLauncher which purpose is to launch duality in such a way that it works well with unit tests, benchmarks etc. I used this in the SerializerBenchmarks so that it uses the same environment that the unit tests are using.
- Added a warning that when a benchmark is run and a debugger is attached that DebugInProcessConfig is used since this might affect benchmarks results.
- Added ExecutionValidator.FailOnError to the benchmark runner when debugger is attached to make it easier to find errors. What this does is run each benchmark only 1 itteration just to verify if its working or not before doing the actual benchmark.

We might want to consider putting the DualityTestLauncher class in core or putting it in a separate nuget package as users might wanna use this class for their own unit tests.

EDIT: seems changing the working directory was to fix something nunit specific so having a separate DualityTestLauncher is not needed