### PR TITLE
Cleanup InitDualityAttribute's

### DIFF
--- a/Test/Core/InitDualityAttribute.cs
+++ b/Test/Core/InitDualityAttribute.cs
@@ -1,8 +1,9 @@
 ﻿using System;
-using System.IO;
+
+using Duality.Launcher;
+
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
-using Duality.Launcher;
 
 namespace Duality.Tests
 {
@@ -25,21 +26,18 @@ namespace Duality.Tests
 
 			// Set environment directory to Duality binary directory
 			this.oldEnvDir = Environment.CurrentDirectory;
-			string codeBaseURI = typeof(DualityApp).Assembly.CodeBase;
-			string codeBasePath = codeBaseURI.StartsWith("file:") ? codeBaseURI.Remove(0, "file:".Length) : codeBaseURI;
-			codeBasePath = codeBasePath.TrimStart('/');
-			Console.WriteLine("Testing Core Assembly: {0}", codeBasePath);
-			Environment.CurrentDirectory = Path.GetDirectoryName(codeBasePath);
+			Console.WriteLine("Testing Core Assembly: {0}", TestContext.CurrentContext.TestDirectory);
+			Environment.CurrentDirectory = TestContext.CurrentContext.TestDirectory;
 
 			if (this.launcher == null)
 			{
 				this.launcher = new DualityLauncher();
 			}
-			
+
 			// Manually register pseudo-plugin for the Unit Testing Assembly
 			this.unitTestPlugin = DualityApp.PluginManager.LoadPlugin(
-				typeof(DualityTestsPlugin).Assembly, 
-				codeBasePath);
+				typeof(DualityTestsPlugin).Assembly,
+				typeof(DualityTestsPlugin).Assembly.Location);
 
 			Console.WriteLine("----- Duality environment setup complete -----");
 		}

--- a/Test/Core/InitDualityAttribute.cs
+++ b/Test/Core/InitDualityAttribute.cs
@@ -26,7 +26,7 @@ namespace Duality.Tests
 
 			// Set environment directory to Duality binary directory
 			this.oldEnvDir = Environment.CurrentDirectory;
-			Console.WriteLine("Testing Core Assembly: {0}", TestContext.CurrentContext.TestDirectory);
+			Console.WriteLine("Testing in working directory: {0}", TestContext.CurrentContext.TestDirectory);
 			Environment.CurrentDirectory = TestContext.CurrentContext.TestDirectory;
 
 			if (this.launcher == null)

--- a/Test/Editor/InitDualityEditorAttribute.cs
+++ b/Test/Editor/InitDualityEditorAttribute.cs
@@ -1,13 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.IO;
 
-using Duality;
-using Duality.Serialization;
-using Duality.Backend;
-using Duality.Editor;
 using Duality.Editor.Forms;
 
 using NUnit.Framework;
@@ -34,11 +26,8 @@ namespace Duality.Editor.Tests
 
 			// Set environment directory to Duality binary directory
 			this.oldEnvDir = Environment.CurrentDirectory;
-			string codeBaseURI = typeof(DualityEditorApp).Assembly.CodeBase;
-			string codeBasePath = codeBaseURI.StartsWith("file:") ? codeBaseURI.Remove(0, "file:".Length) : codeBaseURI;
-			codeBasePath = codeBasePath.TrimStart('/');
-			Console.WriteLine("Testing Editor Assembly: {0}", codeBasePath);
-			Environment.CurrentDirectory = Path.GetDirectoryName(codeBasePath);
+			Console.WriteLine("Testing Editor Assembly: {0}", TestContext.CurrentContext.TestDirectory);
+			Environment.CurrentDirectory = TestContext.CurrentContext.TestDirectory;
 
 			// Add some Console logs manually for NUnit
 			if (this.consoleLogOutput == null)

--- a/Test/Editor/InitDualityEditorAttribute.cs
+++ b/Test/Editor/InitDualityEditorAttribute.cs
@@ -26,7 +26,7 @@ namespace Duality.Editor.Tests
 
 			// Set environment directory to Duality binary directory
 			this.oldEnvDir = Environment.CurrentDirectory;
-			Console.WriteLine("Testing Editor Assembly: {0}", TestContext.CurrentContext.TestDirectory);
+			Console.WriteLine("Testing in working directory: {0}", TestContext.CurrentContext.TestDirectory);
 			Environment.CurrentDirectory = TestContext.CurrentContext.TestDirectory;
 
 			// Add some Console logs manually for NUnit


### PR DESCRIPTION
Just a small cleanup since nunit provides a utility for setting the current directory already.

Also use `typeof(DualityTestsPlugin).Assembly.Location` for the location of the test plugin as thats cleaner and also actually fixes a potential bug as previously it would be set to `Duality.dll` instead of `DualityTests.dll`.