### PR TITLE
Fix exception in cleanup of serialization benchmark due to working folder being wrong

### DIFF
--- a/Benchmarks/DualityBenchmarks/DualityBenchmarks.csproj
+++ b/Benchmarks/DualityBenchmarks/DualityBenchmarks.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net472</TargetFramework>
+    <OutputPath>$(RootFolder)Build\Output\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Benchmarks/DualityBenchmarks/Program.cs
+++ b/Benchmarks/DualityBenchmarks/Program.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
 
 namespace DualityBenchmarks
 {
@@ -14,7 +15,7 @@ namespace DualityBenchmarks
 				Console.ForegroundColor = ConsoleColor.Yellow;
 				Console.WriteLine($"[WARNING] Running with debugger attached, using {nameof(DebugInProcessConfig)} this might affect benchmark results!");
 				Console.ResetColor();
-				BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new DebugInProcessConfig());
+				BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new DebugInProcessConfig().AddValidator(ExecutionValidator.FailOnError));
 			}
 			else {
 				BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/Benchmarks/DualityBenchmarks/SerializerBenchmarks.cs
+++ b/Benchmarks/DualityBenchmarks/SerializerBenchmarks.cs
@@ -3,8 +3,6 @@ using System.IO;
 using Duality.Tests.Serialization;
 using Duality.Serialization;
 using BenchmarkDotNet.Attributes;
-using Duality;
-using Duality.Backend;
 using Duality.Launcher;
 
 namespace DualityBenchmarks
@@ -21,14 +19,12 @@ namespace DualityBenchmarks
 		private byte[] readData;
 		private TestObject data;
 
+		private DualityLauncher launcher;
+
 		[GlobalSetup]
 		public void Setup()
 		{
-			DualityApp.Init(
-				DualityApp.ExecutionEnvironment.Launcher,
-				DualityApp.ExecutionContext.Game,
-				new DefaultAssemblyLoader(),
-				new LauncherArgs());
+			this.launcher = new DualityLauncher();
 
 			this.results = new TestObject[this.N];
 			this.data = new TestObject(new Random(0), 5);
@@ -39,7 +35,7 @@ namespace DualityBenchmarks
 		[GlobalCleanup]
 		public void Cleanup()
 		{
-			DualityApp.Terminate();
+			this.launcher.Dispose();
 		}
 
 		[Benchmark]


### PR DESCRIPTION
Changes:
- Set the correct output path for the benchmarks, this fixes the actually exception.
- Fail fast when debugging benchmarks
- Use DualityLauncher in the benchmark to unify code flow