### PR TITLE
Added XElement support to the serializer

### DIFF
--- a/Source/Core/Duality/Serialization/Surrogates/XElementSurrogate.cs
+++ b/Source/Core/Duality/Serialization/Surrogates/XElementSurrogate.cs
@@ -1,0 +1,26 @@
+﻿using System.Xml.Linq;
+
+namespace Duality.Serialization.Surrogates
+{
+	public class XElementSurrogate : SerializeSurrogate<XElement>
+	{
+		public override void WriteData(IDataWriter writer)
+		{
+			writer.WriteValue("value", this.RealObject.ToString()); 
+		}
+
+		public override void ReadData(IDataReader reader)
+		{
+			reader.ReadValue("value", out string xml);
+
+			XElement xElement = XElement.Parse(xml);
+
+			this.RealObject.Name = xElement.Name;
+			foreach (XAttribute xAttribute in xElement.Attributes())
+			{
+				this.RealObject.SetAttributeValue(xAttribute.Name, xAttribute.Value);
+			}
+			this.RealObject.Add(xElement.Elements());
+		}
+	}
+}

--- a/Source/Core/Duality/Serialization/Surrogates/XElementSurrogate.cs
+++ b/Source/Core/Duality/Serialization/Surrogates/XElementSurrogate.cs
@@ -2,6 +2,9 @@
 
 namespace Duality.Serialization.Surrogates
 {
+	/// <summary>
+	/// Ensures that serializing and deserializing a <see cref="XElement"/> works properly
+	/// </summary>
 	public class XElementSurrogate : SerializeSurrogate<XElement>
 	{
 		public override void WriteData(IDataWriter writer)

--- a/Source/Core/Duality/Serialization/XmlSerializer.cs
+++ b/Source/Core/Duality/Serialization/XmlSerializer.cs
@@ -162,8 +162,16 @@ namespace Duality.Serialization
 			else if (header.DataType.IsMemberInfoType())	this.WriteMemberInfo	(element, obj, header);
 		}
 
+		/// <summary>
+		/// This method is not strictly necessary to serialize <see cref="XElement"/> as that is already solved in <see cref="Surrogates.XElementSurrogate"/>
+		/// However this method nicely embeds the xml in a readable way.
+		/// See https://github.com/AdamsLair/duality/pull/861 for more info.
+		/// </summary>
+		/// <param name="element"></param>
+		/// <param name="childElement"></param>
 		private void WriteXml(XElement element, XElement childElement)
 		{
+			// Simply add the XElement as a child.
 			element.Add(childElement);
 		}
 		private void WritePrimitive(XElement element, object obj)
@@ -479,6 +487,12 @@ namespace Duality.Serialization
 
 			return result;
 		}
+		/// <summary>
+		/// Counterpart of <see cref="WriteXml"/>
+		/// </summary>
+		/// <param name="element"></param>
+		/// <param name="header"></param>
+		/// <returns></returns>
 		private object ReadXml(XElement element, ObjectHeader header)
 		{
 			return element.FirstNode;

--- a/Source/Core/Duality/Serialization/XmlSerializer.cs
+++ b/Source/Core/Duality/Serialization/XmlSerializer.cs
@@ -153,12 +153,18 @@ namespace Duality.Serialization
 		private void WriteObjectBody(XElement element, object obj, ObjectHeader header)
 		{
 			if (header.IsPrimitive)							this.WritePrimitive		(element, obj);
+			else if (obj is XElement childElement)          this.WriteXml(element, childElement);
 			else if (header.DataType == DataType.Enum)		this.WriteEnum			(element, obj as Enum, header);
 			else if (header.DataType == DataType.Struct)	this.WriteStruct		(element, obj, header);
 			else if (header.DataType == DataType.ObjectRef)	element.Value = XmlConvert.ToString(header.ObjectId);
 			else if	(header.DataType == DataType.Array)		this.WriteArray			(element, obj, header);
 			else if (header.DataType == DataType.Delegate)	this.WriteDelegate		(element, obj, header);
 			else if (header.DataType.IsMemberInfoType())	this.WriteMemberInfo	(element, obj, header);
+		}
+
+		private void WriteXml(XElement element, XElement childElement)
+		{
+			element.Add(childElement);
 		}
 		private void WritePrimitive(XElement element, object obj)
 		{
@@ -464,6 +470,7 @@ namespace Duality.Serialization
 
 			if (header.IsPrimitive)							result = this.ReadPrimitive(element, header.DataType);
 			else if (header.DataType == DataType.Enum)		result = this.ReadEnum(element, header);
+			else if (header.ObjectType == typeof(XElement)) result = this.ReadXml(element, header);
 			else if (header.DataType == DataType.Struct)	result = this.ReadStruct(element, header);
 			else if (header.DataType == DataType.ObjectRef)	result = this.ReadObjectRef(element);
 			else if (header.DataType == DataType.Array)		result = this.ReadArray(element, header);
@@ -471,6 +478,10 @@ namespace Duality.Serialization
 			else if (header.DataType.IsMemberInfoType())	result = this.ReadMemberInfo(element, header);
 
 			return result;
+		}
+		private object ReadXml(XElement element, ObjectHeader header)
+		{
+			return element.FirstNode;
 		}
 		private object ReadPrimitive(XElement element, DataType dataType)
 		{

--- a/Test/Core/Serialization/SerializerTest.cs
+++ b/Test/Core/Serialization/SerializerTest.cs
@@ -7,7 +7,8 @@ using System.IO;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
-
+using System.Xml;
+using System.Xml.Linq;
 using Duality;
 using Duality.Components;
 using Duality.Drawing;
@@ -211,6 +212,12 @@ namespace Duality.Tests.Serialization
 
 			// Can we properly serialize null and default values?
 			this.TestWriteRead(nullTestObj, this.PrimaryFormat);
+		}
+		[Test] public void SerializeXml()
+		{
+			var rnd = new Random(6);
+			var xElement = this.GenerateRandomXml(rnd, 10, 10);
+			this.TestWriteRead(xElement, this.PrimaryFormat, (element, element1) => XElement.DeepEquals(element, element1));
 		}
 		[Test] public void SerializeEnumArrays()
 		{
@@ -747,6 +754,27 @@ namespace Duality.Tests.Serialization
 
 			Assert.IsTrue(checkEqual(writeObjA, readObjA), "Failed random access WriteRead of Type {0} with Value {1}", typeof(T), writeObjA);
 			Assert.IsTrue(checkEqual(writeObjB, readObjB), "Failed random access WriteRead of Type {0} with Value {1}", typeof(T), writeObjB);
+		}
+		private XElement GenerateRandomXml(Random rnd, int maxDepth, int maxChilds, XElement parent = null)
+		{
+			if (parent == null) parent = new XElement("root");
+			var index = rnd.Next();
+			var child = new XElement($"Foo{index}");
+			if (index % 3 == 0)
+			{
+				child.SetAttributeValue($"dummyatrribute{rnd.Next()}", $"dummyvalue{rnd.Next()}");
+			}
+
+			if (maxDepth - 1 > 0)
+			{
+				for (int j = 1; j < rnd.Next(maxChilds); j++)
+				{
+					this.GenerateRandomXml(rnd, maxDepth - 1, maxChilds, child);
+				}
+			}
+
+			parent.Add(child);
+			return parent;
 		}
 	}
 }


### PR DESCRIPTION
Serializing and deserializing `XElement` did not work properly before. This PR adds a `XElementSurrogate` which allows all serializers in duality to properly handle `XElement`.

Additionally `XmlSerializer` has a small extra modification to make the serialized xml more readable, without this change the serialized xml would end up as a base64 string.

TODO
- [x]  unittests
- [x] comments