### PR TITLE
csharp_style_var_when_type_is_apparent to true

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -42,7 +42,7 @@ dotnet_style_explicit_tuple_names = true:error
 [*.cs]
 # Prefer not to use "var", be explicit instead
 csharp_style_var_for_built_in_types = false:error
-csharp_style_var_when_type_is_apparent = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = false:suggestion
 
 # Prefer method-like constructs to have a block body


### PR DESCRIPTION
This style change makes it so that the explicit type is no longer needed when the type is apparent. This leads to more concise code and cleans up the find all references results without sacrificing readability.

Some examples:
Before:
```cs
List<string> auxilLibs = new List<string>();
```
After
```cs
var auxilLibs = new List<string>();
```

Before
```cs
ICmpInitializable cInit = this as ICmpInitializable;
```
After
```cs
var cInit = this as ICmpInitializable;
```

However a case like this will still require a explicit type. Even though a method named `CreateCmpInitializable` would probably return a `ICmpInitializable` its not a given as method can be given a name that might not properly communicate its intent.
```cs
ICmpInitializable cInit = CreateICmpInitializable();
```

NOTE: this PR only changes the style rules and does not change any code!