### PR TITLE
Added a bounds check that prevents the editor from crashing when tileset sizes mismatch

### DIFF
--- a/Source/Plugins/Tilemaps/Core/Tilemaps/Tile.cs
+++ b/Source/Plugins/Tilemaps/Core/Tilemaps/Tile.cs
@@ -273,6 +273,10 @@ namespace Duality.Plugins.Tilemaps
 					int tileY = y + beginY;
 					int i = tileX + tileStride * tileY;
 
+					//Skip out of bounds tiles
+					if(i >= tiles.Length) continue;
+					if(tiles[i].BaseIndex >= tileData.Length) continue;
+
 					// Skip non-AutoTiles
 					int autoTileIndex = tileData[tiles[i].BaseIndex].AutoTileLayer - 1;
 					if (autoTileIndex == -1) continue;


### PR DESCRIPTION
Fix for this [issue](https://github.com/AdamsLair/duality/issues/763).
Really simple and small, but i hope it helps ^-^